### PR TITLE
Create openblas_get_parallel to retrieve information about the used threading model

### DIFF
--- a/cblas.h
+++ b/cblas.h
@@ -16,6 +16,16 @@ void goto_set_num_threads(int num_threads);
 /*Get the build configure on runtime.*/
 char* openblas_get_config(void);
 
+/* Get the parallelization type which is used by OpenBLAS */
+int openblas_get_parallel(void); 
+/* OpenBLAS is compiled for sequential use  */
+#define OPENBLAS_SEQUENTIAL  0
+/* OpenBLAS is compiled using normal threading model */
+#define OPENBLAS_THREAD  1 
+/* OpenBLAS is compiled using OpenMP threading model */
+#define OPENBLAS_OPENMP 2 
+
+
 #define CBLAS_INDEX size_t
 
 typedef enum CBLAS_ORDER     {CblasRowMajor=101, CblasColMajor=102} CBLAS_ORDER;

--- a/driver/others/Makefile
+++ b/driver/others/Makefile
@@ -1,7 +1,7 @@
 TOPDIR	= ../..
 include ../../Makefile.system
 
-COMMONOBJS	 = memory.$(SUFFIX) xerbla.$(SUFFIX) c_abs.$(SUFFIX) z_abs.$(SUFFIX) openblas_set_num_threads.$(SUFFIX) openblas_get_config.$(SUFFIX)
+COMMONOBJS	 = memory.$(SUFFIX) xerbla.$(SUFFIX) c_abs.$(SUFFIX) z_abs.$(SUFFIX) openblas_set_num_threads.$(SUFFIX) openblas_get_config.$(SUFFIX) openblas_get_parallel.$(SUFFIX) 
 
 COMMONOBJS	+= slamch.$(SUFFIX) slamc3.$(SUFFIX) dlamch.$(SUFFIX)  dlamc3.$(SUFFIX)
 
@@ -104,6 +104,9 @@ openblas_set_num_threads.$(SUFFIX) : openblas_set_num_threads.c
 	$(CC) $(CFLAGS) -c $< -o $(@F)
 
 openblas_get_config.$(SUFFIX) : openblas_get_config.c
+	$(CC) $(CFLAGS) -c $< -o $(@F)
+
+openblas_get_parallel.$(SUFFIX) : openblas_get_parallel.c
 	$(CC) $(CFLAGS) -c $< -o $(@F)
 
 blasL1thread.$(SUFFIX) : blas_l1_thread.c ../../common.h ../../common_thread.h

--- a/driver/others/openblas_get_parallel.c
+++ b/driver/others/openblas_get_parallel.c
@@ -1,0 +1,52 @@
+/*****************************************************************************
+Copyright (c) 2013 Martin Koehler, grisuthedragon@users.github.com
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   1. Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+   3. Neither the name of the ISCAS nor the names of its contributors may 
+      be used to endorse or promote products derived from this software 
+      without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE 
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL 
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR 
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER 
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE 
+USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+**********************************************************************************/
+
+#include "common.h"
+
+#if defined(USE_OPENMP)
+static int parallel = 2 ; 
+#elif defined(SMP_SERVER) 
+static int parallel = 1; 
+#else 
+static int parallel = 0; 
+#endif 
+
+int openblas_get_parallel() {
+  return parallel;
+}
+
+int openblas_get_parallel_() {
+  return parallel;
+}
+
+
+

--- a/exports/gensymbol
+++ b/exports/gensymbol
@@ -74,11 +74,11 @@
 
 @misc_no_underscore_objs = (
                             openblas_set_num_threads, goto_set_num_threads,
-                            openblas_get_config,
+                            openblas_get_config, openblas_get_parallel
                            );
 
 @misc_underscore_objs = (
-                            openblas_set_num_threads,
+                            openblas_set_num_threads,openblas_get_parallel 
                         );
 
 @lapackobjs = (

--- a/test/get_threading_model.c
+++ b/test/get_threading_model.c
@@ -1,0 +1,18 @@
+#include "../cblas.h" 
+
+int main() {
+	int th_model = openblas_get_parallel(); 
+	switch(th_model) {
+		case OPENBLAS_SEQUENTIAL: 
+			printf("OpenBLAS is compiled sequentially.\n"); 
+			break; 
+		case OPENBLAS_THREAD: 
+			printf("OpenBLAS is compiled using the normal threading model\n"); 
+			break; 
+		case OPENBLAS_OPENMP: 
+			printf("OpenBLAS is compiled using OpenMP\n"); 
+			break; 
+	}
+	return 0; 
+}
+


### PR DESCRIPTION
I integrated a function:

```
int openblas_get_parallel(void); 
```

to detect at runtime which parallelization technique is used by OpenBLAS. In addition I a three constants to cblas.h to identify the return value: 

```
#define OPENBLAS_SEQUENTIAL  0  - means that OpenBLAS operates in sequential mode   
#define OPENBLAS_THREAD  1    - means that OpenBLAS uses the normal threading code 
#define OPENBLAS_OPENMP 2    - means that OpenBLAS uses the OpemMP threading code.
```

I hope that this simple function is useful for other users of OpenBLAS too. 
