### PR TITLE
Fixed error in common.h for Android compilation introduced by e12cf11

### DIFF
--- a/common.h
+++ b/common.h
@@ -413,8 +413,10 @@ typedef char* env_var_t;
 
 #if !defined(RPCC_DEFINED) && !defined(OS_WINDOWS)
 #ifdef _POSIX_MONOTONIC_CLOCK
-#if defined(__GLIBC_PREREQ) && __GLIBC_PREREQ(2, 17) // don't require -lrt
+#if defined(__GLIBC_PREREQ) // cut the if condition if two lines, otherwise will fail at __GLIBC_PREREQ(2, 17)
+#if __GLIBC_PREREQ(2, 17) // don't require -lrt
 #define USE_MONOTONIC
+#endif
 #elif defined(OS_ANDROID)
 #define USE_MONOTONIC
 #endif


### PR DESCRIPTION
It seems that even with short-circuiting of the && operator, preprocessor fails when using __GLIBC_PREREQ(2, 17) if undefined.

This will happen when trying to compile for Android. Splitting the if condition in two parts solves it.