### PR TITLE
fix #394

### DIFF
--- a/common.h
+++ b/common.h
@@ -388,6 +388,15 @@ please https://github.com/xianyi/OpenBLAS/issues/246
 #include "common_arm64.h"
 #endif
 
+#ifndef ASSEMBLER
+#ifdef OS_WINDOWS
+typedef char env_var_t[MAX_PATH];
+#define readenv(p, n) GetEnvironmentVariable((n), (p), sizeof(p))
+#else
+typedef char* env_var_t;
+#define readenv(p, n) ((p)=getenv(n))
+#endif
+#endif
 
 #ifdef OS_LINUX
 #include "common_linux.h"
@@ -515,13 +524,9 @@ static __inline void blas_unlock(volatile BLASULONG *address){
   *address = 0;
 }
 
-static __inline int readenv(char *env) {
-
-  char *p;
-
-  p = getenv(env);
-
-  if (p == NULL) return 0; else return atoi(p);
+static __inline int readenv_atoi(char *env) {
+  env_var_t p;
+  return readenv(p,env) ? 0 : atoi(p);
 }
 
 
@@ -687,8 +692,8 @@ extern int gotoblas_profile;
 #define PRINT_DEBUG_CNAME
 #define PRINT_DEBUG_NAME
 #else
-#define PRINT_DEBUG_CNAME if (readenv("GOTO_DEBUG")) fprintf(stderr, "GotoBLAS : %s\n", CHAR_CNAME)
-#define PRINT_DEBUG_NAME  if (readenv("GOTO_DEBUG")) fprintf(stderr, "GotoBLAS : %s\n", CHAR_NAME)
+#define PRINT_DEBUG_CNAME if (readenv_atoi("GOTO_DEBUG")) fprintf(stderr, "GotoBLAS : %s\n", CHAR_CNAME)
+#define PRINT_DEBUG_NAME  if (readenv_atoi("GOTO_DEBUG")) fprintf(stderr, "GotoBLAS : %s\n", CHAR_NAME)
 #endif
 
 #ifdef __cplusplus

--- a/driver/others/blas_server.c
+++ b/driver/others/blas_server.c
@@ -533,18 +533,15 @@ int blas_thread_init(void){
 
   if (!blas_server_avail){
 
-    char *p;
+    env_var_t p;
 
-    p = getenv("THREAD_TIMEOUT");
-
-    if (p) {
+    if (readenv(p,"THREAD_TIMEOUT")) {
       thread_timeout = atoi(p);
       if (thread_timeout <  4) thread_timeout =  4;
       if (thread_timeout > 30) thread_timeout = 30;
       thread_timeout = (1 << thread_timeout);
     }else{
-		p = getenv("GOTO_THREAD_TIMEOUT");
-		if (p) {
+		if (readenv(p,"GOTO_THREAD_TIMEOUT")) {
 			thread_timeout = atoi(p);
 			if (thread_timeout <  4) thread_timeout =  4;
 			if (thread_timeout > 30) thread_timeout = 30;

--- a/driver/others/init.c
+++ b/driver/others/init.c
@@ -698,11 +698,11 @@ void gotoblas_affinity_init(void) {
 #ifdef USE_OPENMP
   numprocs = 0;
 #else
-  numprocs = readenv("OPENBLAS_NUM_THREADS");
-  if (numprocs == 0) numprocs = readenv("GOTO_NUM_THREADS");
+  numprocs = readenv_atoi("OPENBLAS_NUM_THREADS");
+  if (numprocs == 0) numprocs = readenv_atoi("GOTO_NUM_THREADS");
 #endif
 
-  if (numprocs == 0) numprocs = readenv("OMP_NUM_THREADS");
+  if (numprocs == 0) numprocs = readenv_atoi("OMP_NUM_THREADS");
 
   numnodes = 1;
 
@@ -793,7 +793,7 @@ void gotoblas_affinity_init(void) {
 
     setup_mempolicy();
 
-    if (readenv("OPENBLAS_MAIN_FREE") || readenv("GOTOBLAS_MAIN_FREE")) {
+    if (readenv_atoi("OPENBLAS_MAIN_FREE") || readenv_atoi("GOTOBLAS_MAIN_FREE")) {
       sched_setaffinity(0, sizeof(cpu_orig_mask), &cpu_orig_mask[0]);
     }
 

--- a/driver/others/openblas_error_handle.c
+++ b/driver/others/openblas_error_handle.c
@@ -35,9 +35,8 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 int openblas_verbose() {
   int ret=0;
-  char *p;
-  p = getenv("OPENBLAS_VERBOSE");
-  if (p) ret = atoi(p);
+  env_var_t p;
+  if (readenv(p,"OPENBLAS_VERBOSE")) ret = atoi(p);
   if(ret<0) ret=0;
   return ret;
 }

--- a/driver/others/parameter.c
+++ b/driver/others/parameter.c
@@ -248,7 +248,7 @@ int get_L2_size(void){
 
 void blas_set_parameter(void){
 
-  char *p;
+  env_var_t p;
   int factor;
   int size = get_L2_size();
 
@@ -463,9 +463,8 @@ void blas_set_parameter(void){
 #endif
 #endif
 
-  p = getenv("GOTO_BLOCK_FACTOR");
 
-  if (p) {
+  if (readenv(p,"GOTO_BLOCK_FACTOR")) {
     factor = atoi(p);
     if (factor <  10) factor =  10;
     if (factor > 200) factor = 200;


### PR DESCRIPTION
this cleans up some system handles after openblas is finished with them, and doesn't disable ALL process privileges upon success. It also eliminates calls to `getenv` from `DllInit`, which [msdn documents as unsafe](http://msdn.microsoft.com/en-us/library/windows/desktop/dn633971%28v=vs.85%29.aspx), and uses `GetEnvironmentVariable` directly instead

note: I am still waiting for confirmation that this works on all the user machines that originally reported the problem, but initial reports are very promising: [https://github.com/JuliaLang/julia/issues/5574](https://github.com/JuliaLang/julia/issues/5574)
