### PR TITLE
Make c_check, f_check convert any --exclude-libs arguments to linker flags

### DIFF
--- a/c_check
+++ b/c_check
@@ -234,6 +234,11 @@ $linker_a = "";
 	    $linker_L .= "-Wl,". $flags . " "
 	    }
 
+	if ($flags =~ /^\--exclude-libs/) {
+	    $linker_L .= "-Wl,". $flags . " ";
+	    $flags="";
+	   }
+
 	if (
 	    ($flags =~ /^\-l/)
 	    && ($flags !~ /gfortranbegin/)

--- a/f_check
+++ b/f_check
@@ -283,6 +283,12 @@ if ($link ne "") {
 	    $linker_L .= "-Wl,". $flags . " ";
         }
 
+	if ($flags =~ /^\--exclude-libs/) {
+	    $linker_L .= "-Wl,". $flags . " ";
+	    $flags="";
+	}
+
+
 	if ($flags =~ /^\-rpath\@/) {
 	    $flags =~ s/\@/\,/g;
 	    if ($vendor eq "PGI") {


### PR DESCRIPTION
Fixes #920: building with the TDM-GCC flavor of mingw fails due to unrecognized argument 