### PR TITLE
FreeBSD: replace EXTRALIB -> FEXTRALIB

### DIFF
--- a/exports/Makefile
+++ b/exports/Makefile
@@ -121,7 +121,7 @@ so : ../$(LIBSONAME)
 ../$(LIBSONAME) : ../$(LIBNAME) linux.def linktest.c
 	$(CC) $(CFLAGS)  -shared -o ../$(LIBSONAME) \
 	-Wl,--whole-archive ../$(LIBNAME) -Wl,--no-whole-archive \
-	-Wl,--retain-symbols-file=linux.def $(EXTRALIB)
+	-Wl,--retain-symbols-file=linux.def $(FEXTRALIB)
 	$(CC) $(CFLAGS) -w -o linktest linktest.c ../$(LIBSONAME) $(FEXTRALIB) && echo OK.
 	rm -f linktest
 


### PR DESCRIPTION
Fixes `cannot find -lgfortran` error. On FreeBSD, `libgfortran` is usually installed in `/usr/local/lib/gcc<version>/`.
