### PR TITLE
common_arm.h, common_mips.h: get rid of .func directives

### DIFF
--- a/common_arm.h
+++ b/common_arm.h
@@ -105,7 +105,6 @@ static inline int blas_quickdivide(blasint x, blasint y){
 #define PROLOGUE \
 	.arm		 ;\
 	.global	REALNAME ;\
-	.func	REALNAME  ;\
 REALNAME:
 
 #define EPILOGUE

--- a/common_mips.h
+++ b/common_mips.h
@@ -80,7 +80,6 @@ static inline int blas_quickdivide(blasint x, blasint y){
 #define PROLOGUE \
 	.arm		 ;\
 	.global	REALNAME ;\
-	.func	REALNAME  ;\
 REALNAME:
 
 #define EPILOGUE


### PR DESCRIPTION
.func/.endfunc are gcc/gas-specific directives for generating stabs
debug information (and nothing more). This is near-useless now because
DWARF is commonly used, and moreover, this is not implemented in Clang.
Hence building OpenBLAS with Clang/ARM fails, and there is no sane way
to detect GCC vs. anything else using preprocessor.

Hence, just remove these directives.