### PR TITLE
Remove -Wl,--retain-symbols-file from dynamic link line to fix tool support

### DIFF
--- a/exports/Makefile
+++ b/exports/Makefile
@@ -126,7 +126,7 @@ so : ../$(LIBSONAME)
 ../$(LIBSONAME) : ../$(LIBNAME) linux.def linktest.c
 	$(CC) $(CFLAGS) $(LDFLAGS) -shared -o ../$(LIBSONAME) \
 	-Wl,--whole-archive ../$(LIBNAME) -Wl,--no-whole-archive \
-	-Wl,--retain-symbols-file=linux.def -Wl,-soname,$(LIBPREFIX).so.$(MAJOR_VERSION) $(EXTRALIB)
+	-Wl,-soname,$(LIBPREFIX).so.$(MAJOR_VERSION) $(EXTRALIB)
 ifneq ($(C_COMPILER), LSB)
 	$(CC) $(CFLAGS) $(LDFLAGS) -w -o linktest linktest.c ../$(LIBSONAME) $(FEXTRALIB) && echo OK.
 else
@@ -145,7 +145,7 @@ so : ../$(LIBSONAME)
 ../$(LIBSONAME) : ../$(LIBNAME) linux.def linktest.c
 	$(CC) $(CFLAGS) $(LDFLAGS)  -shared -o ../$(LIBSONAME) \
 	-Wl,--whole-archive ../$(LIBNAME) -Wl,--no-whole-archive \
-	-Wl,--retain-symbols-file=linux.def $(FEXTRALIB) $(EXTRALIB)
+	$(FEXTRALIB) $(EXTRALIB)
 	$(CC) $(CFLAGS) $(LDFLAGS) -w -o linktest linktest.c ../$(LIBSONAME) $(FEXTRALIB) && echo OK.
 	rm -f linktest
 


### PR DESCRIPTION
The aim is to restrict the symbols exported from openBLAS, but for dynamic libraries --retain-symbols-file has the opposite effect intended. It removes symbols from the .symtab section of the library, which is used by tools such as debuggers, profilers, objdump etc. but does not remove them from .dynsym, which is the section used by the runtime when loading the binary.

In short, using --retain-symbols-file like this doesn't prevent symbol leakage but does prevent tools from analyzing applications linked with openBLAS.

This patch improves tool support for openBLAS applications but does not address symbol leakage through .dynsym.
