### PR TITLE
Support Intel Skylake by Haswell kernels.

### DIFF
--- a/cpuid_x86.c
+++ b/cpuid_x86.c
@@ -1150,6 +1150,16 @@ int get_cpuname(void){
 #endif
           else
 	    return CPUTYPE_NEHALEM;
+        case 14:
+	  // Skylake
+          if(support_avx())
+#ifndef NO_AVX2
+            return CPUTYPE_HASWELL;
+#else
+	    return CPUTYPE_SANDYBRIDGE;
+#endif
+          else
+	    return CPUTYPE_NEHALEM;
 	}
 	break;
       }
@@ -1617,6 +1627,16 @@ int get_coretype(void){
         switch (model) {
 	case 6:
 	  //broadwell
+          if(support_avx())
+#ifndef NO_AVX2
+            return CORE_HASWELL;
+#else
+	    return CORE_SANDYBRIDGE;
+#endif
+          else
+	    return CORE_NEHALEM;
+	case 14:
+	  // Skylake
           if(support_avx())
 #ifndef NO_AVX2
             return CORE_HASWELL;

--- a/driver/others/dynamic.c
+++ b/driver/others/dynamic.c
@@ -263,6 +263,15 @@ static gotoblas_t *get_coretype(void){
 	    return &gotoblas_NEHALEM; //OS doesn't support AVX. Use old kernels.
 	  }
 	}
+	//Intel Skylake
+	if (model == 14) {
+	  if(support_avx())
+	    return &gotoblas_HASWELL;
+	  else{
+	    openblas_warning(FALLBACK_VERBOSE, NEHALEM_FALLBACK);
+	    return &gotoblas_NEHALEM; //OS doesn't support AVX. Use old kernels.
+	  }
+	}
 	return NULL;
       }
       case 0xf:


### PR DESCRIPTION
Ref #632 

This makes OpenBLAS compiles and also recognize my computer as Haswell instead of Prescott. I didn't find a complete list of CPUID's for skylake processors and only adding the model/family numbers for 6700K so there's almost certainly missing ones.
