### PR TITLE
Fix #68: don't require SystemStubs on OS X.

### DIFF
--- a/Makefile.system
+++ b/Makefile.system
@@ -95,7 +95,6 @@ DLLWRAP = $(CROSS_SUFFIX)dllwrap
 #
 
 ifeq ($(OSNAME), Darwin)
-EXTRALIB	+= -lSystemStubs
 export MACOSX_DEPLOYMENT_TARGET=10.2
 endif
 


### PR DESCRIPTION
I can't be sure that this doesn't cause problems on some older versions of OS X (presumably this was here for some reason originally), but removing it doesn't cause any problems on Lion, whereas keeping it does since `SystemStubs` does not exist anymore.
