### PR TITLE
add a sanity check on the detected cpu type

### DIFF
--- a/driver/others/dynamic.c
+++ b/driver/others/dynamic.c
@@ -273,6 +273,15 @@ void gotoblas_dynamic_init(void) {
   if (gotoblas == NULL) gotoblas = &gotoblas_KATMAI;
 #else
   if (gotoblas == NULL) gotoblas = &gotoblas_PRESCOTT;
+  /* sanity check, if 64bit pointer we can't have a 32 bit cpu */
+  if (sizeof(void*) == 8) {
+      if (gotoblas == &gotoblas_KATMAI ||
+          gotoblas == &gotoblas_COPPERMINE ||
+          gotoblas == &gotoblas_NORTHWOOD ||
+          gotoblas == &gotoblas_BANIAS ||
+          gotoblas == &gotoblas_ATHLON)
+          gotoblas = &gotoblas_PRESCOTT;
+  }
 #endif
   
   if (gotoblas && gotoblas -> init) {


### PR DESCRIPTION
if we have 64 bit pointers we can't have a 32 bit cpu, so fall back to
the 64bit cpu fallback (prescott)
E.g. the cpu detection fails in amd qemu64 emulation (family 6 model 2)
causing it to use the uninitialized gotoblas_ATHLON
