### PR TITLE
remove input from clobbered list

### DIFF
--- a/kernel/x86_64/cscal_microk_bulldozer-2.c
+++ b/kernel/x86_64/cscal_microk_bulldozer-2.c
@@ -120,7 +120,7 @@ static void cscal_kernel_16( BLASLONG n, FLOAT *alpha, FLOAT *x)
 	  "r" (n),  	// 0
           "r" (x),      // 1
           "r" (alpha)   // 2
-	: "cc", "%0", "%1",
+	: "cc", //"%0", "%1",
 	  "%xmm0", "%xmm1", "%xmm2", "%xmm3", 
 	  "%xmm4", "%xmm5", "%xmm6", "%xmm7", 
 	  "%xmm8", "%xmm9", "%xmm10", "%xmm11", 
@@ -212,7 +212,7 @@ static void cscal_kernel_16_zero_r( BLASLONG n, FLOAT *alpha, FLOAT *x)
 	  "r" (n),  	// 0
           "r" (x),      // 1
           "r" (alpha)   // 2
-	: "cc", "%0", "%1",
+	: "cc", //"%0", "%1",
 	  "%xmm0", "%xmm1", "%xmm2", "%xmm3", 
 	  "%xmm4", "%xmm5", "%xmm6", "%xmm7", 
 	  "%xmm8", "%xmm9", "%xmm10", "%xmm11", 
@@ -289,7 +289,7 @@ static void cscal_kernel_16_zero_i( BLASLONG n, FLOAT *alpha, FLOAT *x)
 	  "r" (n),  	// 0
           "r" (x),      // 1
           "r" (alpha)   // 2
-	: "cc", "%0", "%1",
+	: "cc", //"%0", "%1",
 	  "%xmm0", "%xmm1", "%xmm2", "%xmm3", 
 	  "%xmm4", "%xmm5", "%xmm6", "%xmm7", 
 	  "%xmm8", "%xmm9", "%xmm10", "%xmm11", 
@@ -334,7 +334,7 @@ static void cscal_kernel_16_zero( BLASLONG n, FLOAT *alpha, FLOAT *x)
 	  "r" (n),  	// 0
           "r" (x),      // 1
           "r" (alpha)   // 2
-	: "cc", "%0", "%1",
+	: "cc", //"%0", "%1",
 	  "%xmm0", "%xmm1", "%xmm2", "%xmm3", 
 	  "%xmm4", "%xmm5", "%xmm6", "%xmm7", 
 	  "%xmm8", "%xmm9", "%xmm10", "%xmm11", 

--- a/kernel/x86_64/cscal_microk_haswell-2.c
+++ b/kernel/x86_64/cscal_microk_haswell-2.c
@@ -120,7 +120,7 @@ static void cscal_kernel_16( BLASLONG n, FLOAT *alpha, FLOAT *x)
 	  "r" (n),  	// 0
           "r" (x),      // 1
           "r" (alpha)   // 2
-	: "cc", "0", "1",
+	: "cc", //"0", "1",
 	  "%xmm0", "%xmm1", "%xmm2", "%xmm3", 
 	  "%xmm4", "%xmm5", "%xmm6", "%xmm7", 
 	  "%xmm8", "%xmm9", "%xmm10", "%xmm11", 
@@ -212,7 +212,7 @@ static void cscal_kernel_16_zero_r( BLASLONG n, FLOAT *alpha, FLOAT *x)
 	  "r" (n),  	// 0
           "r" (x),      // 1
           "r" (alpha)   // 2
-	: "cc", "0", "1",
+	: "cc", // "0", "1",
 	  "%xmm0", "%xmm1", "%xmm2", "%xmm3", 
 	  "%xmm4", "%xmm5", "%xmm6", "%xmm7", 
 	  "%xmm8", "%xmm9", "%xmm10", "%xmm11", 
@@ -289,7 +289,7 @@ static void cscal_kernel_16_zero_i( BLASLONG n, FLOAT *alpha, FLOAT *x)
 	  "r" (n),  	// 0
           "r" (x),      // 1
           "r" (alpha)   // 2
-	: "cc", "%0", "%1",
+	: "cc", //"%0", "%1",
 	  "%xmm0", "%xmm1", "%xmm2", "%xmm3", 
 	  "%xmm4", "%xmm5", "%xmm6", "%xmm7", 
 	  "%xmm8", "%xmm9", "%xmm10", "%xmm11", 
