### PR TITLE
TESTING/EIG: fix spurious EXTERNAL references to nonexistent functions

### DIFF
--- a/lapack-netlib/TESTING/EIG/zchkhb2stg.f
+++ b/lapack-netlib/TESTING/EIG/zchkhb2stg.f
@@ -373,7 +373,7 @@
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           DLASUM, XERBLA, ZHBT21, ZHBTRD, ZLACPY, ZLASET,
-     $                   ZLATMR, ZLATMS, ZHBTRD_HB2ST, ZSTEQR
+     $                   ZLATMR, ZLATMS, ZHETRD_HB2ST, ZSTEQR
 *     ..
 *     .. Intrinsic Functions ..
       INTRINSIC          ABS, DBLE, DCONJG, MAX, MIN, SQRT

--- a/lapack-netlib/TESTING/EIG/zdrvst2stg.f
+++ b/lapack-netlib/TESTING/EIG/zdrvst2stg.f
@@ -399,8 +399,7 @@
      $                   ZHET22, ZHPEV, ZHPEVD, ZHPEVX, ZLACPY, ZLASET,
      $                   ZHEEVD_2STAGE, ZHEEVR_2STAGE, ZHEEVX_2STAGE,
      $                   ZHEEV_2STAGE, ZHBEV_2STAGE, ZHBEVD_2STAGE,
-     $                   ZHBEVX_2STAGE, ZHETRD_2STAGE, ZHETRD_SY2SB, 
-     $                   ZHETRD_SB2ST, ZLATMR, ZLATMS
+     $                   ZHBEVX_2STAGE, ZHETRD_2STAGE, ZLATMR, ZLATMS
 *     ..
 *     .. Intrinsic Functions ..
       INTRINSIC          ABS, DBLE, INT, LOG, MAX, MIN, SQRT

--- a/lapack-netlib/TESTING/EIG/zerrst.f
+++ b/lapack-netlib/TESTING/EIG/zerrst.f
@@ -29,8 +29,7 @@
 *> ZHPEV, CHPEVX, CHPEVD, and ZSTEDC.
 *> ZHEEVD_2STAGE, ZHEEVR_2STAGE, ZHEEVX_2STAGE,
 *> ZHEEV_2STAGE, ZHBEV_2STAGE, ZHBEVD_2STAGE,
-*> ZHBEVX_2STAGE, ZHETRD_2STAGE, ZHETRD_SY2SB,
-*> ZHETRD_SB2ST
+*> ZHBEVX_2STAGE, ZHETRD_2STAGE
 *> \endverbatim
 *
 *  Arguments:
@@ -102,8 +101,7 @@
      $                   ZUNGTR, ZUNMTR, ZUPGTR, ZUPMTR,
      $                   ZHEEVD_2STAGE, ZHEEVR_2STAGE, ZHEEVX_2STAGE,
      $                   ZHEEV_2STAGE, ZHBEV_2STAGE, ZHBEVD_2STAGE,
-     $                   ZHBEVX_2STAGE, ZHETRD_2STAGE, ZHETRD_SY2SB,
-     $                   ZHETRD_SB2ST
+     $                   ZHBEVX_2STAGE, ZHETRD_2STAGE
 *     ..
 *     .. Scalars in Common ..
       LOGICAL            LERR, OK


### PR DESCRIPTION
From the epilog of #1069 - the Intel Fortran compiler treated these as unresolved external references