### PR TITLE
add gotoblas_corename to dll exports list

### DIFF
--- a/exports/gensymbol
+++ b/exports/gensymbol
@@ -85,6 +85,7 @@
 @misc_no_underscore_objs = (
                             goto_set_num_threads,
                             openblas_get_config,
+                            gotoblas_corename,
                            );
 
 @misc_underscore_objs = (


### PR DESCRIPTION
This is a useful function to have access to from external applications. Any downside to exporting it?
