### PR TITLE
Update zgetrf2.f, cpuid_x86.c, dynamic.c

### DIFF
--- a/cpuid_x86.c
+++ b/cpuid_x86.c
@@ -1172,6 +1172,8 @@ int get_cpuname(void){
 #endif
           else
 	    return CPUTYPE_NEHALEM;
+	case 12:
+	  // Braswell
 	case 13:
 	  // Avoton
 	    return CPUTYPE_NEHALEM;

--- a/cpuid_x86.c
+++ b/cpuid_x86.c
@@ -1678,6 +1678,8 @@ int get_coretype(void){
 #endif
           else
 	    return CORE_NEHALEM;
+	case 12:
+	  // Braswell
 	case 13:
 	  // Avoton
 	    return CORE_NEHALEM;

--- a/driver/others/dynamic.c
+++ b/driver/others/dynamic.c
@@ -261,8 +261,8 @@ static gotoblas_t *get_coretype(void){
 	    return &gotoblas_NEHALEM; //OS doesn't support AVX. Use old kernels.
 	  }
 	}
-	//Intel Avoton
-	if (model == 13) { 
+	//Intel Braswell / Avoton
+	if (model == 12 || model == 13) { 
 	  openblas_warning(FALLBACK_VERBOSE, NEHALEM_FALLBACK); 
 	  return &gotoblas_NEHALEM;
 	}	

--- a/lapack-netlib/SRC/zgetrf2.f
+++ b/lapack-netlib/SRC/zgetrf2.f
@@ -144,7 +144,7 @@
       EXTERNAL           DLAMCH, IZAMAX
 *     ..
 *     .. External Subroutines ..
-      EXTERNAL           ZGEMM, ZSCAL, ZLASWP, ZTRSM, ZERBLA
+      EXTERNAL           ZGEMM, ZSCAL, ZLASWP, ZTRSM, XERBLA
 *     ..
 *     .. Intrinsic Functions ..
       INTRINSIC          MAX, MIN


### PR DESCRIPTION
1. Trivial typo correction (ZERBLA => XERBLA) to fix #910 (in line with lapack svn, bug and fix were apparently discussed in lapack "User Discussion" list as topic 4891 on Jan 24 but never under Bug reports)
2. Update dynamic.c and cpuid_x86.c for  Intel Braswell (ref #548)