### PR TITLE
Correct ilaver C declaration

### DIFF
--- a/lapack-netlib/lapacke/include/lapacke.h
+++ b/lapack-netlib/lapacke/include/lapacke.h
@@ -10707,9 +10707,9 @@ lapack_int LAPACKE_zsyr_work( int matrix_order, char uplo, lapack_int n,
                                   const lapack_complex_double* x,
                                   lapack_int incx, lapack_complex_double* a,
                                   lapack_int lda );
-void LAPACKE_ilaver( const lapack_int* vers_major,
-                     const lapack_int* vers_minor,
-                     const lapack_int* vers_patch );
+void LAPACKE_ilaver( lapack_int* vers_major,
+                     lapack_int* vers_minor,
+                     lapack_int* vers_patch );
 
 
 #define LAPACK_sgetrf LAPACK_GLOBAL(sgetrf,SGETRF)
@@ -16435,8 +16435,8 @@ void LAPACK_csyr( char* uplo, lapack_int* n, lapack_complex_float* alpha,
 void LAPACK_zsyr( char* uplo, lapack_int* n, lapack_complex_double* alpha,
                       const lapack_complex_double* x, lapack_int* incx,
                       lapack_complex_double* a, lapack_int* lda );
-void LAPACK_ilaver( const lapack_int* vers_major, const lapack_int* vers_minor,
-                     const lapack_int* vers_patch );
+void LAPACK_ilaver( lapack_int* vers_major, lapack_int* vers_minor,
+                     lapack_int* vers_patch );
 
 #ifdef __cplusplus
 }

--- a/lapack-netlib/lapacke/src/lapacke_ilaver.c
+++ b/lapack-netlib/lapacke/src/lapacke_ilaver.c
@@ -26,16 +26,16 @@
   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
   THE POSSIBILITY OF SUCH DAMAGE.
 *****************************************************************************
-* Contents: Native high-level C interface to LAPACK function dgesv
+* Contents: Native high-level C interface to LAPACK function ilaver
 * Author: Intel Corporation
 * Generated November, 2011
 *****************************************************************************/
 
 #include "lapacke_utils.h"
 
-void LAPACKE_ilaver( const lapack_int* vers_major,
-                     const lapack_int* vers_minor,
-                     const lapack_int* vers_patch )
+void LAPACKE_ilaver( lapack_int* vers_major,
+                     lapack_int* vers_minor,
+                     lapack_int* vers_patch )
 {
     /* Call LAPACK function */
     LAPACK_ilaver( vers_major, vers_minor, vers_patch );


### PR DESCRIPTION
The C declaration of `ilaver` is wrong; it declares its arguments constant which it shouldn't.
