### PR TITLE
Introduce openblas_get_num_threads and openblas_get_num_procs

### DIFF
--- a/cblas.h
+++ b/cblas.h
@@ -13,6 +13,12 @@ extern "C" {
 void openblas_set_num_threads(int num_threads);
 void goto_set_num_threads(int num_threads);
 
+/*Get the number of threads on runtime.*/
+int openblas_get_num_threads(void);
+
+/*Get the number of physical processors (cores).*/
+int openblas_get_num_procs(void);
+
 /*Get the build configure on runtime.*/
 char* openblas_get_config(void);
 

--- a/cblas_noconst.h
+++ b/cblas_noconst.h
@@ -13,6 +13,12 @@ extern "C" {
 void openblas_set_num_threads(int num_threads);
 void goto_set_num_threads(int num_threads);
 
+/*Get the number of threads on runtime.*/
+int openblas_get_num_threads(void);
+
+/*Get the number of physical processors (cores).*/
+int openblas_get_num_procs(void);
+
 /*Get the build configure on runtime.*/
 char* openblas_get_config(void);
 

--- a/driver/others/Makefile
+++ b/driver/others/Makefile
@@ -1,7 +1,7 @@
 TOPDIR	= ../..
 include ../../Makefile.system
 
-COMMONOBJS	 = memory.$(SUFFIX) xerbla.$(SUFFIX) c_abs.$(SUFFIX) z_abs.$(SUFFIX) openblas_set_num_threads.$(SUFFIX) openblas_get_config.$(SUFFIX) openblas_get_parallel.$(SUFFIX) openblas_error_handle.$(SUFFIX)
+COMMONOBJS	 = memory.$(SUFFIX) xerbla.$(SUFFIX) c_abs.$(SUFFIX) z_abs.$(SUFFIX) openblas_set_num_threads.$(SUFFIX) openblas_get_num_threads.$(SUFFIX) openblas_get_num_procs.$(SUFFIX) openblas_get_config.$(SUFFIX) openblas_get_parallel.$(SUFFIX) openblas_error_handle.$(SUFFIX)
 
 #COMMONOBJS	+= slamch.$(SUFFIX) slamc3.$(SUFFIX) dlamch.$(SUFFIX)  dlamc3.$(SUFFIX)
 
@@ -101,6 +101,12 @@ blas_server.$(SUFFIX) : $(BLAS_SERVER) ../../common.h ../../common_thread.h ../.
 	$(CC) $(CFLAGS) -c $< -o $(@F)
 
 openblas_set_num_threads.$(SUFFIX) : openblas_set_num_threads.c
+	$(CC) $(CFLAGS) -c $< -o $(@F)
+
+openblas_get_num_threads.$(SUFFIX) : openblas_get_num_threads.c
+	$(CC) $(CFLAGS) -c $< -o $(@F)
+
+openblas_get_num_procs.$(SUFFIX) : openblas_get_num_procs.c
 	$(CC) $(CFLAGS) -c $< -o $(@F)
 
 openblas_get_config.$(SUFFIX) : openblas_get_config.c

--- a/driver/others/memory.c
+++ b/driver/others/memory.c
@@ -241,6 +241,10 @@ void set_stack_limit(int limitMB){
 */
 #endif
 
+int openblas_get_num_procs(void) {
+  return get_num_procs();
+}
+
 /*
 OpenBLAS uses the numbers of CPU cores in multithreading.
 It can be set by openblas_set_num_threads(int num_threads);
@@ -322,6 +326,10 @@ int blas_get_cpu_number(void){
   return blas_num_threads;
 }
 #endif
+
+int openblas_get_num_threads(void) {
+  return blas_get_cpu_number();
+}
 
 struct release_t {
   void *address;

--- a/driver/others/openblas_get_num_procs.c
+++ b/driver/others/openblas_get_num_procs.c
@@ -1,0 +1,40 @@
+/*****************************************************************************
+Copyright (c) 2011-2014, The OpenBLAS Project
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   1. Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+   3. Neither the name of the OpenBLAS project nor the names of 
+      its contributors may be used to endorse or promote products 
+      derived from this software without specific prior written 
+      permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+**********************************************************************************/
+
+#include "common.h"
+
+extern int openblas_get_num_procs(void);
+
+int openblas_get_num_procs_(void) {
+  return openblas_get_num_procs();
+}

--- a/driver/others/openblas_get_num_threads.c
+++ b/driver/others/openblas_get_num_threads.c
@@ -1,0 +1,40 @@
+/*****************************************************************************
+Copyright (c) 2011-2014, The OpenBLAS Project
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   1. Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+   3. Neither the name of the OpenBLAS project nor the names of 
+      its contributors may be used to endorse or promote products 
+      derived from this software without specific prior written 
+      permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+**********************************************************************************/
+
+#include "common.h"
+
+extern int openblas_get_num_threads(void);
+
+int openblas_get_num_threads_(void) {
+  return openblas_get_num_threads();
+}

--- a/exports/gensymbol
+++ b/exports/gensymbol
@@ -81,7 +81,10 @@
 
 #both underscore and no underscore
 @misc_common_objs = (
-                     openblas_set_num_threads, openblas_get_parallel,
+                     openblas_get_parallel,
+                     openblas_get_num_procs,
+                     openblas_set_num_threads,
+                     openblas_get_num_threads,
                     );
 
 @misc_no_underscore_objs = (


### PR DESCRIPTION
Export the two routines `openblas_get_num_threads` and `openblas_get_num_procs` to obtain the number of threads that OpenBLAS uses and the number of processors that the hardware offers. These wrap existing routines.

This would be used in https://github.com/JuliaLang/julia/issues/10028.