### PR TITLE
Replace sched_yield with usleep(1) on Linux

### DIFF
--- a/common.h
+++ b/common.h
@@ -313,6 +313,10 @@ typedef int blasint;
 #if defined(OS_SUNOS)
 #define YIELDING	thr_yield()
 #endif
+	
+#if defined(OS_LINUX)
+#define YIELDING	usleep(1)
+#endif
 
 #if defined(OS_WINDOWS)
 #if defined(_MSC_VER) && !defined(__clang__)

--- a/common.h
+++ b/common.h
@@ -315,7 +315,7 @@ typedef int blasint;
 #endif
 	
 #if defined(OS_LINUX)
-#define YIELDING	usleep(1)
+#define YIELDING	__asm__ __volatile__ ("nop;nop;nop;nop;nop;nop;nop;nop;\n");
 #endif
 
 #if defined(OS_WINDOWS)


### PR DESCRIPTION
to avoid the massive overhead of the sched_yield call on Linux kernels since its semantics were changed in early 2003 (late 2.5 series) to include reordering of the thread queue. Ref. #900,#923