### PR TITLE
Attempt to add Haswell support (using sandybridge optimizations)

### DIFF
--- a/cpuid.h
+++ b/cpuid.h
@@ -196,4 +196,7 @@ typedef struct {
 #define CPUTYPE_SANDYBRIDGE             44
 #define CPUTYPE_BOBCAT                  45
 #define CPUTYPE_BULLDOZER               46
+// this define is because BLAS doesn't have haswell specific optimizations yet
+#define CPUTYPE_HASWELL CPUTYPE_SANDYBRIDGE 
+
 #endif

--- a/cpuid_x86.c
+++ b/cpuid_x86.c
@@ -41,6 +41,7 @@
 #include "cpuid.h"
 
 #ifdef NO_AVX
+#define CPUTYPE_HASWELL CPUTYPE_NEHALEM
 #define CPUTYPE_SANDYBRIDGE CPUTYPE_NEHALEM
 #define CORE_SANDYBRIDGE CORE_NEHALEM
 #define CPUTYPE_BULLDOZER CPUTYPE_BARCELONA
@@ -1050,8 +1051,22 @@ int get_cpuname(void){
 	    return CPUTYPE_SANDYBRIDGE;
 	  else
 	    return CPUTYPE_NEHALEM;
+        case 12:
+          if(support_avx())
+            return CPUTYPE_HASWELL;
+          else
+	    return CPUTYPE_NEHALEM;
 	}
 	break;
+      case 4:
+        switch (model) {
+        case 5:
+          if(support_avx())
+            return CPUTYPE_HASWELL;
+          else
+	    return CPUTYPE_NEHALEM;
+        }
+        break;      
       }
       break;
     case 0x7:


### PR DESCRIPTION
I tried to get OpenBLAS to work on my Haswell machine without having to define TARGET explicitly. This defines A couple Haswell CPUs as `CPUTYPE_SANDYBRIDGE`. This seems to be detected correctly (e.g., `config.h` is generated with `#define SANDYBRIDGE`), but that isn't sufficient to get this to work.

What am I missing here?
