### PR TITLE
BENCH: Minor fixes in SciPy benchmarks

### DIFF
--- a/benchmark/scripts/SCIPY/dsyrk.py
+++ b/benchmark/scripts/SCIPY/dsyrk.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import os
 import sys

--- a/benchmark/scripts/SCIPY/dsyrk.py
+++ b/benchmark/scripts/SCIPY/dsyrk.py
@@ -16,7 +16,7 @@ def run_dsyrk(N, l):
 
     start = time.time()
     for i in range(0, l):
-        C[...] = blas.dsyrk(1.0, A)
+        blas.dsyrk(1.0, A, c=C, overwrite_c=True)
     end = time.time()
 
     timediff = (end - start)

--- a/benchmark/scripts/SCIPY/dsyrk.py
+++ b/benchmark/scripts/SCIPY/dsyrk.py
@@ -16,7 +16,7 @@ def run_dsyrk(N,l):
 
 	start = time.time()
 	for i in range(0,l):
-		C = blas.dsyrk(1.0,A)
+		C[...] = blas.dsyrk(1.0,A)
 	end = time.time()
 	
 	timediff = (end -start) 

--- a/benchmark/scripts/SCIPY/dsyrk.py
+++ b/benchmark/scripts/SCIPY/dsyrk.py
@@ -14,7 +14,7 @@ def run_dsyrk(N,l):
 	C = zeros((N,N), dtype='float64')
 
 
-	start = time.time();
+	start = time.time()
 	for i in range(0,l):
 		C = blas.dsyrk(1.0,A)
 	end = time.time()
@@ -49,7 +49,7 @@ if __name__ == "__main__":
 	if 'OPENBLAS_LOOPS' in os.environ:
 		p = os.environ['OPENBLAS_LOOPS']
 		if p:
-			LOOPS = int(p);
+			LOOPS = int(p)
 
 	print("From: %d To: %d Step=%d Loops=%d" % (N, NMAX, NINC, LOOPS))
 	print("\tSIZE\t\t\tFlops\t\t\t\t\tTime")

--- a/benchmark/scripts/SCIPY/dsyrk.py
+++ b/benchmark/scripts/SCIPY/dsyrk.py
@@ -4,13 +4,14 @@ import os
 import sys
 import time
 import numpy
+from numpy import zeros
 from numpy.random import randn
 from scipy.linalg import blas
 
 def run_dsyrk(N,l):
 
 	A = randn(N,N).astype('float64')
-	C = randn(N,N).astype('float64')
+	C = zeros((N,N), dtype='float64')
 
 
 	start = time.time();

--- a/benchmark/scripts/SCIPY/dsyrk.py
+++ b/benchmark/scripts/SCIPY/dsyrk.py
@@ -8,52 +8,51 @@ from numpy import zeros
 from numpy.random import randn
 from scipy.linalg import blas
 
-def run_dsyrk(N,l):
 
-	A = randn(N,N).astype('float64')
-	C = zeros((N,N), dtype='float64')
+def run_dsyrk(N, l):
 
+    A = randn(N, N).astype('float64')
+    C = zeros((N, N), dtype='float64')
 
-	start = time.time()
-	for i in range(0,l):
-		C[...] = blas.dsyrk(1.0,A)
-	end = time.time()
-	
-	timediff = (end -start) 
-	mflops = ( N*N*N) *l / timediff
-	mflops *= 1e-6
+    start = time.time()
+    for i in range(0, l):
+        C[...] = blas.dsyrk(1.0, A)
+    end = time.time()
 
-	size = "%dx%d" % (N,N)
-	print("%14s :\t%20f MFlops\t%20f sec" % (size,mflops,timediff))
+    timediff = (end - start)
+    mflops = (N * N * N) * l / timediff
+    mflops *= 1e-6
+
+    size = "%dx%d" % (N, N)
+    print("%14s :\t%20f MFlops\t%20f sec" % (size, mflops, timediff))
 
 
 if __name__ == "__main__":
-	N=128
-	NMAX=2048
-	NINC=128
-	LOOPS=1
+    N = 128
+    NMAX = 2048
+    NINC = 128
+    LOOPS = 1
 
