### PR TITLE
Replace SSE With C in Haswell dcopy

### DIFF
--- a/kernel/x86_64/KERNEL.HASWELL
+++ b/kernel/x86_64/KERNEL.HASWELL
@@ -2,6 +2,8 @@ DSCALKERNEL = dscal.c
 CSCALKERNEL = cscal.c
 ZSCALKERNEL = zscal.c
 
+DCOPYKERNEL =  ../arm/copy.c
+
 SGEMVNKERNEL = sgemv_n_4.c
 SGEMVTKERNEL = sgemv_t_4.c
 


### PR DESCRIPTION
Should stop crashes #1137 
Tested on one single broadwell.