### PR TITLE
Fix a buffer overflow with MAX_STACK_ALLOC size in dgemv_t

### DIFF
--- a/kernel/x86_64/dgemv_t_4.c
+++ b/kernel/x86_64/dgemv_t_4.c
@@ -293,7 +293,7 @@ int CNAME(BLASLONG m, BLASLONG n, BLASLONG dummy1, FLOAT alpha, FLOAT *a, BLASLO
         if ( n < 1 ) return(0);
 
 	xbuffer = buffer;
-	ytemp   = buffer + NBMAX;
+	ytemp   = buffer + (m < NBMAX ? m : NBMAX);
 	
 	n0 = n / NBMAX;
         n1 = (n % NBMAX)  >> 2 ;


### PR DESCRIPTION
Refs #478, #482, 9798481, fd9fd42