### PR TITLE
More robust OPENBLAS_ prefixing of macros in openblas_config.h

### DIFF
--- a/Makefile.install
+++ b/Makefile.install
@@ -23,7 +23,7 @@ install : 	lib.grd
 #for inc 
 	@echo \#ifndef OPENBLAS_CONFIG_H > $(DESTDIR)$(OPENBLAS_INCLUDE_DIR)/openblas_config.h
 	@echo \#define OPENBLAS_CONFIG_H >> $(DESTDIR)$(OPENBLAS_INCLUDE_DIR)/openblas_config.h
-	@awk '{print $$1, "OPENBLAS_"$$2, $$3}' config_last.h >> $(DESTDIR)$(OPENBLAS_INCLUDE_DIR)/openblas_config.h
+	@awk 'NF {print $$1, "OPENBLAS_"$$2, $$3}' config_last.h >> $(DESTDIR)$(OPENBLAS_INCLUDE_DIR)/openblas_config.h
 	@echo \#define OPENBLAS_VERSION \" OpenBLAS $(VERSION) \" >> $(DESTDIR)$(OPENBLAS_INCLUDE_DIR)/openblas_config.h
 	@cat openblas_config_template.h >> $(DESTDIR)$(OPENBLAS_INCLUDE_DIR)/openblas_config.h
 	@echo \#endif  \/\* OPENBLAS_CONFIG_H \*\/ >> $(DESTDIR)$(OPENBLAS_INCLUDE_DIR)/openblas_config.h


### PR DESCRIPTION
I cannot reproduce it but in the past I had a blank line in my `config_last.h`. The awk replacement of that line introduced to fix #315 was generating an invalid `openblas_config.h` header in that case.

The `NF` check should prevent this to happen again.

For reference, the error message I had with GCC was:

```
In file included from /opt/OpenBLAS/include/cblas.h:5:0,
                 from /home/ogrisel/tmp/my_file.c:33:
/opt/OpenBLAS/include/openblas_config.h:66:1: error: expected ‘=’, ‘,’, ‘;’, ‘asm’ or ‘__attribute__’ before ‘typedef’
```
