### PR TITLE
(Visual Studio) Don't use C99 complex numbers when building C++ code.

### DIFF
--- a/openblas_config_template.h
+++ b/openblas_config_template.h
@@ -60,7 +60,7 @@ typedef int blasint;
    structure as fallback (see Clause 6.2.5.13 of the C99 standard). */
 #if (defined(__STDC_IEC_559_COMPLEX__) || __STDC_VERSION__ >= 199901L || \
      (__GNUC__ >= 3 && !defined(__cplusplus)) || \
-     _MSC_VER >= 1800) // Visual Studio 2013 supports complex
+     (_MSC_VER >= 1800 && !defined(__cplusplus))) // Visual Studio 2013 supports complex
   #define OPENBLAS_COMPLEX_C99
 #ifndef __cplusplus
   #include <complex.h>


### PR DESCRIPTION
Similar to #193, avoid using C99 `complex.h` when compiling C++ in Visual Studio (2013 or later).