### PR TITLE
add SYMBOLPREFIX and SYMBOLSUFFIX makefile options

### DIFF
--- a/Makefile.system
+++ b/Makefile.system
@@ -186,6 +186,8 @@ LD	= $(CROSS_SUFFIX)ld
 RANLIB	= $(CROSS_SUFFIX)ranlib
 NM	= $(CROSS_SUFFIX)nm
 DLLWRAP = $(CROSS_SUFFIX)dllwrap
+OBJCOPY = $(CROSS_SUFFIX)objcopy
+OBJCONV = $(CROSS_SUFFIX)objconv
 
 #
 #  OS dependent settings
@@ -843,6 +845,14 @@ ifndef LIBNAMESUFFIX
 LIBPREFIX = libopenblas
 else
 LIBPREFIX = libopenblas_$(LIBNAMESUFFIX)
+endif
+
+ifndef SYMBOLPREFIX
+SYMBOLPREFIX =
+endif
+
+ifndef SYMBOLSUFFIX
+SYMBOLSUFFIX =
 endif
 
 KERNELDIR	= $(TOPDIR)/kernel/$(ARCH)

--- a/exports/Makefile
+++ b/exports/Makefile
@@ -88,12 +88,18 @@ dll  : ../$(LIBDLLNAME)
 	-Wl,--whole-archive ../$(LIBNAME) -Wl,--no-whole-archive $(FEXTRALIB) $(EXTRALIB)
 
 libopenblas.def : gensymbol
-	perl ./gensymbol win2k    $(ARCH) dummy $(EXPRECISION) $(NO_CBLAS) $(NO_LAPACK) $(NO_LAPACKE) $(NEED2UNDERSCORES) $(ONLY_CBLAS) > $(@F)
+	perl ./gensymbol win2k    $(ARCH) dummy $(EXPRECISION) $(NO_CBLAS) $(NO_LAPACK) $(NO_LAPACKE) $(NEED2UNDERSCORES) $(ONLY_CBLAS) "$(SYMBOLPREFIX)" "$(SYMBOLSUFFIX)" > $(@F)
 
 libgoto_hpl.def : gensymbol
-	perl ./gensymbol win2khpl $(ARCH) dummy $(EXPRECISION) $(NO_CBLAS) $(NO_LAPACK) $(NO_LAPACKE) $(NEED2UNDERSCORES) $(ONLY_CBLAS) > $(@F)
+	perl ./gensymbol win2khpl $(ARCH) dummy $(EXPRECISION) $(NO_CBLAS) $(NO_LAPACK) $(NO_LAPACKE) $(NEED2UNDERSCORES) $(ONLY_CBLAS) "$(SYMBOLPREFIX)" "$(SYMBOLSUFFIX)" > $(@F)
 
+ifeq (, $(SYMBOLPREFIX)$(SYMBOLSUFFIX))
 $(LIBDYNNAME) : ../$(LIBNAME) osx.def
+else
+../$(LIBNAME).renamed : ../$(LIBNAME) objconv.def
+	$(OBJCONV) @objconv.def ../$(LIBNAME) ../$(LIBNAME).renamed
+$(LIBDYNNAME) : ../$(LIBNAME).renamed osx.def
+endif
 	$(FC) $(FFLAGS) -all_load -headerpad_max_install_names -install_name $(CURDIR)/../$(LIBDYNNAME) -dynamiclib -o ../$(LIBDYNNAME) $< -Wl,-exported_symbols_list,osx.def  $(FEXTRALIB)
 
 dllinit.$(SUFFIX) : dllinit.c
@@ -103,16 +109,22 @@ ifeq ($(OSNAME), Linux)
 
 so : ../$(LIBSONAME)
 
+ifeq (, $(SYMBOLPREFIX)$(SYMBOLSUFFIX))
 ../$(LIBSONAME) : ../$(LIBNAME) linktest.c
+else
+../$(LIBNAME).renamed : ../$(LIBNAME) objcopy.def
+	$(OBJCOPY) --redefine-syms objcopy.def ../$(LIBNAME) ../$(LIBNAME).renamed
+../$(LIBSONAME) : ../$(LIBNAME).renamed linktest.c
+endif
 ifneq ($(C_COMPILER), LSB)
 	$(CC) $(CFLAGS) $(LDFLAGS) -shared -o ../$(LIBSONAME) \
