### PR TITLE
re enable Fortran optimization flag on windows

### DIFF
--- a/Makefile.system
+++ b/Makefile.system
@@ -986,11 +986,7 @@ COMMON_OPT = -O2
 endif
 
 ifndef FCOMMON_OPT
-ifeq ($(OSNAME), WINNT)
-FCOMMON_OPT = -O0 
-else
 FCOMMON_OPT = -O2 -frecursive
-endif
 endif
 
 


### PR DESCRIPTION
partial revert of https://github.com/xianyi/OpenBLAS/commit/299cdcdc29999d591fcb300630d50b2986bfb6fc
from #696, was not explained why that was needed cc @wernsaar