### PR TITLE
gemv: Ensure stack buffer is large enough to handle memory alignment

### DIFF
--- a/interface/gemv.c
+++ b/interface/gemv.c
@@ -38,6 +38,7 @@
 
 #include <stdio.h>
 #include "common.h"
+#include "l1param.h"
 #ifdef FUNCTION_PROFILE
 #include "functable.h"
 #endif
@@ -214,6 +215,9 @@ void CNAME(enum CBLAS_ORDER order,
   volatile int stack_alloc_size = 0;
   //for gemv_n and gemv_t, try to allocate on stack
   stack_alloc_size = m + n;
+#ifdef ALIGNED_ACCESS
+  stack_alloc_size += 3;
+#endif
   if(stack_alloc_size < 128)
     //dgemv_n.S require a 128 bytes buffer
     stack_alloc_size = 128;


### PR DESCRIPTION
I tested this for several days and it run well so I think it can be merged. I wonder if it's correct (would need +7 instead of +3 ?) when using single precision but I was able to find a case where it's not.

Ref #478 