-	-Wl,--whole-archive ../$(LIBNAME) -Wl,--no-whole-archive \
+	-Wl,--whole-archive $< -Wl,--no-whole-archive \
 	-Wl,-soname,$(LIBPREFIX).so.$(MAJOR_VERSION) $(EXTRALIB)
 	$(CC) $(CFLAGS) $(LDFLAGS) -w -o linktest linktest.c ../$(LIBSONAME) $(FEXTRALIB) && echo OK.
 else
 #for LSB
 	env LSBCC_SHAREDLIBS=gfortran $(CC) $(CFLAGS) $(LDFLAGS) -shared -o ../$(LIBSONAME) \
-	-Wl,--whole-archive ../$(LIBNAME) -Wl,--no-whole-archive \
+	-Wl,--whole-archive $< -Wl,--no-whole-archive \
 	-Wl,-soname,$(LIBPREFIX).so.$(MAJOR_VERSION) $(EXTRALIB)
 	$(FC) $(CFLAGS) $(LDFLAGS) -w -o linktest linktest.c ../$(LIBSONAME) $(FEXTRALIB) && echo OK.
 endif
@@ -125,9 +137,15 @@ ifeq ($(OSNAME), $(filter $(OSNAME),FreeBSD NetBSD))
 
 so : ../$(LIBSONAME)
 
+ifeq (, $(SYMBOLPREFIX)$(SYMBOLSUFFIX))
 ../$(LIBSONAME) : ../$(LIBNAME) linktest.c
+else
+../$(LIBNAME).renamed : ../$(LIBNAME) objcopy.def
+	$(OBJCOPY) --redefine-syms objcopy.def ../$(LIBNAME) ../$(LIBNAME).renamed
+../$(LIBSONAME) : ../$(LIBNAME).renamed linktest.c
+endif
 	$(CC) $(CFLAGS) $(LDFLAGS)  -shared -o ../$(LIBSONAME) \
-	-Wl,--whole-archive ../$(LIBNAME) -Wl,--no-whole-archive \
+	-Wl,--whole-archive $< -Wl,--no-whole-archive \
 	$(FEXTRALIB) $(EXTRALIB)
 	$(CC) $(CFLAGS) $(LDFLAGS) -w -o linktest linktest.c ../$(LIBSONAME) $(FEXTRALIB) && echo OK.
 	rm -f linktest
@@ -178,17 +196,23 @@ static : ../$(LIBNAME)
 	rm -f goto.$(SUFFIX)
 
 osx.def : gensymbol ../Makefile.system ../getarch.c
-	perl ./gensymbol osx $(ARCH) $(BU) $(EXPRECISION) $(NO_CBLAS)  $(NO_LAPACK) $(NO_LAPACKE) $(NEED2UNDERSCORES) $(ONLY_CBLAS) > $(@F)
+	perl ./gensymbol osx $(ARCH) $(BU) $(EXPRECISION) $(NO_CBLAS)  $(NO_LAPACK) $(NO_LAPACKE) $(NEED2UNDERSCORES) $(ONLY_CBLAS) "$(SYMBOLPREFIX)" "$(SYMBOLSUFFIX)" > $(@F)
 
 aix.def : gensymbol ../Makefile.system ../getarch.c
