### PR TITLE
Fix detection of ARM architectures in c_check.

### DIFF
--- a/c_check
+++ b/c_check
@@ -4,6 +4,8 @@
 $hostos   = `uname -s | sed -e s/\-.*//`;    chop($hostos);
 $hostarch = `uname -m | sed -e s/i.86/x86/`;chop($hostarch);
 $hostarch = "x86_64" if ($hostarch eq "amd64");
+$hostarch = "arm" if ($hostarch =~ /^arm.*/);
+$hostarch = "arm64" if ($hostarch eq "aarch64");
 
 $binary = $ENV{"BINARY"};
 


### PR DESCRIPTION
This is necessary to avoid the false detection of a cross-compiling environment.