### PR TITLE
Enable the EXCAVATOR kernels on AMD PRO A12-9800

### DIFF
--- a/cpuid_x86.c
+++ b/cpuid_x86.c
@@ -1250,64 +1250,70 @@ int get_cpuname(void){
   }
 
   if (vendor == VENDOR_AMD){
-    switch (family) {
-    case 0x4:
-      return CPUTYPE_AMD5X86;
-    case 0x5:
-      return CPUTYPE_AMDK6;
-    case 0x6:
-      return CPUTYPE_ATHLON;
-    case 0xf:
-      switch (exfamily) {
-      case  0:
-      case  2:
-	return CPUTYPE_OPTERON;
-      case  1:
-      case  3:
-      case 10:
-	return CPUTYPE_BARCELONA;
-      case  6:
-	switch (model) {
-	case 1:
-	  //AMD Bulldozer Opteron 6200 / Opteron 4200 / AMD FX-Series
-	  if(support_avx())
-	    return CPUTYPE_BULLDOZER;
-	  else
-	    return CPUTYPE_BARCELONA; //OS don't support AVX.
-	case 2: //AMD Piledriver
-	case 3: //AMD Richland
-	  if(support_avx())
-	    return CPUTYPE_PILEDRIVER;
-	  else
-	    return CPUTYPE_BARCELONA; //OS don't support AVX.
-	case 0:
-	  switch(exmodel){
-	  case 1: //AMD Trinity
-	    if(support_avx())
-	      return CPUTYPE_PILEDRIVER;
-	    else
-	      return CPUTYPE_BARCELONA; //OS don't support AVX.
-	  case 3:
-	    if(support_avx())
-	      return CPUTYPE_STEAMROLLER;
-	    else
-	      return CPUTYPE_BARCELONA; //OS don't support AVX.
+      /* fprintf(stderr, "Family: %x exfamily: %x model: %x exmodel: %x\n", family, exfamily, model, exmodel ); */
+      switch (family) {
+          case 0x4:
+              return CPUTYPE_AMD5X86;
+          case 0x5:
+              return CPUTYPE_AMDK6;
+          case 0x6:
+              return CPUTYPE_ATHLON;
+          case 0xf:
+              switch (exfamily) {
+                  case  0:
+                  case  2:
+                      return CPUTYPE_OPTERON;
+                  case  1:
+                  case  3:
+                  case 10:
+                      return CPUTYPE_BARCELONA;
+                  case  6:
+                      switch (model) {
+                          case 1:
+                              //AMD Bulldozer Opteron 6200 / Opteron 4200 / AMD FX-Series
+                              if(support_avx())
+                                  return CPUTYPE_BULLDOZER;
+                              else
+                                  return CPUTYPE_BARCELONA; //OS don't support AVX.
+                          case 2: //AMD Piledriver
+                          case 3: //AMD Richland
+                              if(support_avx())
+                                  return CPUTYPE_PILEDRIVER;
+                              else
+                                  return CPUTYPE_BARCELONA; //OS don't support AVX.
+                          case 5: // EXCAVATOR
+                              if(support_avx())
+                                  return CPUTYPE_EXCAVATOR;
+                              else
+                                  return CPUTYPE_BARCELONA; //OS don't support AVX.
+                          case 0:
+                              switch(exmodel){
+                                  case 1: //AMD Trinity
+                                      if(support_avx())
+                                          return CPUTYPE_PILEDRIVER;
+                                      else
+                                          return CPUTYPE_BARCELONA; //OS don't support AVX.
+                                  case 3:
+                                      if(support_avx())
+                                          return CPUTYPE_STEAMROLLER;
+                                      else
+                                          return CPUTYPE_BARCELONA; //OS don't support AVX.
 
-	  case 6:
-	    if(support_avx())
-	      return CPUTYPE_EXCAVATOR;
-	    else
-	      return CPUTYPE_BARCELONA; //OS don't support AVX.
-	  }
-	  break;
-	}
-	break;
-      case  5:
-	return CPUTYPE_BOBCAT;
+                                  case 6:
+                                      if(support_avx())
+                                          return CPUTYPE_EXCAVATOR;
+                                      else
+                                          return CPUTYPE_BARCELONA; //OS don't support AVX.
+                              }
+                              break;
+                      }
+                      break;
+                  case  5:
+                      return CPUTYPE_BOBCAT;
+              }
+              break;
       }
-      break;
-    }
-    return CPUTYPE_AMD_UNKNOWN;
+      return CPUTYPE_AMD_UNKNOWN;
   }
 
   if (vendor == VENDOR_CYRIX){
@@ -1767,52 +1773,57 @@ int get_coretype(void){
   }
 
   if (vendor == VENDOR_AMD){
-    if (family <= 0x5) return CORE_80486;
-    if (family <= 0xe) return CORE_ATHLON;
-    if (family == 0xf){
-      if ((exfamily == 0) || (exfamily == 2)) return CORE_OPTERON;
-      else if (exfamily == 5) return CORE_BOBCAT;
-      else if (exfamily == 6) {
-	switch (model) {
-	case 1:
-	  //AMD Bulldozer Opteron 6200 / Opteron 4200 / AMD FX-Series
-	  if(support_avx())
-	    return CORE_BULLDOZER;
-	  else
-	    return CORE_BARCELONA; //OS don't support AVX.
-	case 2: //AMD Piledriver
-	case 3: //AMD Richland
-	  if(support_avx())
-	    return CORE_PILEDRIVER;
-	  else
-	    return CORE_BARCELONA; //OS don't support AVX.
-	
-	case 0:
-	  switch(exmodel){
-	  case 1: //AMD Trinity
-	    if(support_avx())
-	      return CORE_PILEDRIVER;
-	    else
-	      return CORE_BARCELONA; //OS don't support AVX.
+      if (family <= 0x5) return CORE_80486;
+      if (family <= 0xe) return CORE_ATHLON;
+      if (family == 0xf){
+          if ((exfamily == 0) || (exfamily == 2)) return CORE_OPTERON;
+          else if (exfamily == 5) return CORE_BOBCAT;
+          else if (exfamily == 6) {
+              switch (model) {
+                  case 1:
+                      //AMD Bulldozer Opteron 6200 / Opteron 4200 / AMD FX-Series
+                      if(support_avx())
+                          return CORE_BULLDOZER;
+                      else
+                          return CORE_BARCELONA; //OS don't support AVX.
+                  case 2: //AMD Piledriver
+                  case 3: //AMD Richland
+                      if(support_avx())
+                          return CORE_PILEDRIVER;
+                      else
+                          return CORE_BARCELONA; //OS don't support AVX.
+                  case 5:
+                      if(support_avx())
+                          return CORE_EXCAVATOR;
+                      else
+                          return CORE_BARCELONA; //OS don't support AVX.
 
-	  case 3:
-	    if(support_avx())
-	      return CORE_STEAMROLLER;
-	    else
-	      return CORE_BARCELONA; //OS don't support AVX.
+                  case 0:
+                      switch(exmodel){
+                          case 1: //AMD Trinity
+                              if(support_avx())
+                                  return CORE_PILEDRIVER;
+                              else
+                                  return CORE_BARCELONA; //OS don't support AVX.
 
-	  case 6:
-	    if(support_avx())
-	      return CORE_EXCAVATOR;
-	    else
-	      return CORE_BARCELONA; //OS don't support AVX.
-	  }
-	  break;
-	}
+                          case 3:
+                              if(support_avx())
+                                  return CORE_STEAMROLLER;
+                              else
+                                  return CORE_BARCELONA; //OS don't support AVX.
+
+                          case 6:
+                              if(support_avx())
+                                  return CORE_EXCAVATOR;
+                              else
+                                  return CORE_BARCELONA; //OS don't support AVX.
+                      }
+                      break;
+              }
 
 
-      }else return CORE_BARCELONA;
-    }
+          }else return CORE_BARCELONA;
+      }
   }
 
   if (vendor == VENDOR_CENTAUR) {

--- a/driver/others/dynamic.c
+++ b/driver/others/dynamic.c
@@ -318,75 +318,83 @@ static gotoblas_t *get_coretype(void){
   }
 
   if (vendor == VENDOR_AMD){
-    if (family <= 0xe) {
-        // Verify that CPU has 3dnow and 3dnowext before claiming it is Athlon
-        cpuid(0x80000000, &eax, &ebx, &ecx, &edx);
-        if ( (eax & 0xffff)  >= 0x01) {
-            cpuid(0x80000001, &eax, &ebx, &ecx, &edx);
-            if ((edx & (1 << 30)) == 0 || (edx & (1 << 31)) == 0)
-              return NULL;
+      if (family <= 0xe) {
+          // Verify that CPU has 3dnow and 3dnowext before claiming it is Athlon
+          cpuid(0x80000000, &eax, &ebx, &ecx, &edx);
+          if ( (eax & 0xffff)  >= 0x01) {
+              cpuid(0x80000001, &eax, &ebx, &ecx, &edx);
+              if ((edx & (1 << 30)) == 0 || (edx & (1 << 31)) == 0)
+                  return NULL;
           }
-        else
-          return NULL;
+          else
+              return NULL;
 
-        return &gotoblas_ATHLON;
+          return &gotoblas_ATHLON;
       }
-    if (family == 0xf){
-      if ((exfamily == 0) || (exfamily == 2)) {
-	if (ecx & (1 <<  0)) return &gotoblas_OPTERON_SSE3;
-	else return &gotoblas_OPTERON;
-      }  else if (exfamily == 5) {
-	return &gotoblas_BOBCAT;
-      } else if (exfamily == 6) {
-	if(model == 1){
-	  //AMD Bulldozer Opteron 6200 / Opteron 4200 / AMD FX-Series
-	  if(support_avx())
-	    return &gotoblas_BULLDOZER;
-	  else{
-	    openblas_warning(FALLBACK_VERBOSE, BARCELONA_FALLBACK);
-	    return &gotoblas_BARCELONA; //OS doesn't support AVX. Use old kernels.
-	  }
-	}else if(model == 2 || model == 3){
-	  //AMD Bulldozer Opteron 6300 / Opteron 4300 / Opteron 3300
-	  if(support_avx())
-	    return &gotoblas_PILEDRIVER;
-	  else{
-	    openblas_warning(FALLBACK_VERBOSE, BARCELONA_FALLBACK);
-	    return &gotoblas_BARCELONA; //OS doesn't support AVX. Use old kernels.
-	  }
-	}else if(model == 0){
-	  if (exmodel == 1) {
-	    //AMD Trinity
-	    if(support_avx())
-	      return &gotoblas_PILEDRIVER;
-	    else{
-	      openblas_warning(FALLBACK_VERBOSE, BARCELONA_FALLBACK);
-	      return &gotoblas_BARCELONA; //OS doesn't support AVX. Use old kernels.
-	    }
-	   }else if (exmodel == 3) {
-	    //AMD STEAMROLLER
-	    if(support_avx())
-	      return &gotoblas_STEAMROLLER;
-	    else{
-	      openblas_warning(FALLBACK_VERBOSE, BARCELONA_FALLBACK);
-	      return &gotoblas_BARCELONA; //OS doesn't support AVX. Use old kernels.
-	    }
-	  }else if (exmodel == 6) {
-	    if(support_avx())
-	      return &gotoblas_EXCAVATOR;
-	    else{
-	      openblas_warning(FALLBACK_VERBOSE, BARCELONA_FALLBACK);
-	      return &gotoblas_BARCELONA; //OS doesn't support AVX. Use old kernels.
-	    }
+      if (family == 0xf){
+          if ((exfamily == 0) || (exfamily == 2)) {
+              if (ecx & (1 <<  0)) return &gotoblas_OPTERON_SSE3;
+              else return &gotoblas_OPTERON;
+          }  else if (exfamily == 5) {
+              return &gotoblas_BOBCAT;
+          } else if (exfamily == 6) {
+              if(model == 1){
+                  //AMD Bulldozer Opteron 6200 / Opteron 4200 / AMD FX-Series
+                  if(support_avx())
+                      return &gotoblas_BULLDOZER;
+                  else{
+                      openblas_warning(FALLBACK_VERBOSE, BARCELONA_FALLBACK);
+                      return &gotoblas_BARCELONA; //OS doesn't support AVX. Use old kernels.
+                  }
+              }else if(model == 2 || model == 3){
+                  //AMD Bulldozer Opteron 6300 / Opteron 4300 / Opteron 3300
+                  if(support_avx())
+                      return &gotoblas_PILEDRIVER;
+                  else{
+                      openblas_warning(FALLBACK_VERBOSE, BARCELONA_FALLBACK);
+                      return &gotoblas_BARCELONA; //OS doesn't support AVX. Use old kernels.
+                  }
+              }else if(model == 5) { // EXCAVATOR 
+                  if(support_avx())
+                      return &gotoblas_EXCAVATOR;
+                  else{
+                      openblas_warning(FALLBACK_VERBOSE, BARCELONA_FALLBACK);
+                      return &gotoblas_BARCELONA; //OS doesn't support AVX. Use old kernels.
+                  }
 
-	  }
-	}
+              }else if(model == 0){
+                  if (exmodel == 1) {
+                      //AMD Trinity
+                      if(support_avx())
+                          return &gotoblas_PILEDRIVER;
+                      else{
+                          openblas_warning(FALLBACK_VERBOSE, BARCELONA_FALLBACK);
+                          return &gotoblas_BARCELONA; //OS doesn't support AVX. Use old kernels.
+                      }
+                  }else if (exmodel == 3) {
+                      //AMD STEAMROLLER
+                      if(support_avx())
+                          return &gotoblas_STEAMROLLER;
+                      else{
+                          openblas_warning(FALLBACK_VERBOSE, BARCELONA_FALLBACK);
+                          return &gotoblas_BARCELONA; //OS doesn't support AVX. Use old kernels.
+                      }
+                  }else if (exmodel == 6) {
+                      if(support_avx())
+                          return &gotoblas_EXCAVATOR;
+                      else{
+                          openblas_warning(FALLBACK_VERBOSE, BARCELONA_FALLBACK);
+                          return &gotoblas_BARCELONA; //OS doesn't support AVX. Use old kernels.
+                      }
+
+                  }
+              }
 
 
-      } else {
-	return &gotoblas_BARCELONA;
+          } else {
+              return &gotoblas_BARCELONA;
+          }
       }
-    }
   }
 
   if (vendor == VENDOR_CENTAUR) {


### PR DESCRIPTION
The AMD A12-9800 are not recognized by the cpuid_x86.c detection. I added their CPUIDs to be used with the EXCAVATOR kernels.