### PR TITLE
make utest/Makefile respect LDFLAGS

### DIFF
--- a/utest/Makefile
+++ b/utest/Makefile
@@ -18,7 +18,7 @@ endif
 all : run_test
 
 $(UTESTBIN): $(OBJS)
-	$(CC) $(CFLAGS) -o $@ $^ ../$(LIBNAME) $(EXTRALIB) $(FEXTRALIB)
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^ ../$(LIBNAME) $(EXTRALIB) $(FEXTRALIB)
 
 run_test: $(UTESTBIN)
 ifndef CROSS


### PR DESCRIPTION
Currently utest/Makefile is the only place that doesn't respect `LDFLAGS`. This causes when compiling with a compiler that is not in a standard location and runpath are specified through `LDFLAGS` for example. See https://trac.sagemath.org/ticket/21689 for such a case with `libgfortan`.