-	z=0
-	for arg in sys.argv:
-		if z == 1:
-			N = int(arg)
-		elif z == 2:
-			NMAX = int(arg)
-		elif z == 3:
-			NINC = int(arg)
-		elif z == 4:
-			LOOPS = int(arg)
+    z = 0
+    for arg in sys.argv:
+        if z == 1:
+            N = int(arg)
+        elif z == 2:
+            NMAX = int(arg)
+        elif z == 3:
+            NINC = int(arg)
+        elif z == 4:
+            LOOPS = int(arg)
 
-		z = z + 1
+        z = z + 1
 
-	if 'OPENBLAS_LOOPS' in os.environ:
-		p = os.environ['OPENBLAS_LOOPS']
-		if p:
-			LOOPS = int(p)
+    if 'OPENBLAS_LOOPS' in os.environ:
+        p = os.environ['OPENBLAS_LOOPS']
+        if p:
+            LOOPS = int(p)
 
-	print("From: %d To: %d Step=%d Loops=%d" % (N, NMAX, NINC, LOOPS))
-	print("\tSIZE\t\t\tFlops\t\t\t\t\tTime")
+    print("From: %d To: %d Step=%d Loops=%d" % (N, NMAX, NINC, LOOPS))
+    print("\tSIZE\t\t\tFlops\t\t\t\t\tTime")
 
-	for i in range (N,NMAX+NINC,NINC):
-		run_dsyrk(i,LOOPS)
-
+    for i in range(N, NMAX + NINC, NINC):
+        run_dsyrk(i, LOOPS)

--- a/benchmark/scripts/SCIPY/dsyrk.py
+++ b/benchmark/scripts/SCIPY/dsyrk.py
@@ -11,8 +11,8 @@ from scipy.linalg import blas
 
 def run_dsyrk(N, l):
 
-    A = randn(N, N).astype('float64')
-    C = zeros((N, N), dtype='float64')
+    A = randn(N, N).astype('float64', order='F')
+    C = zeros((N, N), dtype='float64', order='F')
 
     start = time.time()
     for i in range(0, l):

--- a/benchmark/scripts/SCIPY/ssyrk.py
+++ b/benchmark/scripts/SCIPY/ssyrk.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import os
 import sys

--- a/benchmark/scripts/SCIPY/ssyrk.py
+++ b/benchmark/scripts/SCIPY/ssyrk.py
@@ -14,7 +14,7 @@ def run_ssyrk(N,l):
 	C = zeros((N,N), dtype='float32')
 
 
-	start = time.time();
+	start = time.time()
 	for i in range(0,l):
 		C = blas.ssyrk(1.0,A)
 	end = time.time()
@@ -49,7 +49,7 @@ if __name__ == "__main__":
 	if 'OPENBLAS_LOOPS' in os.environ:
 		p = os.environ['OPENBLAS_LOOPS']
 		if p:
-			LOOPS = int(p);
+			LOOPS = int(p)
 
 	print("From: %d To: %d Step=%d Loops=%d" % (N, NMAX, NINC, LOOPS))
 	print("\tSIZE\t\t\tFlops\t\t\t\t\tTime")

--- a/benchmark/scripts/SCIPY/ssyrk.py
+++ b/benchmark/scripts/SCIPY/ssyrk.py
@@ -16,7 +16,7 @@ def run_ssyrk(N, l):
 
     start = time.time()
     for i in range(0, l):
-        C[...] = blas.ssyrk(1.0, A)
+        blas.ssyrk(1.0, A, c=C, overwrite_c=True)
     end = time.time()
 
     timediff = (end - start)

--- a/benchmark/scripts/SCIPY/ssyrk.py
+++ b/benchmark/scripts/SCIPY/ssyrk.py
@@ -4,13 +4,14 @@ import os
 import sys
 import time
 import numpy
+from numpy import zeros
 from numpy.random import randn
 from scipy.linalg import blas
 
 def run_ssyrk(N,l):
 
 	A = randn(N,N).astype('float32')
-	C = randn(N,N).astype('float32')
+	C = zeros((N,N), dtype='float32')
 
 
 	start = time.time();

