### PR TITLE
Do not override MACOSX_DEPLOYMENT_TARGET if it is already defined.

### DIFF
--- a/Makefile.system
+++ b/Makefile.system
@@ -217,7 +217,9 @@ endif
 #
 
 ifeq ($(OSNAME), Darwin)
+ifndef MACOSX_DEPLOYMENT_TARGET
 export MACOSX_DEPLOYMENT_TARGET=10.6
+endif
 MD5SUM = md5 -r
 endif
 


### PR DESCRIPTION
This can cause strange messages when using a gcc compiled for a later version of OS X for example
```
gcc -O2 -DMAX_STACK_ALLOC=2048 -DEXPRECISION -m128bit-long-double -Wall -m64 -DF_INTERFACE_GFORT -fPIC -DNO_WARMUP -DMAX_CPU_NUMBER=4 -DASMNAME=_ -DASMFNAME=__ -DNAME=_ -DCNAME= -DCHAR_NAME=\"_\" -DCHAR_CNAME=\"\" -DNO_AFFINITY -I.. -all_load -headerpad_max_install_names -install_name "/Users/fbissey/build/sage/local/var/tmp/sage/build/openblas-0.2.19/src/exports/../libopenblas_haswell-r0.2.19.dylib" -dynamiclib -o ../libopenblas_haswell-r0.2.19.dylib ../libopenblas_haswell-r0.2.19.a -Wl,-exported_symbols_list,osx.def  -L/Users/fbissey/build/sage/local/lib -L/Users/fbissey/build/sage/local/lib/gcc/x86_64-apple-darwin16.1.0/5.4.0 -L/Users/fbissey/build/sage/local/lib/gcc/x86_64-apple-darwin16.1.0/5.4.0/../../.. -L/Users/fbissey/build/sage/local/lib -L/Users/fbissey/build/sage/local/lib/gcc/x86_64-apple-darwin16.1.0/5.4.0 -L/Users/fbissey/build/sage/local/lib/gcc/x86_64-apple-darwin16.1.0/5.4.0/../../..  -lgfortran -lSystem -lquadmath -lm -lSystem -lgfortran -lSystem -lquadmath -lm -lSystem  
ld: warning: object file (/Users/fbissey/build/sage/local/lib/gcc/x86_64-apple-darwin16.1.0/5.4.0/libgcc.a(_muldi3.o)) was built for newer OSX version (10.9) than being linked (10.6)
ld: warning: object file (/Users/fbissey/build/sage/local/lib/gcc/x86_64-apple-darwin16.1.0/5.4.0/libgcc.a(_negdi2.o)) was built for newer OSX version (10.9) than being linked (10.6)
....
```