### PR TITLE
Updated CROSS_SUFFIX regex to work with CC containing arguments

### DIFF
--- a/c_check
+++ b/c_check
@@ -34,7 +34,7 @@ if (dirname($compiler_name) ne ".") {
     $cross_suffix .= dirname($compiler_name) . "/";
 }
 
-if (basename($compiler_name) =~ /(.*-)(.*)/) {
+if (basename($compiler_name) =~ /([^\s]*-)(.*)/) {
     $cross_suffix .= $1;
 }
 


### PR DESCRIPTION
Fixes issues raised in #858 by @tkelman when CC contains arguments, i.e. `CC="x86_64-w64-mingw32-gcc -march=x86-64 -m64"`.