### PR TITLE
Add lacking headers declarations when compiling for Android ARM7. 

### DIFF
--- a/driver/others/blas_server.c
+++ b/driver/others/blas_server.c
@@ -70,7 +70,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 /*********************************************************************/
 
 #include "common.h"
-#if defined(OS_LINUX) || defined(OS_NETBSD) || defined(OS_DARWIN)
+#if defined(OS_LINUX) || defined(OS_NETBSD) || defined(OS_DARWIN) || defined(OS_ANDROID)
 #include <dlfcn.h>
 #include <signal.h>
 #include <sys/resource.h>


### PR DESCRIPTION
Add lacking headers declarations when compiling for Android ARM7.

Solves #673 