-	perl ./gensymbol aix $(ARCH) $(BU) $(EXPRECISION) $(NO_CBLAS)  $(NO_LAPACK) $(NO_LAPACKE) $(NEED2UNDERSCORES) $(ONLY_CBLAS) > $(@F)
+	perl ./gensymbol aix $(ARCH) $(BU) $(EXPRECISION) $(NO_CBLAS)  $(NO_LAPACK) $(NO_LAPACKE) $(NEED2UNDERSCORES) $(ONLY_CBLAS) "$(SYMBOLPREFIX)" "$(SYMBOLSUFFIX)" > $(@F)
+
+objcopy.def : gensymbol ../Makefile.system ../getarch.c
+	perl ./gensymbol objcopy $(ARCH) $(BU) $(EXPRECISION) $(NO_CBLAS)  $(NO_LAPACK) $(NO_LAPACKE) $(NEED2UNDERSCORES) $(ONLY_CBLAS) "$(SYMBOLPREFIX)" "$(SYMBOLSUFFIX)" > $(@F)
+
+objconv.def : gensymbol ../Makefile.system ../getarch.c
+	perl ./gensymbol objconv $(ARCH) $(BU) $(EXPRECISION) $(NO_CBLAS)  $(NO_LAPACK) $(NO_LAPACKE) $(NEED2UNDERSCORES) $(ONLY_CBLAS) "$(SYMBOLPREFIX)" "$(SYMBOLSUFFIX)" > $(@F)
 
 test : linktest.c
 	$(CC) $(CFLAGS) $(LDFLAGS) -w -o linktest linktest.c ../$(LIBSONAME) -lm && echo OK.
 	rm -f linktest
 
 linktest.c : gensymbol ../Makefile.system ../getarch.c
-	perl ./gensymbol linktest  $(ARCH) $(BU) $(EXPRECISION) $(NO_CBLAS) $(NO_LAPACK) $(NO_LAPACKE) $(NEED2UNDERSCORES) $(ONLY_CBLAS) > linktest.c
+	perl ./gensymbol linktest  $(ARCH) $(BU) $(EXPRECISION) $(NO_CBLAS) $(NO_LAPACK) $(NO_LAPACKE) $(NEED2UNDERSCORES) $(ONLY_CBLAS) "$(SYMBOLPREFIX)" "$(SYMBOLSUFFIX)" > linktest.c
 
 clean ::
 	@rm -f *.def *.dylib __.SYMDEF*

--- a/exports/gensymbol
+++ b/exports/gensymbol
@@ -2784,22 +2784,26 @@ $bu = $ARGV[2];
 
 $bu = "" if (($bu eq "0") || ($bu eq "1"));
 
