### PR TITLE
Fix access violation on Windows while static linking in MSVC

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -147,5 +147,6 @@ In chronological order:
   * [2016-03-14] Additional functional Assembly Kernels for Cortex-A57
   * [2016-03-14] Optimize Dgemm 4x4 for Cortex-A57
 
-* [Your name or handle] <[email or website]>
-  * [Date] [Brief summary of your changes]
+* theoractice <https://github.com/theoractice/>
+  * [2016-03-20] Fix compiler error in VisualStudio with CMake
+  * [2016-03-22] Fix access violation on Windows while static linking

--- a/driver/others/memory.c
+++ b/driver/others/memory.c
@@ -1452,6 +1452,26 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD  ul_reason_for_call, LPVOID lpReser
   }
   return TRUE;
 }
+
+/*
+  This is to allow static linking.
+  Code adapted from Google performance tools:
+  https://gperftools.googlecode.com/git-history/perftools-1.0/src/windows/port.cc
+  Reference:
+  https://sourceware.org/ml/pthreads-win32/2008/msg00028.html
+*/
+static int on_process_term(void)
+{
+	gotoblas_quit();
+	return 0;
+}
+#pragma comment(linker, "/INCLUDE:__tls_used")
+#pragma data_seg(push, old_seg)
+#pragma data_seg(".CRT$XLB")
+static void (APIENTRY *dll_callback)(HINSTANCE h, DWORD ul_reason_for_call, PVOID pv) = DllMain;
+#pragma data_seg(".CRT$XTU")
+static int(*p_process_term)(void) = on_process_term;
+#pragma data_seg(pop, old_seg)
 #endif
 
 #if (defined(C_PGI) || (!defined(C_SUN) && defined(F_INTERFACE_SUN))) && (defined(ARCH_X86) || defined(ARCH_X86_64))

--- a/driver/others/memory.c
+++ b/driver/others/memory.c
@@ -1459,13 +1459,18 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD  ul_reason_for_call, LPVOID lpReser
   https://gperftools.googlecode.com/git-history/perftools-1.0/src/windows/port.cc
   Reference:
   https://sourceware.org/ml/pthreads-win32/2008/msg00028.html
+  http://ci.boost.org/svn-trac/browser/trunk/libs/thread/src/win32/tss_pe.cpp
 */
 static int on_process_term(void)
 {
 	gotoblas_quit();
 	return 0;
 }
+#ifdef _WIN64
+#pragma comment(linker, "/INCLUDE:_tls_used")
+#else
 #pragma comment(linker, "/INCLUDE:__tls_used")
+#endif
 #pragma data_seg(push, old_seg)
 #pragma data_seg(".CRT$XLB")
 static void (APIENTRY *dll_callback)(HINSTANCE h, DWORD ul_reason_for_call, PVOID pv) = DllMain;


### PR DESCRIPTION
Tested to work with VS2013 and CMake. No need to call any initialization code now.
I used the 2nd solution posted [here](https://github.com/xianyi/OpenBLAS/issues/810#issuecomment-199701383). This technique has been used in Boost and Google Performance Tools. I adapted the code from Google Performance Tools for simplicity.