### PR TITLE
set parameters for CORE_ATHLON

### DIFF
--- a/kernel/setparam-ref.c
+++ b/kernel/setparam-ref.c
@@ -634,10 +634,10 @@ static void init_parameter(void) {
   TABLE_NAME.xgemm_q = XGEMM_DEFAULT_Q;
 #endif
 
-#if defined(CORE_KATMAI)  || defined(CORE_COPPERMINE) || defined(CORE_BANIAS) || defined(CORE_YONAH)
+#if defined(CORE_KATMAI)  || defined(CORE_COPPERMINE) || defined(CORE_BANIAS) || defined(CORE_YONAH) || defined(CORE_ATHLON)
 
 #ifdef DEBUG
-  fprintf(stderr, "Katmai, Coppermine, Banias\n");
+  fprintf(stderr, "Katmai, Coppermine, Banias, Athlon\n");
 #endif
 
   TABLE_NAME.sgemm_p =  64 * (l2 >> 7);


### PR DESCRIPTION
else dgemm_p is set to zero leading to a segfault in alloc_mmap due to
allocsize being zero
