### PR TITLE
MIPS threading fixes

### DIFF
--- a/common_mips.h
+++ b/common_mips.h
@@ -33,8 +33,8 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef COMMON_MIPS
 #define COMMON_MIPS
 
-#define MB
-#define WMB
+#define MB  __sync_synchronize()
+#define WMB __sync_synchronize()
 
 #define INLINE inline
 

--- a/common_mips.h
+++ b/common_mips.h
@@ -42,11 +42,6 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #ifndef ASSEMBLER
 
-static void INLINE blas_lock(volatile unsigned long *address){
-
-}
-#define BLAS_LOCK_DEFINED
-
 static inline unsigned int rpcc(void){
   unsigned long ret;
 

--- a/common_mips64.h
+++ b/common_mips64.h
@@ -78,28 +78,6 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #ifndef ASSEMBLER
 
-static void INLINE blas_lock(volatile unsigned long *address){
-
-  long int ret, val = 1;
-
-  do {
-    while (*address) {YIELDING;};
-
-    __asm__ __volatile__(
-			 "1:	ll	%0, %3\n"
-			 "	ori	%2, %0, 1\n"
-			 "	sc	%2, %1\n"
-			 "	beqz	%2, 1b\n"
-			 "	 andi	%2, %0, 1\n"
-			 "	sync\n"
-			 : "=&r" (val), "=m" (address), "=&r" (ret)
-			 : "m" (address)
-			 : "memory");
-
-  } while (ret);
-}
-#define BLAS_LOCK_DEFINED
-
 static inline unsigned int rpcc(void){
   unsigned long ret;
 

--- a/common_mips64.h
+++ b/common_mips64.h
@@ -71,8 +71,8 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef COMMON_MIPS64
 #define COMMON_MIPS64
 
-#define MB
-#define WMB
+#define MB  __sync_synchronize()
+#define WMB __sync_synchronize()
 
 #define INLINE inline
 


### PR DESCRIPTION
https://bugs.debian.org/861486

This PR fixes some threading issues on MIPS found while trying to build Julia in Debian.

The first commit implements `MB` and `WMB` on MIPS (using GCC builtins, but hopefully that's fine). The second commit removes the broken `blas_lock` implementations so the code falls back to using GCC builtins which do work correctly on MIPS.