@@ -334,7 +334,7 @@ static void cscal_kernel_16_zero( BLASLONG n, FLOAT *alpha, FLOAT *x)
 	  "r" (n),  	// 0
           "r" (x),      // 1
           "r" (alpha)   // 2
-	: "cc", "0", "1",
+	: "cc", //"0", "1",
 	  "%xmm0", "%xmm1", "%xmm2", "%xmm3", 
 	  "%xmm4", "%xmm5", "%xmm6", "%xmm7", 
 	  "%xmm8", "%xmm9", "%xmm10", "%xmm11", 

--- a/kernel/x86_64/cscal_microk_steamroller-2.c
+++ b/kernel/x86_64/cscal_microk_steamroller-2.c
@@ -121,7 +121,7 @@ static void cscal_kernel_16( BLASLONG n, FLOAT *alpha, FLOAT *x)
 	  "r" (n),  	// 0
           "r" (x),      // 1
           "r" (alpha)   // 2
-	: "cc", "0", "1",
+	: "cc", //"0", "1",
 	  "%xmm0", "%xmm1", "%xmm2", "%xmm3", 
 	  "%xmm4", "%xmm5", "%xmm6", "%xmm7", 
 	  "%xmm8", "%xmm9", "%xmm10", "%xmm11", 
@@ -213,7 +213,7 @@ static void cscal_kernel_16_zero_r( BLASLONG n, FLOAT *alpha, FLOAT *x)
 	  "r" (n),  	// 0
           "r" (x),      // 1
           "r" (alpha)   // 2
-	: "cc", "0", "1",
+	: "cc", //"0", "1",
 	  "%xmm0", "%xmm1", "%xmm2", "%xmm3", 
 	  "%xmm4", "%xmm5", "%xmm6", "%xmm7", 
 	  "%xmm8", "%xmm9", "%xmm10", "%xmm11", 
@@ -290,7 +290,7 @@ static void cscal_kernel_16_zero_i( BLASLONG n, FLOAT *alpha, FLOAT *x)
 	  "r" (n),  	// 0
           "r" (x),      // 1
           "r" (alpha)   // 2
-	: "cc", "%0", "%1",
+	: "cc", //"%0", "%1",
 	  "%xmm0", "%xmm1", "%xmm2", "%xmm3", 
 	  "%xmm4", "%xmm5", "%xmm6", "%xmm7", 
 	  "%xmm8", "%xmm9", "%xmm10", "%xmm11", 
@@ -335,7 +335,7 @@ static void cscal_kernel_16_zero( BLASLONG n, FLOAT *alpha, FLOAT *x)
 	  "r" (n),  	// 0
           "r" (x),      // 1
           "r" (alpha)   // 2
-	: "cc", "0", "1",
+	: "cc", //"0", "1",
 	  "%xmm0", "%xmm1", "%xmm2", "%xmm3", 
 	  "%xmm4", "%xmm5", "%xmm6", "%xmm7", 
 	  "%xmm8", "%xmm9", "%xmm10", "%xmm11", 

