### PR TITLE
Fix for issue #1024: arm-linux-androideabi-g++ Compiler Error in /cpu…

### DIFF
--- a/cpuid_arm.c
+++ b/cpuid_arm.c
@@ -74,7 +74,7 @@ int get_feature(char *search)
   	fclose(infile);
 
 
-	if( p == NULL ) return;
+	if( p == NULL ) return 0;
 
 	t = strtok(p," ");
 	while( t = strtok(NULL," "))


### PR DESCRIPTION
…id_arm.c

Line 77: Compiler requires non-void function to return a value