--- a/benchmark/scripts/SCIPY/ssyrk.py
+++ b/benchmark/scripts/SCIPY/ssyrk.py
@@ -8,52 +8,51 @@ from numpy import zeros
 from numpy.random import randn
 from scipy.linalg import blas
 
-def run_ssyrk(N,l):
 
-	A = randn(N,N).astype('float32')
-	C = zeros((N,N), dtype='float32')
+def run_ssyrk(N, l):
 
+    A = randn(N, N).astype('float32')
+    C = zeros((N, N), dtype='float32')
 
-	start = time.time()
-	for i in range(0,l):
-		C[...] = blas.ssyrk(1.0,A)
-	end = time.time()
-	
-	timediff = (end -start) 
-	mflops = ( N*N*N) *l / timediff
-	mflops *= 1e-6
+    start = time.time()
+    for i in range(0, l):
+        C[...] = blas.ssyrk(1.0, A)
+    end = time.time()
 
-	size = "%dx%d" % (N,N)
-	print("%14s :\t%20f MFlops\t%20f sec" % (size,mflops,timediff))
+    timediff = (end - start)
+    mflops = (N * N * N) * l / timediff
+    mflops *= 1e-6
+
+    size = "%dx%d" % (N, N)
+    print("%14s :\t%20f MFlops\t%20f sec" % (size, mflops, timediff))
 
 
 if __name__ == "__main__":
-	N=128
-	NMAX=2048
-	NINC=128
-	LOOPS=1
+    N = 128
+    NMAX = 2048
+    NINC = 128
+    LOOPS = 1
 
-	z=0
-	for arg in sys.argv:
-		if z == 1:
-			N = int(arg)
-		elif z == 2:
-			NMAX = int(arg)
-		elif z == 3:
-			NINC = int(arg)
-		elif z == 4:
-			LOOPS = int(arg)
+    z = 0
+    for arg in sys.argv:
+        if z == 1:
+            N = int(arg)
+        elif z == 2:
+            NMAX = int(arg)
+        elif z == 3:
+            NINC = int(arg)
+        elif z == 4:
+            LOOPS = int(arg)
 
-		z = z + 1
+        z = z + 1
 
-	if 'OPENBLAS_LOOPS' in os.environ:
-		p = os.environ['OPENBLAS_LOOPS']
-		if p:
-			LOOPS = int(p)
+    if 'OPENBLAS_LOOPS' in os.environ:
+        p = os.environ['OPENBLAS_LOOPS']
+        if p:
+            LOOPS = int(p)
 
-	print("From: %d To: %d Step=%d Loops=%d" % (N, NMAX, NINC, LOOPS))
-	print("\tSIZE\t\t\tFlops\t\t\t\t\tTime")
+    print("From: %d To: %d Step=%d Loops=%d" % (N, NMAX, NINC, LOOPS))
+    print("\tSIZE\t\t\tFlops\t\t\t\t\tTime")
 
-	for i in range (N,NMAX+NINC,NINC):
-		run_ssyrk(i,LOOPS)
-
+    for i in range(N, NMAX + NINC, NINC):
+        run_ssyrk(i, LOOPS)

--- a/benchmark/scripts/SCIPY/ssyrk.py
+++ b/benchmark/scripts/SCIPY/ssyrk.py
@@ -11,8 +11,8 @@ from scipy.linalg import blas
 
 def run_ssyrk(N, l):
 
-    A = randn(N, N).astype('float32')
-    C = zeros((N, N), dtype='float32')
+    A = randn(N, N).astype('float32', order='F')
+    C = zeros((N, N), dtype='float32', order='F')
 
     start = time.time()
     for i in range(0, l):

--- a/benchmark/scripts/SCIPY/ssyrk.py
+++ b/benchmark/scripts/SCIPY/ssyrk.py
@@ -16,7 +16,7 @@ def run_ssyrk(N,l):
 
 	start = time.time()
 	for i in range(0,l):
-		C = blas.ssyrk(1.0,A)
+		C[...] = blas.ssyrk(1.0,A)
 	end = time.time()
 	
 	timediff = (end -start) 


### PR DESCRIPTION
* Allocate a normal zeroed array instead of a random one.
* Write results into the array.
* Drop unneeded semicolons
* Use environment Python.
* Fix PEP8 issues.
* Use Fortran arrays.