### PR TITLE
Respect user's LDFLAGS

### DIFF
--- a/Makefile.generic
+++ b/Makefile.generic
@@ -1,6 +1,1 @@
 COPT	= -Wall -O2 # -DGEMMTEST
-ifdef BINARY64
-else
-# LDFLAGS		 = -m elf32ppc
-LDFLAGS		 = -m elf_i386
-endif

--- a/Makefile.power
+++ b/Makefile.power
@@ -17,13 +17,7 @@ endif
 endif
 
 ifdef BINARY64
-ifeq ($(OSNAME), Linux)
-LDFLAGS		= -m elf64ppc
-endif
 
-ifeq ($(OSNAME), Darwin)
-LDFLAGS		= -arch ppc64
-endif
 
 ifeq ($(OSNAME), AIX)
 CCOMMON_OPT	+= -mpowerpc64 -maix64
@@ -34,17 +28,12 @@ ifeq ($(COMPILER_F77), xlf)
 FCOMMON_OPT	+= -q64
 endif
 ARFLAGS		= -X 64
-LDFLAGS		= -b64
 ASFLAGS		= -a64
 endif
 else
-ifeq ($(OSNAME), Linux)
-LDFLAGS		 = -m elf32ppc
-endif
 ifeq ($(OSNAME), AIX)
 CCOMMON_OPT	+= -Wa,-a32
 ARFLAGS		= -X 32
-LDFLAGS		= -b32
 ASFLAGS		= -a32
 endif
 endif

--- a/Makefile.sparc
+++ b/Makefile.sparc
@@ -10,7 +10,6 @@ endif
 ifeq ($(COMPILER_F77), f90)
 FCOMMON_OPT += -xarch=v9
 endif
-LDFLAGS	= -64
 else
 
 CCOMMON_OPT += -mcpu=v9

--- a/Makefile.x86
+++ b/Makefile.x86
@@ -1,8 +1,5 @@
 # COMPILER_PREFIX = mingw32-
 
-ifeq ($(OSNAME), Linux)
-LDFLAGS     = -melf_i386
-endif
 
 ifeq ($(OSNAME), Interix)
 ARFLAGS		= -m x86

--- a/Makefile.x86_64
+++ b/Makefile.x86_64
@@ -2,23 +2,10 @@
 
 ifeq ($(OSNAME), SunOS)
 ifdef BINARY64
-LDFLAGS = -64
 ifeq ($(F_COMPILER), SUN)
 FCOMMON_OPT += -m64
 endif
 endif
-endif
-
-ifeq ($(OSNAME), FreeBSD)
-LDFLAGS		 = -m elf_x86_64_fbsd
-endif
-
-ifeq ($(OSNAME), Linux)
-LDFLAGS		 = -m elf_x86_64
-endif
-
-ifeq ($(OSNAME), Darwin)
-LDFLAGS		 = 
 endif
 
 ifeq ($(OSNAME), Interix)

--- a/ctest/Makefile
+++ b/ctest/Makefile
@@ -77,7 +77,7 @@ endif
 clean ::
 	rm -f x* 
 
-FLDFLAGS = $(FFLAGS:-fPIC=)
+FLDFLAGS = $(FFLAGS:-fPIC=) $(LDFLAGS)
 CEXTRALIB = 
 
 # Single real

--- a/exports/Makefile
+++ b/exports/Makefile
@@ -89,7 +89,7 @@ else
 endif
 
 libgoto2_shared.dll : ../$(LIBNAME) libgoto2_shared.def
-	$(CC) $(CFLAGS) libgoto2_shared.def -shared -o $(@F) \
+	$(CC) $(LDFLAGS) libgoto2_shared.def -shared -o $(@F) \
 	-Wl,--whole-archive ../$(LIBNAME) -Wl,--no-whole-archive \
 	-Wl,--out-implib,libgoto2_shared.lib $(FEXTRALIB)
 
@@ -116,14 +116,14 @@ ifeq ($(OSNAME), Linux)
 so : ../$(LIBSONAME)
 
 ../$(LIBSONAME) : ../$(LIBNAME) linux.def linktest.c
