### PR TITLE
Add test for drotmg bug fixed by 692b14c

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -121,5 +121,8 @@ In chronological order:
   * [2014-10-10] trmm and sgemm kernels (optimized for APM's X-Gene 1).
                  ARMv8 support.
 
+* Dan Kortschak
+  * [2015-01-07] Added test for drotmg bug #484.
+
 * [Your name or handle] <[email or website]>
   * [Date] [Brief summary of your changes]

--- a/utest/common_utest.h
+++ b/utest/common_utest.h
@@ -59,6 +59,7 @@ void test_zdotu_n_1(void);
 void test_zdotu_offset_1(void);
 
 void test_drotmg(void);
+void test_drotmg_D1eqD2_X1eqX2();
 
 void test_dsdot_n_1(void);
 

--- a/utest/main.c
+++ b/utest/main.c
@@ -57,6 +57,7 @@ CU_TestInfo test_level1[]={
 	{"Testing zdotu with input x & y offset == 1",test_zdotu_offset_1},
 
 	{"Testing drotmg",test_drotmg},
+	{"Testing drotmg with D1 == D2 && X1 == X2",test_drotmg_D1eqD2_X1eqX2},
 
 	{"Testing dsdot with n == 1",test_dsdot_n_1},
 

--- a/utest/test_rotmg.c
+++ b/utest/test_rotmg.c
@@ -65,3 +65,36 @@ void test_drotmg()
 		CU_ASSERT_DOUBLE_EQUAL(te_param[i], tr_param[i], CHECK_EPS);
 	}
 }
+
+void test_drotmg_D1eqD2_X1eqX2()
+{
+	double te_d1, tr_d1;
+	double te_d2, tr_d2;
+	double te_x1, tr_x1;
+	double te_y1, tr_y1;
+	double te_param[5];
+	double tr_param[5];
+	int i=0;
+	te_d1= tr_d1=2.;
+	te_d2= tr_d2=2.;
+	te_x1= tr_x1=8.;
+	te_y1= tr_y1=8.;
+
+	for(i=0; i<5; i++){
+	  te_param[i]=tr_param[i]=0.0;
+	}
+
+	//OpenBLAS
+	BLASFUNC(drotmg)(&te_d1, &te_d2, &te_x1, &te_y1, te_param);
+	//reference
+	BLASFUNC_REF(drotmg)(&tr_d1, &tr_d2, &tr_x1, &tr_y1, tr_param);
+
+	CU_ASSERT_DOUBLE_EQUAL(te_d1, tr_d1, CHECK_EPS);
+	CU_ASSERT_DOUBLE_EQUAL(te_d2, tr_d2, CHECK_EPS);
+	CU_ASSERT_DOUBLE_EQUAL(te_x1, tr_x1, CHECK_EPS);
+	CU_ASSERT_DOUBLE_EQUAL(te_y1, tr_y1, CHECK_EPS);
+
+	for(i=0; i<5; i++){
+		CU_ASSERT_DOUBLE_EQUAL(te_param[i], tr_param[i], CHECK_EPS);
+	}
+}


### PR DESCRIPTION
Test requested in issue xianyi/OpenBLAS#484.

Run tests by applying the following change and then make:

	diff --git a/Makefile.rule b/Makefile.rule
	index bea1fe1..9852ff3 100644
	--- a/Makefile.rule
	+++ b/Makefile.rule
	@@ -140,7 +140,7 @@ NO_AFFINITY = 1

	-# UTEST_CHECK = 1
	+UTEST_CHECK = 1