### PR TITLE
Let openblas_get_num_threads return the number of active threads

### DIFF
--- a/driver/others/memory.c
+++ b/driver/others/memory.c
@@ -357,7 +357,9 @@ int openblas_get_num_threads(void) {
 #ifndef SMP
   return 1;
 #else
-  return blas_get_cpu_number();
+  // init blas_cpu_number if needed
+  blas_get_cpu_number();
+  return blas_cpu_number;
 #endif
 }
 


### PR DESCRIPTION
... not the number of allocated threads.

Close #760