### PR TITLE
c_check: set $hostarch to x86_64 instead of amd64

### DIFF
--- a/c_check
+++ b/c_check
@@ -3,6 +3,7 @@
 # Checking cross compile
 $hostos   = `uname -s | sed -e s/\-.*//`;    chop($hostos);
 $hostarch = `uname -m | sed -e s/i.86/x86/`;chop($hostarch);
+$hostarch = "x86_64" if ($hostarch eq "amd64");
 
 $binary = $ENV{"BINARY"};
 


### PR DESCRIPTION
`uname -m` returns "amd64" on some systems.
