### PR TITLE
Use appropriate int32/int64 format for error number in message string

### DIFF
--- a/driver/others/xerbla.c
+++ b/driver/others/xerbla.c
@@ -47,9 +47,9 @@
 #endif
 
 #ifdef INTERFACE64
-#define MSGFMT " ** On entry to %6s parameter number %2d had an illegal value\n" 
+#define MSGFMT " ** On entry to %6s parameter number %2ld had an illegal value\n" 
 #else
-#define MSGFMT " ** On entry to %6s parameter number %2ld had an illegal value\n"
+#define MSGFMT " ** On entry to %6s parameter number %2d had an illegal value\n"
 #endif
 
 #ifdef __ELF__

--- a/driver/others/xerbla.c
+++ b/driver/others/xerbla.c
@@ -46,10 +46,16 @@
 #define printf	_cprintf
 #endif
 
+#ifdef INTERFACE64
+#define MSGFMT " ** On entry to %6s parameter number %2d had an illegal value\n" 
+#else
+#define MSGFMT " ** On entry to %6s parameter number %2ld had an illegal value\n"
+#endif
+
 #ifdef __ELF__
 int __xerbla(char *message, blasint *info, blasint length){
 
-  printf(" ** On entry to %6s parameter number %2d had an illegal value\n",
+  printf(MSGFMT,
 	  message, *info);
 
   return 0;
@@ -61,7 +67,7 @@ int BLASFUNC(xerbla)(char *, blasint *, blasint) __attribute__ ((weak, alias ("_
 
 int BLASFUNC(xerbla)(char *message, blasint *info, blasint length){
 
-  printf(" ** On entry to %6s parameter number %2d had an illegal value\n",
+  printf(MSGFMT,
 	  message, *info);
 
   return 0;


### PR DESCRIPTION
Fixes #1038, compiler warning generated when building with INTERFACE64=1