### PR TITLE
CPUID mappings for Core i5-7600K (Kaby Lake)

### DIFF
--- a/cpuid_x86.c
+++ b/cpuid_x86.c
@@ -636,6 +636,13 @@ int get_cacheinfo(int type, cache_info_t *cacheinfo){
 	LD1.associative = 8;
 	LD1.linesize    = 64;
 	break;
+      case 0x63 :
+  DTB.size        = 2048;
+  DTB.associative = 4;
+  DTB.linesize    = 32;
+  LDTB.size       = 4096;
+  LDTB.associative= 4;
+  LDTB.linesize   = 32;
       case 0x66 :
 	LD1.size        = 8;
 	LD1.associative = 4;
@@ -667,6 +674,13 @@ int get_cacheinfo(int type, cache_info_t *cacheinfo){
 	LC1.size        = 64;
 	LC1.associative = 8;
 	break;
+      case 0x76 :
+  ITB.size        = 2048;
+  ITB.associative = 0;
+  ITB.linesize    = 8;
+  LITB.size       = 4096;
+  LITB.associative= 0;
+  LITB.linesize   = 8;
       case 0x77 :
 	LC1.size        = 16;
 	LC1.associative = 4;
@@ -1220,6 +1234,7 @@ int get_cpuname(void){
 	    return CPUTYPE_NEHALEM;
 	}
 	break;
+      case 9:
       case 8: 
         switch (model) {
 	case 14: // Kaby Lake
@@ -1759,6 +1774,7 @@ int get_coretype(void){
 	    return CORE_NEHALEM;
         }
 	break;
+      case 9:
       case 8:
         if (model == 14) // Kaby Lake 
           return CORE_HASWELL;

--- a/driver/others/dynamic.c
+++ b/driver/others/dynamic.c
@@ -300,6 +300,7 @@ static gotoblas_t *get_coretype(void){
 	  return &gotoblas_NEHALEM;
 	}	
 	return NULL;
+      case 9:
       case 8:
 	if (model == 14 ) { // Kaby Lake
 	  if(support_avx())


### PR DESCRIPTION
On my new computer, I found that OpenBLAS didn't recognize the CPU.  This was because it was getting an `exfamily` of 9, instead of the `8` that mapped to Kaby Lake in the existing OpenBLAS source.  This patch fixes that and adds in a few new CPUID mappings as best I could from the sandpile table.  Please verify that I interpreted the sandpile webpage correctly, there was some ambiguity with regards to huge pages and I just did my best to guess and choose the most reasonable choices.  With this patch, the tests all pass on my local machine.