### PR TITLE
Missing threshold in gemm.c

### DIFF
--- a/interface/gemm.c
+++ b/interface/gemm.c
@@ -71,6 +71,10 @@
 #endif
 #endif
 
+#ifndef GEMM_MULTITHREAD_THRESHOLD
+# define GEMM_MULTITHREAD_THRESHOLD 4
+#endif
+
 static int (*gemm[])(blas_arg_t *, BLASLONG *, BLASLONG *, FLOAT *, FLOAT *, BLASLONG) = {
 #ifndef GEMM3M
   GEMM_NN, GEMM_TN, GEMM_RN, GEMM_CN,


### PR DESCRIPTION
This seems to fix the build on Ubuntu; at least,

```
make TARGET=BARCELONA
```

works. Plain `make` still crashes. This is probably not a very clean solution, but I honestly didn't understand what the Makefiles were doing to get `GEMM_MULTITHREAD_THRESHOLD` into `gemm.c`.
