### PR TITLE
Fix link error on Linux/musl.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -114,5 +114,8 @@ In chronological order:
 * carlkl <https://github.com/carlkl>
   * [2013-12-13] Fixed LAPACKE building bug on Windows
 
+* Isaac Dunham <https://github.com/idunham>
+  * [2014-08-03] Fixed link error on Linux/musl
+
 * [Your name or handle] <[email or website]>
   * [Date] [Brief summary of your changes]

--- a/driver/others/init.c
+++ b/driver/others/init.c
@@ -865,7 +865,7 @@ void gotoblas_set_affinity2(int threads) {};
 
 void gotoblas_affinity_reschedule(void) {};
 
-int get_num_procs(void) { return get_nprocs(); }
+int get_num_procs(void) { return sysconf(_SC_NPROCESSORS_ONLN); }
 
 int get_num_nodes(void) { return 1; }
 

--- a/driver/others/memory.c
+++ b/driver/others/memory.c
@@ -162,7 +162,7 @@ int get_num_procs(void);
 #else
 int get_num_procs(void) {
   static int nums = 0;
-  if (!nums) nums = get_nprocs();
+  if (!nums) nums = sysconf(_SC_NPROCESSORS_ONLN);
   return nums;
 }
 #endif


### PR DESCRIPTION
get_nprocs() is a GNU convenience function equivalent to POSIX2008
sysconf(_SC_NPROCESSORS_ONLN); the latter should be available in unistd.h
on any current *nix. (OS X supports this call since 10.5, and FreeBSD
currently supports it. But this commit does not change FreeBSD or OS X
versions.)

On musl (an alternate Linux libc), get_nprocs is not supported, so replace it with the POSIX equivalent.
