### PR TITLE
Fix a minor compiler error in VisualStudio with CMake

### DIFF
--- a/common_x86.h
+++ b/common_x86.h
@@ -62,7 +62,7 @@ static void __inline blas_lock(volatile BLASULONG *address){
 
 #if defined(_MSC_VER) && !defined(__clang__)
 	// use intrinsic instead of inline assembly
-	ret = _InterlockedExchange(address, 1);
+	ret = _InterlockedExchange((volatile LONG *)address, 1);
 	// inline assembly
 	/*__asm {
 		mov eax, address


### PR DESCRIPTION
The first param of [_InterlockedExchange](https://msdn.microsoft.com/en-us/library/1s26w950.aspx) is **_long volatile *_**, however openblas uses **_BLASULONG *_** here, which leads to a compiler error under **VS2013** with CMake generated **Debug** settings.
This is a small fix. Similar type casting has already been present in common_x86_64.h but not here.