### PR TITLE
cpuid_arm: fix detection when cpuinfo uses "Processor"

### DIFF
--- a/cpuid_arm.c
+++ b/cpuid_arm.c
@@ -90,7 +90,7 @@ int detect(void)
 	while (fgets(buffer, sizeof(buffer), infile))
 	{
 
-		if (!strncmp("model name", buffer, 10))
+		if ((!strncmp("model name", buffer, 10)) || (!strncmp("Processor", buffer, 9)))
 		{
 			p = strchr(buffer, ':') + 2;
 			break;


### PR DESCRIPTION
This patch fixes cpuid on arm when `/proc/cpuinfo` identifies the cpu by `Processor` rather than `model name`.

On my system (Samsung Chromebook XE303C12 / Exynos5  / Cortex A15 with Ubuntu 12.04), cpuinfo has the following output:

```
user@chrubuntu:~/dev/OpenBLAS$ cat /proc/cpuinfo
Processor       : ARMv7 Processor rev 4 (v7l)
processor       : 0
BogoMIPS        : 1694.10

processor       : 1
BogoMIPS        : 1694.10

Features        : swp half thumb fastmult vfp edsp thumbee neon vfpv3 tls vfpv4 idiva idivt
CPU implementer : 0x41
CPU architecture: 7
CPU variant     : 0x0
CPU part        : 0xc0f
CPU revision    : 4

Hardware        : SAMSUNG EXYNOS5 (Flattened Device Tree)
Revision        : 0000
Serial          : 0000000000000000
```

(based on some limited google searches, I believe that some other ARM systems have such output, but I do not know what is the general convention)
