### PR TITLE
Avoid failure on qemu guests declaring an Athlon CPU without 3dnow!

### DIFF
--- a/driver/others/dynamic.c
+++ b/driver/others/dynamic.c
@@ -222,7 +222,19 @@ static gotoblas_t *get_coretype(void){
   }
 
   if (vendor == VENDOR_AMD){
-    if (family <= 0xe) return &gotoblas_ATHLON;
+    if (family <= 0xe) {
+        // Verify that CPU has 3dnow and 3dnowext before claiming it is Athlon
+        cpuid(0x80000000, &eax, &ebx, &ecx, &edx);
+        if (eax & 0xffff >= 0x01) {
+            cpuid(0x80000001, &eax, &ebx, &ecx, &edx);
+            if ((edx & (1 << 30)) == 0 || (edx & (1 << 31)) == 0)
+              return NULL;
+          }
+        else
+          return NULL;
+
+        return &gotoblas_ATHLON;
+      }
     if (family == 0xf){
       if ((exfamily == 0) || (exfamily == 2)) {
 	if (ecx & (1 <<  0)) return &gotoblas_OPTERON_SSE3; 


### PR DESCRIPTION
The present patch verifies that, on machines declaring an Athlon CPU model and
family, the 3dnow and 3dnowext feature flags are indeed present. If they are
not, it fallbacks on the most generic x86 kernel. This prevents crashes due to
illegal instruction on qemu guests with a weird configuration.

Closes #272
