### PR TITLE
Workaround PIC limitations in cpuid.

### DIFF
--- a/cpuid_x86.c
+++ b/cpuid_x86.c
@@ -59,9 +59,16 @@
 void cpuid(int op, int *eax, int *ebx, int *ecx, int *edx);
 #else
 static inline void cpuid(int op, int *eax, int *ebx, int *ecx, int *edx){
+#if defined(__i386__) && defined(__PIC__)
+  __asm__ __volatile__
+    ("mov %%ebx, %%edi;"
+     "cpuid;"
+     "xchgl %%ebx, %%edi;"
+     : "=a" (*eax), "=D" (*ebx), "=c" (*ecx), "=d" (*edx) : "a" (op) : "cc");
+#else
   __asm__ __volatile__
     ("cpuid": "=a" (*eax), "=b" (*ebx), "=c" (*ecx), "=d" (*edx) : "a" (op) : "cc");
-
+#endif
 }
 #endif
 


### PR DESCRIPTION
cpuid uses register ebx, but ebx is reserved in PIC.
So save ebx, swap ebx & edi, and return edi.
This fixes issue #442.

Copied from Igor Pavlov's equivalent fix for 7zip (in CpuArch.c),
which is public domain and thus OK license-wise.
