### PR TITLE
Add TARGETs for newer Intel CPUs - Kaby Lake, Knights Landing, Apollo Lake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,9 +31,10 @@ set(NO_LAPACKE 1)
 endif()
 
 if(BUILD_DEBUG)
-set(CMAKE_BUILD_TYPE Debug)
+	set(CMAKE_BUILD_TYPE Debug)
+	set(OpenBLAS_LIBNAME "${OpenBLAS_LIBNAME}_d")
 else()
-set(CMAKE_BUILD_TYPE Release)
+	set(CMAKE_BUILD_TYPE Release)
 endif()
 
 if(BUILD_WITHOUT_CBLAS)
@@ -143,6 +144,7 @@ include("${PROJECT_SOURCE_DIR}/cmake/export.cmake")
 set_target_properties( ${OpenBLAS_LIBNAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib)
 foreach (OUTPUTCONFIG ${CMAKE_CONFIGURATION_TYPES})
   string( TOUPPER ${OUTPUTCONFIG} OUTPUTCONFIG )
+  
   set_target_properties( ${OpenBLAS_LIBNAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY_${OUTPUTCONFIG} ${PROJECT_BINARY_DIR}/lib)
   set_target_properties( ${OpenBLAS_LIBNAME} PROPERTIES LIBRARY_OUTPUT_DIRECTORY_${OUTPUTCONFIG} ${PROJECT_BINARY_DIR}/lib)
   set_target_properties( ${OpenBLAS_LIBNAME} PROPERTIES ARCHIVE_OUTPUT_DIRECTORY_${OUTPUTCONFIG} ${PROJECT_BINARY_DIR}/lib)
@@ -152,14 +154,19 @@ enable_testing()
 add_subdirectory(utest)
 
 if(NOT MSVC)
-#only build shared library for MSVC
-add_library(${OpenBLAS_LIBNAME}_static STATIC ${LA_SOURCES} ${LAPACKE_SOURCES} ${TARGET_OBJS})
-set_target_properties(${OpenBLAS_LIBNAME}_static PROPERTIES OUTPUT_NAME ${OpenBLAS_LIBNAME})
-set_target_properties(${OpenBLAS_LIBNAME}_static PROPERTIES CLEAN_DIRECT_OUTPUT 1)
+	#only build shared library for MSVC
+	set(DEBUG_POSTFIX "")
+	if(BUILD_DEBUG)
+		set(DEBUG_POSTFIX "_d")
+	endif()
 
-if(SMP)
-target_link_libraries(${OpenBLAS_LIBNAME} pthread)
-target_link_libraries(${OpenBLAS_LIBNAME}_static pthread)
+	add_library(${OpenBLAS_LIBNAME}_static${DEBUG_POSTFIX} STATIC ${LA_SOURCES} ${LAPACKE_SOURCES} ${TARGET_OBJS})
+	set_target_properties(${OpenBLAS_LIBNAME}_static${DEBUG_POSTFIX} PROPERTIES OUTPUT_NAME ${OpenBLAS_LIBNAME})
+	set_target_properties(${OpenBLAS_LIBNAME}_static${DEBUG_POSTFIX} PROPERTIES CLEAN_DIRECT_OUTPUT 1)
+
+	if(SMP)
+	target_link_libraries(${OpenBLAS_LIBNAME} pthread)
+	target_link_libraries(${OpenBLAS_LIBNAME}_static${DEBUG_POSTFIX} pthread)
 endif()
 
 #build test and ctest
@@ -198,3 +205,22 @@ set_target_properties(${OpenBLAS_LIBNAME} PROPERTIES
 #endif
 #	@touch lib.grd
 
+# Install project
+
+# Install libraries
+install(TARGETS ${OpenBLAS_LIBNAME}
+	RUNTIME DESTINATION bin
+	ARCHIVE DESTINATION lib
+	LIBRARY DESTINATION lib )
+
+# Install include files
+FILE(GLOB_RECURSE INCLUDE_FILES "${CMAKE_CURRENT_SOURCE_DIR}/*.h")
+install (FILES ${INCLUDE_FILES} DESTINATION include)
+ 
+if(NOT MSVC)
+	set(DEBUG_POSTFIX "")
+	if(BUILD_DEBUG)
+		set(DEBUG_POSTFIX "_d")
+	endif()
+	install (TARGETS ${OpenBLAS_LIBNAME}_static${DEBUG_POSTFIX} DESTINATION lib)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,15 +30,23 @@ set(NO_LAPACK 1)
 set(NO_LAPACKE 1)
 endif()
 
-if( NOT CMAKE_BUILD_TYPE )
-	if(BUILD_DEBUG)
-		set(CMAKE_BUILD_TYPE Debug)
-	else()
-		set(CMAKE_BUILD_TYPE Release)
+if(CMAKE_CONFIGURATION_TYPES) # multiconfig generator?
+        set(CMAKE_CONFIGURATION_TYPES "Debug;Release" CACHE STRING "" FORCE)
+	set(OpenBLAS_LIBNAME
+    		$<$<CONFIG:Debug>:"${OpenBLAS_LIBNAME}_d">
+    		$<$<CONFIG:Release>:"${OpenBLAS_LIBNAME}"> 
+    	)
+else()
+	if( NOT CMAKE_BUILD_TYPE )
+		if(BUILD_DEBUG)
+			set(CMAKE_BUILD_TYPE Debug)
+		else()
+			set(CMAKE_BUILD_TYPE Release)
+		endif()
 	endif()
 endif()
 
-if (CMAKE_BUILD_TYPE = Debug)
+if (CMAKE_BUILD_TYPE STREQUAL Debug)
 	set(OpenBLAS_LIBNAME "${OpenBLAS_LIBNAME}_d")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,10 @@ endif()
 
 if(CMAKE_CONFIGURATION_TYPES) # multiconfig generator?
         set(CMAKE_CONFIGURATION_TYPES "Debug;Release" CACHE STRING "" FORCE)
+        set(CMAKE_BUILD_TYPE
+	        Debug Debug
+		Release Release
+	)
 	set(OpenBLAS_LIBNAME
     		Debug "${OpenBLAS_LIBNAME}_d"
     		Release "${OpenBLAS_LIBNAME}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,8 +33,8 @@ endif()
 if(CMAKE_CONFIGURATION_TYPES) # multiconfig generator?
         set(CMAKE_CONFIGURATION_TYPES "Debug;Release" CACHE STRING "" FORCE)
 	set(OpenBLAS_LIBNAME
-    		$<$<CONFIG:Debug>:"${OpenBLAS_LIBNAME}_d">
-    		$<$<CONFIG:Release>:"${OpenBLAS_LIBNAME}"> 
+    		Debug "${OpenBLAS_LIBNAME}_d"
+    		Release "${OpenBLAS_LIBNAME}"
     	)
 else()
 	if( NOT CMAKE_BUILD_TYPE )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ else()
 	endif()
 endif()
 
-set_target_properties (${OpenBLAS_LIBNAME} PROPERTIES OUTPUT_NAME_DEBUG "${OpenBLAS_LIBNAME}_d")
+set_target_properties (OpenBLAS PROPERTIES OUTPUT_NAME_DEBUG "${OpenBLAS_LIBNAME}_d")
 
 if(BUILD_WITHOUT_CBLAS)
 set(NO_CBLAS 1)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,10 +36,6 @@ if(CMAKE_CONFIGURATION_TYPES) # multiconfig generator?
 	        Debug Debug
 		Release Release
 	)
-#	set(OpenBLAS_LIBNAME
-#   		Debug "${OpenBLAS_LIBNAME}_d"
-#    		Release "${OpenBLAS_LIBNAME}"
-#    	)
 else()
 	if( NOT CMAKE_BUILD_TYPE )
 		if(BUILD_DEBUG)
@@ -50,10 +46,7 @@ else()
 	endif()
 endif()
 
-if (CMAKE_BUILD_TYPE STREQUAL Debug)
-	set(OpenBLAS_LIBNAME "${OpenBLAS_LIBNAME}_d")
-endif()
-
+set_target_properties (${OpenBLAS_LIBNAME} PROPERTIES OUTPUT_NAME_DEBUG "${OpenBLAS_LIBNAME}_d")
 
 if(BUILD_WITHOUT_CBLAS)
 set(NO_CBLAS 1)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,10 +36,10 @@ if(CMAKE_CONFIGURATION_TYPES) # multiconfig generator?
 	        Debug Debug
 		Release Release
 	)
-	set(OpenBLAS_LIBNAME
-    		Debug "${OpenBLAS_LIBNAME}_d"
-    		Release "${OpenBLAS_LIBNAME}"
-    	)
+#	set(OpenBLAS_LIBNAME
+#   		Debug "${OpenBLAS_LIBNAME}_d"
+#    		Release "${OpenBLAS_LIBNAME}"
+#    	)
 else()
 	if( NOT CMAKE_BUILD_TYPE )
 		if(BUILD_DEBUG)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,20 +30,10 @@ set(NO_LAPACK 1)
 set(NO_LAPACKE 1)
 endif()
 
-if(CMAKE_CONFIGURATION_TYPES) # multiconfig generator?
-        set(CMAKE_CONFIGURATION_TYPES "Debug;Release" CACHE STRING "" FORCE)
-        set(CMAKE_BUILD_TYPE
-	        Debug Debug
-		Release Release
-	)
+if(BUILD_DEBUG)
+set(CMAKE_BUILD_TYPE Debug)
 else()
-	if( NOT CMAKE_BUILD_TYPE )
-		if(BUILD_DEBUG)
-			set(CMAKE_BUILD_TYPE Debug)
-		else()
-			set(CMAKE_BUILD_TYPE Release)
-		endif()
-	endif()
+set(CMAKE_BUILD_TYPE Release)
 endif()
 
 if(BUILD_WITHOUT_CBLAS)
@@ -151,11 +141,8 @@ include("${PROJECT_SOURCE_DIR}/cmake/export.cmake")
 
 # Set output for libopenblas
 set_target_properties( ${OpenBLAS_LIBNAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib)
-set_target_properties( ${OpenBLAS_LIBNAME} PROPERTIES LIBRARY_OUTPUT_NAME_DEBUG "${OpenBLAS_LIBNAME}_d")
-
 foreach (OUTPUTCONFIG ${CMAKE_CONFIGURATION_TYPES})
   string( TOUPPER ${OUTPUTCONFIG} OUTPUTCONFIG )
-  
   set_target_properties( ${OpenBLAS_LIBNAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY_${OUTPUTCONFIG} ${PROJECT_BINARY_DIR}/lib)
   set_target_properties( ${OpenBLAS_LIBNAME} PROPERTIES LIBRARY_OUTPUT_DIRECTORY_${OUTPUTCONFIG} ${PROJECT_BINARY_DIR}/lib)
   set_target_properties( ${OpenBLAS_LIBNAME} PROPERTIES ARCHIVE_OUTPUT_DIRECTORY_${OUTPUTCONFIG} ${PROJECT_BINARY_DIR}/lib)
@@ -165,15 +152,14 @@ enable_testing()
 add_subdirectory(utest)
 
 if(NOT MSVC)
-	#only build shared library for MSVC
+#only build shared library for MSVC
+add_library(${OpenBLAS_LIBNAME}_static STATIC ${LA_SOURCES} ${LAPACKE_SOURCES} ${TARGET_OBJS})
+set_target_properties(${OpenBLAS_LIBNAME}_static PROPERTIES OUTPUT_NAME ${OpenBLAS_LIBNAME})
+set_target_properties(${OpenBLAS_LIBNAME}_static PROPERTIES CLEAN_DIRECT_OUTPUT 1)
 
-	add_library(${OpenBLAS_LIBNAME}_static STATIC ${LA_SOURCES} ${LAPACKE_SOURCES} ${TARGET_OBJS})
-	set_target_properties(${OpenBLAS_LIBNAME}_static PROPERTIES OUTPUT_NAME ${OpenBLAS_LIBNAME})
-	set_target_properties(${OpenBLAS_LIBNAME}_static PROPERTIES CLEAN_DIRECT_OUTPUT 1)
-
-	if(SMP)
-	target_link_libraries(${OpenBLAS_LIBNAME} pthread)
-	target_link_libraries(${OpenBLAS_LIBNAME}_static pthread)
+if(SMP)
+target_link_libraries(${OpenBLAS_LIBNAME} pthread)
+target_link_libraries(${OpenBLAS_LIBNAME}_static pthread)
 endif()
 
 #build test and ctest
@@ -212,18 +198,3 @@ set_target_properties(${OpenBLAS_LIBNAME} PROPERTIES
 #endif
 #	@touch lib.grd
 
-# Install project
-
-# Install libraries
-install(TARGETS ${OpenBLAS_LIBNAME}
-	RUNTIME DESTINATION bin
-	ARCHIVE DESTINATION lib
-	LIBRARY DESTINATION lib )
-
-# Install include files
-FILE(GLOB_RECURSE INCLUDE_FILES "${CMAKE_CURRENT_SOURCE_DIR}/*.h")
-install (FILES ${INCLUDE_FILES} DESTINATION include)
- 
-if(NOT MSVC)
-	install (TARGETS ${OpenBLAS_LIBNAME}_static DESTINATION lib)
-endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,12 +30,18 @@ set(NO_LAPACK 1)
 set(NO_LAPACKE 1)
 endif()
 
-if(BUILD_DEBUG)
-	set(CMAKE_BUILD_TYPE Debug)
-	set(OpenBLAS_LIBNAME "${OpenBLAS_LIBNAME}_d")
-else()
-	set(CMAKE_BUILD_TYPE Release)
+if( NOT CMAKE_BUILD_TYPE )
+	if(BUILD_DEBUG)
+		set(CMAKE_BUILD_TYPE Debug)
+	else()
+		set(CMAKE_BUILD_TYPE Release)
+	endif()
 endif()
+
+if (CMAKE_BUILD_TYPE = Debug)
+	set(OpenBLAS_LIBNAME "${OpenBLAS_LIBNAME}_d")
+endif()
+
 
 if(BUILD_WITHOUT_CBLAS)
 set(NO_CBLAS 1)
@@ -155,18 +161,14 @@ add_subdirectory(utest)
 
 if(NOT MSVC)
 	#only build shared library for MSVC
-	set(DEBUG_POSTFIX "")
-	if(BUILD_DEBUG)
-		set(DEBUG_POSTFIX "_d")
-	endif()
 
-	add_library(${OpenBLAS_LIBNAME}_static${DEBUG_POSTFIX} STATIC ${LA_SOURCES} ${LAPACKE_SOURCES} ${TARGET_OBJS})
-	set_target_properties(${OpenBLAS_LIBNAME}_static${DEBUG_POSTFIX} PROPERTIES OUTPUT_NAME ${OpenBLAS_LIBNAME})
-	set_target_properties(${OpenBLAS_LIBNAME}_static${DEBUG_POSTFIX} PROPERTIES CLEAN_DIRECT_OUTPUT 1)
+	add_library(${OpenBLAS_LIBNAME}_static STATIC ${LA_SOURCES} ${LAPACKE_SOURCES} ${TARGET_OBJS})
+	set_target_properties(${OpenBLAS_LIBNAME}_static PROPERTIES OUTPUT_NAME ${OpenBLAS_LIBNAME})
+	set_target_properties(${OpenBLAS_LIBNAME}_static PROPERTIES CLEAN_DIRECT_OUTPUT 1)
 
 	if(SMP)
 	target_link_libraries(${OpenBLAS_LIBNAME} pthread)
-	target_link_libraries(${OpenBLAS_LIBNAME}_static${DEBUG_POSTFIX} pthread)
+	target_link_libraries(${OpenBLAS_LIBNAME}_static pthread)
 endif()
 
 #build test and ctest
@@ -218,9 +220,5 @@ FILE(GLOB_RECURSE INCLUDE_FILES "${CMAKE_CURRENT_SOURCE_DIR}/*.h")
 install (FILES ${INCLUDE_FILES} DESTINATION include)
  
 if(NOT MSVC)
-	set(DEBUG_POSTFIX "")
-	if(BUILD_DEBUG)
-		set(DEBUG_POSTFIX "_d")
-	endif()
-	install (TARGETS ${OpenBLAS_LIBNAME}_static${DEBUG_POSTFIX} DESTINATION lib)
+	install (TARGETS ${OpenBLAS_LIBNAME}_static DESTINATION lib)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,8 +46,6 @@ else()
 	endif()
 endif()
 
-set_target_properties (OpenBLAS PROPERTIES OUTPUT_NAME_DEBUG "${OpenBLAS_LIBNAME}_d")
-
 if(BUILD_WITHOUT_CBLAS)
 set(NO_CBLAS 1)
 endif()
@@ -153,6 +151,8 @@ include("${PROJECT_SOURCE_DIR}/cmake/export.cmake")
 
 # Set output for libopenblas
 set_target_properties( ${OpenBLAS_LIBNAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib)
+set_target_properties( ${OpenBLAS_LIBNAME} PROPERTIES LIBRARY_OUTPUT_NAME_DEBUG "${OpenBLAS_LIBNAME}_d")
+
 foreach (OUTPUTCONFIG ${CMAKE_CONFIGURATION_TYPES})
   string( TOUPPER ${OUTPUTCONFIG} OUTPUTCONFIG )
   

--- a/cpuid_x86.c
+++ b/cpuid_x86.c
@@ -1205,8 +1205,34 @@ int get_cpuname(void){
 #endif
           else
 	    return CPUTYPE_NEHALEM;
+	case 7:
+	    // Xeon Phi Knights Landing
+          if(support_avx())
+#ifndef NO_AVX2
+            return CPUTYPE_HASWELL;
+#else
+	    return CPUTYPE_SANDYBRIDGE;
+#endif
+          else
+	    return CPUTYPE_NEHALEM;
+	case 12:
+	    // Apollo Lake
+	    return CPUTYPE_NEHALEM;
 	}
 	break;
+      case 8: 
+        switch (model) {
+	case 14: // Kaby Lake
+          if(support_avx())
+#ifndef NO_AVX2
+            return CPUTYPE_HASWELL;
+#else
+	    return CPUTYPE_SANDYBRIDGE;
+#endif
+          else
+	    return CPUTYPE_NEHALEM;
+	}
+	break;    
       }
       break;
     case 0x7:
@@ -1713,8 +1739,24 @@ int get_coretype(void){
 #endif
           else
 	    return CORE_NEHALEM;
-	}
+	case 7:
+	  // Phi Knights Landing
+          if(support_avx())
+#ifndef NO_AVX2
+            return CORE_HASWELL;
+#else
+	    return CORE_SANDYBRIDGE;
+#endif
+          else
+	    return CORE_NEHALEM;
+	case 12:
+	  // Apollo Lake
+	    return CORE_NEHALEM;
+        }
 	break;
+      case 8:
+        if (model == 14) // Kaby Lake 
+          return CORE_HASWELL;
       }
       break;
 

--- a/driver/others/dynamic.c
+++ b/driver/others/dynamic.c
@@ -264,7 +264,6 @@ static gotoblas_t *get_coretype(void){
 	}
 	//Intel Braswell / Avoton
 	if (model == 12 || model == 13) { 
-	  openblas_warning(FALLBACK_VERBOSE, NEHALEM_FALLBACK); 
 	  return &gotoblas_NEHALEM;
 	}	
 	return NULL;
@@ -280,6 +279,29 @@ static gotoblas_t *get_coretype(void){
 	}
 	//Intel Skylake
 	if (model == 14 || model == 5) {
+	  if(support_avx())
+	    return &gotoblas_HASWELL;
+	  else{
+	    openblas_warning(FALLBACK_VERBOSE, NEHALEM_FALLBACK);
+	    return &gotoblas_NEHALEM; //OS doesn't support AVX. Use old kernels.
+	  }
+	}
+	//Intel Phi Knights Landing
+	if (model == 7) {
+	  if(support_avx())
+	    return &gotoblas_HASWELL;
+	  else{
+	    openblas_warning(FALLBACK_VERBOSE, NEHALEM_FALLBACK);
+	    return &gotoblas_NEHALEM; //OS doesn't support AVX. Use old kernels.
+	  }
+	}
+	//Apollo Lake
+	if (model == 14) { 
+	  return &gotoblas_NEHALEM;
+	}	
+	return NULL;
+      case 8:
+	if (model == 14 ) { // Kaby Lake
 	  if(support_avx())
 	    return &gotoblas_HASWELL;
 	  else{


### PR DESCRIPTION
Add cpu model detection for Intel 7xxx (Kaby Lake) and Xeon Phi x200 (Knights Landing) - both mapped to HASWELL - and for the latest crop of Intel "Apollo Lake" Atom cpus (NEHALEM)