### PR TITLE
Fix issue #508

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -124,5 +124,8 @@ In chronological order:
 * Dan Kortschak
   * [2015-01-07] Added test for drotmg bug #484.
 
+* Ton van den Heuvel <https://github.com/ton>
+  * [2015-03-18] Fix race condition during shutdown causing a crash in gotoblas_set_affinity().
+
 * [Your name or handle] <[email or website]>
   * [Date] [Brief summary of your changes]

--- a/driver/others/memory.c
+++ b/driver/others/memory.c
@@ -1353,6 +1353,8 @@ void DESTRUCTOR gotoblas_quit(void) {
 
   if (gotoblas_initialized == 0) return;
 
+  blas_shutdown();
+
 #ifdef PROFILE
    moncontrol (0);
 #endif
@@ -1374,8 +1376,6 @@ void DESTRUCTOR gotoblas_quit(void) {
 #ifdef PROFILE
    moncontrol (1);
 #endif
-
-   blas_shutdown();
 }
 
 #if (defined(C_PGI) || (!defined(C_SUN) && defined(F_INTERFACE_SUN))) && (defined(ARCH_X86) || defined(ARCH_X86_64))


### PR DESCRIPTION
Possible fix for a race condition during shutdown causing a crash in `gotoblas_set_affinity()`. Please review.