### PR TITLE
change old GNU keyword __real__ __imag__ to CREAL, CIMAG macro

### DIFF
--- a/kernel/x86_64/cdot.c
+++ b/kernel/x86_64/cdot.c
@@ -100,8 +100,8 @@ FLOAT _Complex CNAME(BLASLONG n, FLOAT *x, BLASLONG inc_x, FLOAT *y, BLASLONG in
 
 	if ( n <= 0 ) 
 	{
-	        __real__ result = 0.0 ;
-        	__imag__ result = 0.0 ;
+	        CREAL(result) = 0.0 ;
+        	CIMAG(result) = 0.0 ;
 		return(result);
 
 	}
@@ -161,11 +161,11 @@ FLOAT _Complex CNAME(BLASLONG n, FLOAT *x, BLASLONG inc_x, FLOAT *y, BLASLONG in
 	}
 
 #if !defined(CONJ)
-	__real__ result = dot[0] - dot[1];
-	__imag__ result = dot[4] + dot[5];
+	CREAL(result) = dot[0] - dot[1];
+	CIMAG(result) = dot[4] + dot[5];
 #else
-	__real__ result = dot[0] + dot[1];
-	__imag__ result = dot[4] - dot[5];
+	CREAL(result) = dot[0] + dot[1];
+	CIMAG(result) = dot[4] - dot[5];
 
 #endif
 

--- a/kernel/x86_64/zdot.c
+++ b/kernel/x86_64/zdot.c
@@ -96,8 +96,8 @@ FLOAT _Complex CNAME(BLASLONG n, FLOAT *x, BLASLONG inc_x, FLOAT *y, BLASLONG in
 
 	if ( n <= 0 ) 
 	{
-	        __real__ result = 0.0 ;
-        	__imag__ result = 0.0 ;
+	        CREAL(result) = 0.0 ;
+        	CIMAG(result) = 0.0 ;
 		return(result);
 
 	}
@@ -151,11 +151,11 @@ FLOAT _Complex CNAME(BLASLONG n, FLOAT *x, BLASLONG inc_x, FLOAT *y, BLASLONG in
 	}
 
 #if !defined(CONJ)
-	__real__ result = dot[0] - dot[1];
-	__imag__ result = dot[2] + dot[3];
+	CREAL(result) = dot[0] - dot[1];
+	CIMAG(result) = dot[2] + dot[3];
 #else
-	__real__ result = dot[0] + dot[1];
-	__imag__ result = dot[2] - dot[3];
+	CREAL(result) = dot[0] + dot[1];
+	CIMAG(result) = dot[2] - dot[3];
 
 #endif
 


### PR DESCRIPTION
Hi,

Most file use the macro defined in `common.h`, but i guess `cdot.c` and `zdot.c` missed the memo ^_^ .

Best,
Min Dong
