### PR TITLE
LAPACK: fix missing comma on continued lines

### DIFF
--- a/lapack-netlib/SRC/chbev_2stage.f
+++ b/lapack-netlib/SRC/chbev_2stage.f
@@ -247,7 +247,7 @@
       EXTERNAL           LSAME, SLAMCH, CLANHB, ILAENV
 *     ..
 *     .. External Subroutines ..
-      EXTERNAL           SSCAL, SSTERF, XERBLA, CLASCL, CSTEQR
+      EXTERNAL           SSCAL, SSTERF, XERBLA, CLASCL, CSTEQR,
      $                   CHETRD_2STAGE
 *     ..
 *     .. Intrinsic Functions ..

--- a/lapack-netlib/SRC/dsbev_2stage.f
+++ b/lapack-netlib/SRC/dsbev_2stage.f
@@ -239,7 +239,7 @@
       EXTERNAL           LSAME, DLAMCH, DLANSB, ILAENV
 *     ..
 *     .. External Subroutines ..
-      EXTERNAL           DLASCL, DSCAL, DSTEQR, DSTERF, XERBLA
+      EXTERNAL           DLASCL, DSCAL, DSTEQR, DSTERF, XERBLA,
      $                   DSYTRD_SB2ST 
 *     ..
 *     .. Intrinsic Functions ..

--- a/lapack-netlib/SRC/ssbev_2stage.f
+++ b/lapack-netlib/SRC/ssbev_2stage.f
@@ -239,7 +239,7 @@
       EXTERNAL           LSAME, SLAMCH, SLANSB, ILAENV
 *     ..
 *     .. External Subroutines ..
-      EXTERNAL           SLASCL, SSCAL, SSTEQR, SSTERF, XERBLA
+      EXTERNAL           SLASCL, SSCAL, SSTEQR, SSTERF, XERBLA,
      $                   SSYTRD_SB2ST 
 *     ..
 *     .. Intrinsic Functions ..

--- a/lapack-netlib/SRC/zhbev_2stage.f
+++ b/lapack-netlib/SRC/zhbev_2stage.f
@@ -247,7 +247,7 @@
       EXTERNAL           LSAME, DLAMCH, ZLANHB, ILAENV
 *     ..
 *     .. External Subroutines ..
-      EXTERNAL           DSCAL, DSTERF, XERBLA, ZLASCL, ZSTEQR
+      EXTERNAL           DSCAL, DSTERF, XERBLA, ZLASCL, ZSTEQR,
      $                   ZHETRD_2STAGE
 *     ..
 *     .. Intrinsic Functions ..

--- a/lapack-netlib/SRC/ztrevc3.f
+++ b/lapack-netlib/SRC/ztrevc3.f
@@ -287,7 +287,7 @@
       EXTERNAL           LSAME, ILAENV, IZAMAX, DLAMCH, DZASUM
 *     ..
 *     .. External Subroutines ..
-      EXTERNAL           XERBLA, ZCOPY, ZDSCAL, ZGEMV, ZLATRS
+      EXTERNAL           XERBLA, ZCOPY, ZDSCAL, ZGEMV, ZLATRS,
      $                   ZGEMM, DLABAD, ZLASET
 *     ..
 *     .. Intrinsic Functions ..


### PR DESCRIPTION
In a few files from netlib 3.7.0, an EXTERNAL declaration of subroutines missed a comma before the continuation line. This caused concatenated names to appear as unresolved external dependencies in the objects and library at least when compiled with ifort. Fixes #1069