-	$(CC) $(CFLAGS) -shared -o ../$(LIBSONAME) \
+	$(CC) $(LDFLAGS) -shared -o ../$(LIBSONAME) \
 	-Wl,--whole-archive ../$(LIBNAME) -Wl,--no-whole-archive \
 	-Wl,--retain-symbols-file=linux.def -Wl,-soname,$(LIBPREFIX).so.$(MAJOR_VERSION) $(EXTRALIB)
 ifneq ($(C_COMPILER), LSB)
-	$(CC) $(CFLAGS) -w -o linktest linktest.c ../$(LIBSONAME) $(FEXTRALIB) && echo OK.
+	$(CC) $(CFLAGS) $(LDFLAGS) -w -o linktest linktest.c ../$(LIBSONAME) $(FEXTRALIB) && echo OK.
 else
 #Use FC on LSB
-	$(FC) $(FFLAGS) -w -o linktest linktest.c ../$(LIBSONAME) $(FEXTRALIB) && echo OK.
+	$(FC) $(FFLAGS) $(LDFLAGS) -w -o linktest linktest.c ../$(LIBSONAME) $(FEXTRALIB) && echo OK.
 endif
 	rm -f linktest
 
@@ -135,10 +135,10 @@ ifeq ($(OSNAME), $(filter $(OSNAME),FreeBSD NetBSD))
 so : ../$(LIBSONAME)
 
 ../$(LIBSONAME) : ../$(LIBNAME) linux.def linktest.c
-	$(CC) $(CFLAGS)  -shared -o ../$(LIBSONAME) \
+	$(CC) $(LDFLAGS)  -shared -o ../$(LIBSONAME) \
 	-Wl,--whole-archive ../$(LIBNAME) -Wl,--no-whole-archive \
 	-Wl,--retain-symbols-file=linux.def $(FEXTRALIB) $(EXTRALIB)
-	$(CC) $(CFLAGS) -w -o linktest linktest.c ../$(LIBSONAME) $(FEXTRALIB) && echo OK.
+	$(CC) $(CFLAGS) $(LDFLAGS) -w -o linktest linktest.c ../$(LIBSONAME) $(FEXTRALIB) && echo OK.
 	rm -f linktest
 
 endif
@@ -148,15 +148,15 @@ ifeq ($(OSNAME), OSF1)
 so : ../$(LIBSONAME)
 
 ../$(LIBSONAME) :
-	$(CC) -shared -o ../$(LIBSONAME) ../$(LIBNAME)
+	$(CC) $(LDFLAGS) -shared -o ../$(LIBSONAME) ../$(LIBNAME)
 endif
 
 ifeq ($(OSNAME), SunOS)
 
 so : ../$(LIBSONAME)
-	$(CC) $(CFLAGS)  -shared -o ../$(LIBSONAME) \
+	$(CC) $(LDFLAGS)  -shared -o ../$(LIBSONAME) \
 	-Wl,--whole-archive ../$(LIBNAME) -Wl,--no-whole-archive $(EXTRALIB)
-	$(CC) $(CFLAGS) -w -o linktest linktest.c ../$(LIBSONAME) $(FEXTRALIB) && echo OK.
+	$(CC) $(LDFLAGS) -w -o linktest linktest.c ../$(LIBSONAME) $(FEXTRALIB) && echo OK.
 	rm -f linktest
 
 endif
@@ -199,7 +199,7 @@ symbol.S : gensymbol
 	perl ./gensymbol win2kasm noarch dummy $(EXPRECISION) $(NO_CBLAS)  $(NO_LAPACK) $(NO_LAPACKE) > symbol.S
 
 test : linktest.c
-	$(CC) $(CFLAGS) -w -o linktest linktest.c ../$(LIBSONAME) -lm && echo OK.
+	$(CC) $(CFLAGS) $(LDFLAGS) -w -o linktest linktest.c ../$(LIBSONAME) -lm && echo OK.
 	rm -f linktest
 
 linktest.c : gensymbol ../Makefile.system ../getarch.c

--- a/test/Makefile
+++ b/test/Makefile
@@ -88,7 +88,7 @@ else
 endif
 endif
 
-FLDFLAGS = $(FFLAGS:-fPIC=)
+FLDFLAGS = $(FFLAGS:-fPIC=) $(LDFLAGS)
 CEXTRALIB = 
 
 


### PR DESCRIPTION
This is a patch to respect the user's LDFLAGS (such as -Wl,--as-needed). Also most of -m<flags> are not linking flags and are usually absorbed by the distribution compiler or cross-compiler.
