### PR TITLE
Add -lgfortran flag to gcc call in a makefile

### DIFF
--- a/exports/Makefile
+++ b/exports/Makefile
@@ -85,7 +85,7 @@ dll  : ../$(LIBDLLNAME)
 	$(RANLIB) ../$(LIBNAME)
 	$(CC) $(CFLAGS) $(LDFLAGS) libopenblas.def dllinit.$(SUFFIX) \
 	-shared -o ../$(LIBDLLNAME) -Wl,--out-implib,../$(LIBPREFIX).lib \
-	-Wl,--whole-archive ../$(LIBNAME) -Wl,--no-whole-archive $(FEXTRALIB)
+	-Wl,--whole-archive ../$(LIBNAME) -Wl,--no-whole-archive $(FEXTRALIB) $(EXTRALIB)
 
 libopenblas.def : gensymbol
 	perl ./gensymbol win2k    $(ARCH) dummy $(EXPRECISION) $(NO_CBLAS) $(NO_LAPACK) $(NO_LAPACKE) $(NEED2UNDERSCORES) $(ONLY_CBLAS) > $(@F)


### PR DESCRIPTION
Adding $(EXTRALIB) adds this flag when things are built with
msys2 on windows. Without this the build fails.
