### PR TITLE
Possible fix for hyperthreading on OSX

### DIFF
--- a/driver/others/init.c
+++ b/driver/others/init.c
@@ -82,6 +82,10 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <sched.h>
 #include <dirent.h>
 #include <dlfcn.h>
+                
+#ifdef __APPLE__
+#include <sys/sysctl.h>
+#endif
 
 #define MAX_NODES	16
 #define MAX_CPUS	256
@@ -844,7 +848,15 @@ void gotoblas_set_affinity2(int threads) {};
 
 void gotoblas_affinity_reschedule(void) {};
 
-int get_num_procs(void) { return get_nprocs(); }
+int get_num_procs(void) {
+#ifdef __APPLE__
+    int physicalCores;
+    sysctlbyname("hw.physicalcpu", &physicalCores, sizeof(physicalCores), NULL, 0);
+    return physicalCores;
+#else
+    return get_nprocs();
+#endif
+}
 
 int get_num_nodes(void) { return 1; }
 


### PR DESCRIPTION
Regarding discussion in https://github.com/JuliaLang/LinearAlgebra.jl/issues/1513#issuecomment-10306914, I took at look at `driver/others/init.c`, and since you're doing very linux-specific lookups to `/sys`, perhaps an alternative for OSX would be to use [`hw.physicalcpu`](http://stackoverflow.com/questions/2904283/c-c-assembly-programatically-detect-if-hyper-threading-is-active-on-windows-m) instead of `get_ncpu()`. 

Would this work if used in `get_num_procs()` instead of calling out to `get_nprocs()`?  I don't have a mac with Hyperthreading otherwise I would test it, but it compiles and tests fine.  :)
