### PR TITLE
Small change to allow compiling with USE_OPENMP on MSVC

### DIFF
--- a/common.h
+++ b/common.h
@@ -626,8 +626,13 @@ void gotoblas_profile_init(void);
 void gotoblas_profile_quit(void);
 
 #ifdef USE_OPENMP
+#ifndef C_MSVC
 int omp_in_parallel(void);
 int omp_get_num_procs(void);
+#else
+__declspec(dllimport) int __cdecl omp_in_parallel(void);
+__declspec(dllimport) int __cdecl omp_get_num_procs(void);
+#endif
 #else
 #ifdef __ELF__
 int omp_in_parallel  (void) __attribute__ ((weak));


### PR DESCRIPTION
In omp.h in Visual Studio, the definitions of omp_in_parallel and omp_get_num_procs are as follows:
```
_OMPIMP int _OMPAPI
omp_get_num_procs(
    void
    );

_OMPIMP int _OMPAPI
omp_in_parallel(
    void
    );
```
Where` _OMPIMP` is defined as` __declspec(dllimport)` and `_OMPAPI` is defined as `__cdecl`

MSVC treats the declaration of omp_in_parallel and omp_get_num_procs in common.h without the modifiers __declspec(dllimport) and __cdecl as a redefinition. The Visual Studio solution generated by CMake compiles successfully with this modification.