### PR TITLE
Apply COMMON_OPT to default FFLAGS

### DIFF
--- a/Makefile.system
+++ b/Makefile.system
@@ -1004,7 +1004,7 @@ endif
 override CFLAGS     += $(COMMON_OPT) $(CCOMMON_OPT) -I$(TOPDIR)
 override PFLAGS     += $(COMMON_OPT) $(CCOMMON_OPT) -I$(TOPDIR) -DPROFILE $(COMMON_PROF)
 
-override FFLAGS     += $(FCOMMON_OPT)
+override FFLAGS     += $(COMMON_OPT) $(FCOMMON_OPT)
 override FPFLAGS    += $(FCOMMON_OPT) $(COMMON_PROF)
 #MAKEOVERRIDES =
 


### PR DESCRIPTION
Apply COMMON_OPT to the default FFLAGS as well to avoid building a non-optimized (and significantly slower than default netlib "Release" mode build) LAPACK by mistake, i.e. when FFLAGS is not provided via the environment at compile time. Fixes #843