### PR TITLE
Fixes to driver/others/memory.c

### DIFF
--- a/driver/others/memory.c
+++ b/driver/others/memory.c
@@ -1015,7 +1015,7 @@ void *blas_memory_alloc(int procpos){
   mypos = WhereAmI();
 
   position = mypos;
-  while (position > NUM_BUFFERS) position >>= 1;
+  while (position >= NUM_BUFFERS) position >>= 1;
 
   do {
     if (!memory[position].used && (memory[position].pos == mypos)) {

--- a/driver/others/memory.c
+++ b/driver/others/memory.c
@@ -1164,8 +1164,8 @@ void blas_memory_free(void *free_area){
   position = 0;
   LOCK_COMMAND(&alloc_lock);
 
-  while ((memory[position].addr != free_area)
-	 && (position < NUM_BUFFERS)) position++;
+  while ((position < NUM_BUFFERS) && (memory[position].addr != free_area))
+    position++;
 
   if (memory[position].addr != free_area) goto error;
 


### PR DESCRIPTION
This PR fixes some issues I noticed in `driver/others/memory.c` while debugging the MIPS threading issues. Both appear to have been programming mistakes.

The first commit moves the `position < NUM_BUFFERS` condition to the front of the `&&` so it actually has an effect (it was being optimized away before).

The second commit ensures the case where `position == NUM_BUFFERS` is handled correctly in `blas_memory_alloc`. Having said that, this situation is pretty unlikely since `NUM_BUFFERS` is supposed to be greater than the number of CPUs (according to its definition in `common.h` anyway).