--- a/kernel/x86_64/dscal.c
+++ b/kernel/x86_64/dscal.c
@@ -141,7 +141,7 @@ static void dscal_kernel_inc_8(BLASLONG n, FLOAT *alpha, FLOAT *x, BLASLONG inc_
           "r" (alpha),  // 3
           "r" (inc_x),  // 4
           "r" (inc_x3)  // 5
-        : "cc", "%0", "%1", "%2",
+        : "cc", //"%0", "%1", "%2",
           "%xmm0", "%xmm1", "%xmm2", "%xmm3",
           "%xmm4", "%xmm5", "%xmm6", "%xmm7",
           "%xmm8", "%xmm9", "%xmm10", "%xmm11",

--- a/kernel/x86_64/zscal_microk_bulldozer-2.c
+++ b/kernel/x86_64/zscal_microk_bulldozer-2.c
@@ -120,7 +120,7 @@ static void zscal_kernel_8( BLASLONG n, FLOAT *alpha, FLOAT *x)
 	  "r" (n),  	// 0
           "r" (x),      // 1
           "r" (alpha)   // 2
-	: "cc", "%0", "%1",
+	: "cc", //"%0", "%1",
 	  "%xmm0", "%xmm1", "%xmm2", "%xmm3", 
 	  "%xmm4", "%xmm5", "%xmm6", "%xmm7", 
 	  "%xmm8", "%xmm9", "%xmm10", "%xmm11", 
@@ -212,7 +212,7 @@ static void zscal_kernel_8_zero_r( BLASLONG n, FLOAT *alpha, FLOAT *x)
 	  "r" (n),  	// 0
           "r" (x),      // 1
           "r" (alpha)   // 2
-	: "cc", "%0", "%1",
+	: "cc", //"%0", "%1",
 	  "%xmm0", "%xmm1", "%xmm2", "%xmm3", 
 	  "%xmm4", "%xmm5", "%xmm6", "%xmm7", 
 	  "%xmm8", "%xmm9", "%xmm10", "%xmm11", 
@@ -289,7 +289,7 @@ static void zscal_kernel_8_zero_i( BLASLONG n, FLOAT *alpha, FLOAT *x)
 	  "r" (n),  	// 0
           "r" (x),      // 1
           "r" (alpha)   // 2
-	: "cc", "%0", "%1",
+	: "cc", //"%0", "%1",
 	  "%xmm0", "%xmm1", "%xmm2", "%xmm3", 
 	  "%xmm4", "%xmm5", "%xmm6", "%xmm7", 
 	  "%xmm8", "%xmm9", "%xmm10", "%xmm11", 
@@ -334,7 +334,7 @@ static void zscal_kernel_8_zero( BLASLONG n, FLOAT *alpha, FLOAT *x)
 	  "r" (n),  	// 0
           "r" (x),      // 1
           "r" (alpha)   // 2
-	: "cc", "%0", "%1",
+	: "cc", //"%0", "%1",
 	  "%xmm0", "%xmm1", "%xmm2", "%xmm3", 
 	  "%xmm4", "%xmm5", "%xmm6", "%xmm7", 
 	  "%xmm8", "%xmm9", "%xmm10", "%xmm11", 

--- a/kernel/x86_64/zscal_microk_haswell-2.c
+++ b/kernel/x86_64/zscal_microk_haswell-2.c
@@ -120,7 +120,7 @@ static void zscal_kernel_8( BLASLONG n, FLOAT *alpha, FLOAT *x)
 	  "r" (n),  	// 0
           "r" (x),      // 1
           "r" (alpha)   // 2
-	: "cc", "%0", "%1",
+	: "cc", //"%0", "%1",
 	  "%xmm0", "%xmm1", "%xmm2", "%xmm3", 
 	  "%xmm4", "%xmm5", "%xmm6", "%xmm7", 
 	  "%xmm8", "%xmm9", "%xmm10", "%xmm11", 
@@ -212,7 +212,7 @@ static void zscal_kernel_8_zero_r( BLASLONG n, FLOAT *alpha, FLOAT *x)
 	  "r" (n),  	// 0
           "r" (x),      // 1
           "r" (alpha)   // 2
-	: "cc", "%0", "%1",
+	: "cc", //"%0", "%1",
 	  "%xmm0", "%xmm1", "%xmm2", "%xmm3", 
 	  "%xmm4", "%xmm5", "%xmm6", "%xmm7", 
 	  "%xmm8", "%xmm9", "%xmm10", "%xmm11", 
@@ -289,7 +289,7 @@ static void zscal_kernel_8_zero_i( BLASLONG n, FLOAT *alpha, FLOAT *x)
 	  "r" (n),  	// 0
           "r" (x),      // 1
           "r" (alpha)   // 2
-	: "cc", "%0", "%1",
+	: "cc", //"%0", "%1",
 	  "%xmm0", "%xmm1", "%xmm2", "%xmm3", 
 	  "%xmm4", "%xmm5", "%xmm6", "%xmm7", 
 	  "%xmm8", "%xmm9", "%xmm10", "%xmm11", 
@@ -334,7 +334,7 @@ static void zscal_kernel_8_zero( BLASLONG n, FLOAT *alpha, FLOAT *x)
 	  "r" (n),  	// 0
           "r" (x),      // 1
           "r" (alpha)   // 2
-	: "cc", "%0", "%1",
+	: "cc", //"%0", "%1",
 	  "%xmm0", "%xmm1", "%xmm2", "%xmm3", 
 	  "%xmm4", "%xmm5", "%xmm6", "%xmm7", 
 	  "%xmm8", "%xmm9", "%xmm10", "%xmm11", 

--- a/kernel/x86_64/zscal_microk_steamroller-2.c
+++ b/kernel/x86_64/zscal_microk_steamroller-2.c
@@ -121,7 +121,7 @@ static void zscal_kernel_8( BLASLONG n, FLOAT *alpha, FLOAT *x)
 	  "r" (n),  	// 0
           "r" (x),      // 1
           "r" (alpha)   // 2
-	: "cc", "%0", "%1",
+	: "cc", //"%0", "%1",
 	  "%xmm0", "%xmm1", "%xmm2", "%xmm3", 
 	  "%xmm4", "%xmm5", "%xmm6", "%xmm7", 
 	  "%xmm8", "%xmm9", "%xmm10", "%xmm11", 
@@ -213,7 +213,7 @@ static void zscal_kernel_8_zero_r( BLASLONG n, FLOAT *alpha, FLOAT *x)
 	  "r" (n),  	// 0
           "r" (x),      // 1
           "r" (alpha)   // 2
-	: "cc", "%0", "%1",
+	: "cc", //"%0", "%1",
 	  "%xmm0", "%xmm1", "%xmm2", "%xmm3", 
 	  "%xmm4", "%xmm5", "%xmm6", "%xmm7", 
 	  "%xmm8", "%xmm9", "%xmm10", "%xmm11", 
@@ -290,7 +290,7 @@ static void zscal_kernel_8_zero_i( BLASLONG n, FLOAT *alpha, FLOAT *x)
 	  "r" (n),  	// 0
           "r" (x),      // 1
           "r" (alpha)   // 2
-	: "cc", "%0", "%1",
+	: "cc", //"%0", "%1",
 	  "%xmm0", "%xmm1", "%xmm2", "%xmm3", 
 	  "%xmm4", "%xmm5", "%xmm6", "%xmm7", 
 	  "%xmm8", "%xmm9", "%xmm10", "%xmm11", 
@@ -335,7 +335,7 @@ static void zscal_kernel_8_zero( BLASLONG n, FLOAT *alpha, FLOAT *x)
 	  "r" (n),  	// 0
           "r" (x),      // 1
           "r" (alpha)   // 2
-	: "cc", "%0", "%1",
+	: "cc", //"%0", "%1",
 	  "%xmm0", "%xmm1", "%xmm2", "%xmm3", 
 	  "%xmm4", "%xmm5", "%xmm6", "%xmm7", 
 	  "%xmm8", "%xmm9", "%xmm10", "%xmm11", 


### PR DESCRIPTION
Hi,

My ASM is bit rusty, please let me know if i am wrong. ^_^ 

Code below would not work for ICC, it would work for GCC or PGI. I assume both compiler do not do much of checking on ASM code.

```
__asm__ __volatile__
(  mov
   :
   : "r" (XXX), ....
   : "cc", "%0", "%1", "%2",
```

In GCC manual, I see following explanation:

> You may not write a clobber description in a way that overlaps with an input or output operand. For example, you may not have an operand describing a register class with one member if you mention that register in the clobber list. Variables declared to live in specific registers (see Explicit Reg Vars), and used as asm input or output operands must have no part mentioned in the clobber description. There is no way for you to specify that an input operand is modified without also specifying it as an output operand. Note that if all the output operands you specify are for this purpose (and hence unused), you then also need to specify volatile for the asm construct, as described below, to prevent GCC from deleting the asm statement as unused.

As far as i understand, in this case since we have `__asm__ __volatile__`. This code will not be removed as long as it is reachable. Since memory is in the clobber registers, the code would not be optimized away. So remove `"%0", "%1", "%2",` should not cause any issue, and it would allow ICC to build OpenBlas. Please correct me if i am mistaken.

Build with flags:

```
DYNAMIC_ARCH=1 USE_THREAD=1 USE_OPENMP=0 NUM_THREADS=128 NO_LAPACK=1 INTERFACE64=1 BINARY=64
```

```
$ icc -V
Intel(R) C Intel(R) 64 Compiler for applications running on Intel(R) 64, Version 16.0.3.210 Build 20160415
Copyright (C) 1985-2016 Intel Corporation.  All rights reserved.
```

Error messages:

```
catastrophic error: unknown register name %2 in asm statement
```

Possible related to issue #718 

Best,
Min Dong
