### PR TITLE
Include system headers for blas_server on FreeBSD

### DIFF
--- a/driver/others/blas_server.c
+++ b/driver/others/blas_server.c
@@ -70,7 +70,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 /*********************************************************************/
 
 #include "common.h"
-#if defined(OS_LINUX) || defined(OS_NETBSD) || defined(OS_DARWIN) || defined(OS_ANDROID) || defined(OS_SUNOS)
+#if defined(OS_LINUX) || defined(OS_NETBSD) || defined(OS_DARWIN) || defined(OS_ANDROID) || defined(OS_SUNOS) || defined(OS_FREEBSD)
 #include <dlfcn.h>
 #include <signal.h>
 #include <sys/resource.h>


### PR DESCRIPTION
FreeBSD requires the same headers as Linux, NetBSD, Darwin, and Android in blas_server.c, but it was not included in the `#if`, thereby caused the build to fail on FreeBSD. This PR simply adds a check for FreeBSD along with the others.