### PR TITLE
Fix z/ctrmv stack allocation on AMD bulldozer and barcelona target

### DIFF
--- a/interface/ztrmv.c
+++ b/interface/ztrmv.c
@@ -243,6 +243,8 @@ void CNAME(enum CBLAS_ORDER order, enum CBLAS_UPLO Uplo,
 #endif
   {
     buffer_size = ((n - 1) / DTB_ENTRIES) * 2 * DTB_ENTRIES + 32 / sizeof(FLOAT);
+    // It seems to be required for some K8 or Barcelona CPU
+    buffer_size += 8;
     if(incx != 1)
       buffer_size += n * 2;
   }


### PR DESCRIPTION
* Hopefully, because this was found by error and trial (dark magic)
* Ref #786