### PR TITLE
Fix a segfault in gemv when MAX_STACK_ALLOC is set

### DIFF
--- a/interface/gemv.c
+++ b/interface/gemv.c
@@ -209,7 +209,9 @@ void CNAME(enum CBLAS_ORDER order,
   if (incy < 0) y -= (leny - 1) * incy;
 
 #ifdef MAX_STACK_ALLOC
-  int stack_alloc_size = m + n;
+  // make it volatile because some gemv implementation (ex: dgemv_n.S)
+  // do not restore all register
+  volatile int stack_alloc_size = m + n;
   if(stack_alloc_size < 128)
       //dgemv_n.S require a 128 bytes buffer
       stack_alloc_size = 128;

--- a/interface/ger.c
+++ b/interface/ger.c
@@ -172,7 +172,7 @@ void CNAME(enum CBLAS_ORDER order,
   if (incx < 0) x -= (m - 1) * incx;
 
 #ifdef MAX_STACK_ALLOC
-  int stack_alloc_size = m;
+  volatile int stack_alloc_size = m;
   if(stack_alloc_size > MAX_STACK_ALLOC / sizeof(FLOAT))
       stack_alloc_size = 0;
   FLOAT stack_buffer[stack_alloc_size];


### PR DESCRIPTION
* stack_alloc_size is needed after the implementation call but it may be overwritten if it's optimized to a register, because some gemv implementation (ex: dgemv_n.S) do not restore all register (ex: r10).

* do the same in ger.c for the same reasons even if the bug has not been observed.