### PR TITLE
fix default prefix handling in makefiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,6 @@ ifdef SANITY_CHECK
 BLASDIRS += reference
 endif
 
-ifndef PREFIX
-PREFIX = /opt/OpenBLAS
-endif
-
 SUBDIRS	= $(BLASDIRS)
 ifneq ($(NO_LAPACK), 1)
 SUBDIRS	+= lapack

--- a/Makefile.install
+++ b/Makefile.install
@@ -3,6 +3,8 @@ export GOTOBLAS_MAKEFILE = 1
 -include $(TOPDIR)/Makefile.conf_last
 include ./Makefile.system
 
+PREFIX?=/opt/OpenBLAS
+
 OPENBLAS_INCLUDE_DIR:=$(PREFIX)/include
 OPENBLAS_LIBRARY_DIR:=$(PREFIX)/lib
 OPENBLAS_BUILD_DIR:=$(CURDIR)


### PR DESCRIPTION
On my Ubuntu box, `PREFIX` wasn't communicated to `Makefile.install` by `Makefile`. The result was that the default `PREFIX` was effectively empty and OpenBLAS was being installed in `/lib`. This patches fixes that by setting the default in `Makefile.install`.
