### PR TITLE
build: fix libxlmass errors building on Power CPU

### DIFF
--- a/Makefile.power
+++ b/Makefile.power
@@ -43,7 +43,7 @@ endif
 
 ifeq ($(USE_MASS), 1)
 # Path to MASS libs, change it if the libs are installed at any other location
-MASSPATH        = /opt/ibm/xlmass/8.1.3/lib
+MASSPATH        = /opt/ibm/xlmass/8.1.5/lib
 COMMON_OPT     += -mveclibabi=mass -ftree-vectorize -funsafe-math-optimizations -DUSE_MASS
 EXTRALIB       += -L$(MASSPATH) -lmass -lmassvp8 -lmass_simdp8
 endif

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The library can be installed as below -
     wget -q http://public.dhe.ibm.com/software/server/POWER/Linux/xl-compiler/eval/ppc64le/ubuntu/public.gpg -O- | sudo apt-key add -</br>
     echo "deb http://public.dhe.ibm.com/software/server/POWER/Linux/xl-compiler/eval/ppc64le/ubuntu/ trusty main" | sudo tee /etc/apt/sources.list.d/ibm-xl-compiler-eval.list</br>
     sudo apt-get update</br>
-    sudo apt-get install libxlmass-devel.8.1.3</br>
+    sudo apt-get install libxlmass-devel.8.1.5</br>
 
  * On RHEL/CentOS:
 
@@ -62,7 +62,7 @@ The library can be installed as below -
     sudo rpm --import repomd.xml.key</br>
     wget http://public.dhe.ibm.com/software/server/POWER/Linux/xl-compiler/eval/ppc64le/rhel7/ibm-xl-compiler-eval.repo</br>
     sudo cp ibm-xl-compiler-eval.repo /etc/yum.repos.d/</br>
-    sudo yum install libxlmass-devel.8.1.3</br>
+    sudo yum install libxlmass-devel.8.1.5</br>
 
 After installing MASS library, compile openblas with USE_MASS=1.
 


### PR DESCRIPTION
IBM MASS library is upgraded to 8.1.5 and 8.1.3 is not available.
Update README.md and Makefile.power to use version 8.1.5 of libxlmass.