+$symbolprefix = $ARGV[9];
+
+$symbolsuffix = $ARGV[10];
+
 if ($ARGV[0] eq "osx"){
 
     @underscore_objs = (@underscore_objs, @misc_common_objs);
     @no_underscore_objs = (@no_underscore_objs, @misc_common_objs);
 
     foreach $objs (@underscore_objs) {
-	print "_", $objs, $bu, "\n";
+	print "_", $symbolprefix, $objs, $bu, $symbolsuffix, "\n";
     }
 
     foreach $objs (@need_2underscore_objs) {
-	print "_", $objs, $bu, $bu, "\n";
+	print "_", $symbolprefix, $objs, $bu, $bu, $symbolsuffix, "\n";
     }
 
 #    if ($ARGV[4] == 0) {
 	foreach $objs (@no_underscore_objs) {
-	    print "_", $objs, "\n";
+	    print "_", $symbolprefix, $objs, $symbolsuffix, "\n";
 	}
 #    }
     exit(0);
@@ -2811,16 +2815,58 @@ if ($ARGV[0] eq "aix"){
     @no_underscore_objs = (@no_underscore_objs, @misc_common_objs);
 
     foreach $objs (@underscore_objs) {
-	print $objs, $bu, "\n";
+	print $symbolprefix, $objs, $bu, $symbolsuffix, "\n";
     }
 
     foreach $objs (@need_2underscore_objs) {
-	print $objs, $bu, $bu, "\n";
+	print $symbolprefix, $objs, $bu, $bu, $symbolsuffix, "\n";
     }
 
 #    if ($ARGV[4] == 0) {
 	foreach $objs (@no_underscore_objs) {
-	    print $objs, "\n";
+	    print $symbolprefix, $objs, $symbolsuffix, "\n";
+	}
+#    }
+    exit(0);
+}
+
+if ($ARGV[0] eq "objcopy"){
+
+    @underscore_objs = (@underscore_objs, @misc_common_objs);
+    @no_underscore_objs = (@no_underscore_objs, @misc_common_objs);
+
+    foreach $objs (@underscore_objs) {
+	print $objs, $bu, " ", $symbolprefix, $objs, $bu, $symbolsuffix, "\n";
+    }
+
+    foreach $objs (@need_2underscore_objs) {
+	print $objs, $bu, $bu, " ", $symbolprefix, $objs, $bu, $bu, $symbolsuffix, "\n";
+    }
+
+#    if ($ARGV[4] == 0) {
+	foreach $objs (@no_underscore_objs) {
+	    print $objs, " ", $symbolprefix, $objs, $symbolsuffix, "\n";
+	}
+#    }
+    exit(0);
+}
+
+if ($ARGV[0] eq "objconv"){
+
+    @underscore_objs = (@underscore_objs, @misc_common_objs);
+    @no_underscore_objs = (@no_underscore_objs, @misc_common_objs);
+
+    foreach $objs (@underscore_objs) {
+	print "-nr:_", $objs, $bu, ":_", $symbolprefix, $objs, $bu, $symbolsuffix, "\n";
+    }
+
+    foreach $objs (@need_2underscore_objs) {
+	print "-nr:_", $objs, $bu, $bu, ":_", $symbolprefix, $objs, $bu, $bu, $symbolsuffix, "\n";
+    }
+
+#    if ($ARGV[4] == 0) {
+	foreach $objs (@no_underscore_objs) {
+	    print "-nr:_", $objs, ":_", $symbolprefix, $objs, $symbolsuffix, "\n";
 	}
 #    }
     exit(0);
@@ -2835,22 +2881,22 @@ if ($ARGV[0] eq "win2k"){
     foreach $objs (@underscore_objs) {
 	$uppercase = $objs;
 	$uppercase =~ tr/[a-z]/[A-Z]/;
-	print "\t$objs=$objs","_  \@", $count, "\n";
+	print "\t",$symbolprefix, $objs, $symbolsuffix, "=$objs","_  \@", $count, "\n";
 	$count ++;
-	print "\t",$objs, "_=$objs","_  \@", $count, "\n";
+	print "\t",$symbolprefix, $objs, "_", $symbolsuffix, "=$objs","_  \@", $count, "\n";
 	$count ++;
-	print "\t$uppercase=$objs", "_  \@", $count, "\n";
+	print "\t",$symbolprefix, $uppercase, $symbolsuffix, "=$objs", "_  \@", $count, "\n";
 	$count ++;
     }
 
     foreach $objs (@need_2underscore_objs) {
 	$uppercase = $objs;
 	$uppercase =~ tr/[a-z]/[A-Z]/;
-	print "\t$objs=$objs","__  \@", $count, "\n";
+	print "\t",$symbolprefix, $objs, $symbolsuffix, "=$objs","__  \@", $count, "\n";
 	$count ++;
-	print "\t",$objs, "__=$objs","__  \@", $count, "\n";
+	print "\t",$symbolprefix, $objs, "__", $symbolsuffix, "=$objs","__  \@", $count, "\n";
 	$count ++;
-	print "\t$uppercase=$objs", "__  \@", $count, "\n";
+	print "\t",$symbolprefix, $uppercase, $symbolsuffix, "=$objs", "__  \@", $count, "\n";
 	$count ++;
     }
 
@@ -2859,15 +2905,15 @@ if ($ARGV[0] eq "win2k"){
 
 	$uppercase = $objs;
 	$uppercase =~ tr/[a-z]/[A-Z]/;
-	print "\t",$objs, "_=$objs","_  \@", $count, "\n";
+	print "\t",$symbolprefix, $objs, "_", $symbolsuffix, "=$objs","_  \@", $count, "\n";
 	$count ++;
-	print "\t$uppercase=$objs", "_  \@", $count, "\n";
+	print "\t",$symbolprefix, $uppercase, $symbolsuffix, "=$objs", "_  \@", $count, "\n";
 	$count ++;
     }
 
 
     foreach $objs (@no_underscore_objs) {
-	print "\t",$objs,"=$objs","  \@", $count, "\n";
+	print "\t",$symbolprefix,$objs,$symbolsuffix,"=$objs","  \@", $count, "\n";
 	$count ++;
     }
 
@@ -2880,11 +2926,11 @@ if ($ARGV[0] eq "win2khpl"){
     foreach $objs (@hplobjs) {
 	$uppercase = $objs;
 	$uppercase =~ tr/[a-z]/[A-Z]/;
-   	print "\t$objs=$objs","_  \@", $count, "\n";
+   	print "\t",$symbolprefix, $objs, $symbolsuffix, "=$objs","_  \@", $count, "\n";
 	$count ++;
-   	print "\t",$objs, "_=$objs","_  \@", $count, "\n";
+   	print "\t",$symbolprefix, $objs, "_", $symbolsuffix, "=$objs","_  \@", $count, "\n";
 	$count ++;
-	print "\t$uppercase=$objs", "_  \@", $count, "\n";
+	print "\t",$symbolprefix, $uppercase, $symbolsuffix, "=$objs", "_  \@", $count, "\n";
 	$count ++;
     }
 
@@ -2905,24 +2951,24 @@ if ($ARGV[0] eq "microsoft"){
     foreach $objs (@underscore_objs) {
 	$uppercase = $objs;
 	$uppercase =~ tr/[a-z]/[A-Z]/;
-   	print "\t$objs = $objs","_\n";
+   	print "\t",$symbolprefix, $objs, $symbolsuffix, " = $objs","_\n";
 	$count ++;
-   	print "\t$objs\_ = $objs","_\n";
+   	print "\t",$symbolprefix, $objs, "\_", $symbolsuffix, " = $objs","_\n";
 	$count ++;
-   	print "\t$uppercase = $objs","_\n";
+   	print "\t",$symbolprefix, $uppercase, $symbolsuffix, " = $objs","_\n";
 	$count ++;
-   	print "\t$uppercase\_ = $objs","_\n";
+   	print "\t",$symbolprefix, $uppercase, "\_", $symbolsuffix, " = $objs","_\n";
 	$count ++;
     }
 
     foreach $objs (@need_2underscore_objs) {
 	$uppercase = $objs;
 	$uppercase =~ tr/[a-z]/[A-Z]/;
-	print "\t$objs=$objs","__  \@", $count, "\n";
+	print "\t",$symbolprefix, $objs, $symbolsuffix, "=$objs","__  \@", $count, "\n";
 	$count ++;
-	print "\t",$objs, "__=$objs","__  \@", $count, "\n";
+	print "\t",$symbolprefix, $objs, "__", $symbolsuffix, "=$objs","__  \@", $count, "\n";
 	$count ++;
-	print "\t$uppercase=$objs", "__  \@", $count, "\n";
+	print "\t",$symbolprefix, $uppercase, $symbolsuffix, "=$objs", "__  \@", $count, "\n";
 	$count ++;
     }
 
@@ -2936,16 +2982,16 @@ if ($ARGV[0] eq "linktest"){
 
     print "int main(void){\n";
     foreach $objs (@underscore_objs) {
-	print $objs, $bu, "();\n" if $objs ne "xerbla";
+	print $symbolprefix, $objs, $bu, $symbolsuffix, "();\n" if $objs ne "xerbla";
     }
 
     foreach $objs (@need_2underscore_objs) {
-	print $objs, $bu, $bu, "();\n";
+	print $symbolprefix, $objs, $bu, $bu, $symbolsuffix, "();\n";
     }
 
 #    if ($ARGV[4] == 0) {
 	foreach $objs (@no_underscore_objs) {
-	print $objs, "();\n";
+	print $symbolprefix, $objs, $symbolsuffix, "();\n";
 	}
 #    }
 


### PR DESCRIPTION
for adding a prefix or suffix to all exported symbol names in the shared library
Useful to avoid conflicts with other BLAS libraries, especially when using
64 bit integer interfaces in OpenBLAS

Note that since OSX does not have the objcopy utility, setting these options
to non-empty values on Mac requires the objconv tool, available (GPL license)
from http://www.agner.org/optimize/#objconv
(It is only run as a command-line application to change the symbol names at OpenBLAS-build-time so I don't think the GPL license is a problem, and if the options are not set then objconv is not needed.)

Refer to https://github.com/JuliaLang/julia/pull/8734 and https://github.com/JuliaLang/julia/pull/4923 for background motivation.
