### PR TITLE
pthreads: prefer `-pthread` during linking

### DIFF
--- a/Makefile.system
+++ b/Makefile.system
@@ -306,7 +306,7 @@ ifneq ($(OSNAME), CYGWIN_NT)
 ifneq ($(OSNAME), Interix)
 ifneq ($(OSNAME), Android)
 ifdef SMP
-EXTRALIB   += -lpthread
+EXTRALIB   += -pthread
 endif
 endif
 endif

--- a/Makefile.x86
+++ b/Makefile.x86
@@ -6,9 +6,9 @@ ARFLAGS		= -m x86
 endif
 
 ifndef SMP
-LIBMKL		= -L$(MKLPATH)/32 -Wl,-rpath,$(MKLPATH)/32 -lmkl_intel -lmkl_sequential -lmkl_core -lguide -lpthread -lm
+LIBMKL		= -L$(MKLPATH)/32 -Wl,-rpath,$(MKLPATH)/32 -lmkl_intel -lmkl_sequential -lmkl_core -lguide -pthread -lm
 else
-LIBMKL		= -L$(MKLPATH)/32 -Wl,-rpath,$(MKLPATH)/32 -lmkl_intel -lmkl_intel_thread -lmkl_core -lguide -lpthread -lm
+LIBMKL		= -L$(MKLPATH)/32 -Wl,-rpath,$(MKLPATH)/32 -lmkl_intel -lmkl_intel_thread -lmkl_core -lguide -pthread -lm
 endif
 
 # LIBMKL		= -L$(MKLPATH)/32 -lmkl_lapack -lmkl_ia32 -lguide -lpthread -lm
@@ -16,7 +16,7 @@ endif
 ifndef SMP
 LIBATLAS	= -L$(ATLAS) -lf77blas -latlas -lg2c -lm
 else
-LIBATLAS	= -L$(ATLAS) -lptf77blas -latlas -lpthread -lg2c -lm
+LIBATLAS	= -L$(ATLAS) -lptf77blas -latlas -pthread -lg2c -lm
 endif
 
 ifeq ($(COMPILER_F77), g77)
@@ -52,5 +52,5 @@ LIBVECLIB	= /System/Library/Frameworks/vecLib.framework/Versions/Current/vecLib
 ifndef SMP
 LIBATLAS	= -L$(ATLASPATH)/32 -lcblas -lf77blas -latlas -lm
 else
-LIBATLAS	= -L$(ATLASPATH)/32 -lptf77blas -lptatlas -lpthread -lm
+LIBATLAS	= -L$(ATLASPATH)/32 -lptf77blas -lptatlas -pthread -lm
 endif

--- a/Makefile.x86_64
+++ b/Makefile.x86_64
@@ -20,9 +20,9 @@ LIBMKL		= -L$(MKLPATH)/em64t -Wl,-rpath,$(MKLPATH)/em64t -lmkl_intel_lp64 -lmkl_
 endif
 else
 ifndef SMP
-LIBMKL		= -L$(MKLPATH)/em64t -Wl,-rpath,$(MKLPATH)/em64t -Wl,--start-group -lmkl_intel_lp64 -lmkl_sequential -lmkl_core -Wl,--end-group -lguide -lpthread -lm
+LIBMKL		= -L$(MKLPATH)/em64t -Wl,-rpath,$(MKLPATH)/em64t -Wl,--start-group -lmkl_intel_lp64 -lmkl_sequential -lmkl_core -Wl,--end-group -lguide -pthread -lm
 else
-LIBMKL		= -L$(MKLPATH)/em64t -Wl,-rpath,$(MKLPATH)/em64t -Wl,--start-group -lmkl_intel_lp64 -lmkl_intel_thread -lmkl_core -Wl,--end-group -lguide -lpthread -lm
+LIBMKL		= -L$(MKLPATH)/em64t -Wl,-rpath,$(MKLPATH)/em64t -Wl,--start-group -lmkl_intel_lp64 -lmkl_intel_thread -lmkl_core -Wl,--end-group -lguide -pthread -lm
 endif
 endif
 
@@ -30,10 +30,10 @@ endif
 ifndef SMP
 LIBATLAS	= -L$(ATLASPATH)64 -llapack -lcblas -lf77blas -latlas -lm
 else
-LIBATLAS	= -L$(ATLASPATH)64 -llapack -lptcblas -lptf77blas -latlas -lpthread -lm
+LIBATLAS	= -L$(ATLASPATH)64 -llapack -lptcblas -lptf77blas -latlas -pthread -lm
 endif
 
-LIBFLAME	= -L$(FLAMEPATH) -llapack2flame -lflame $(TOPDIR)/$(LIBNAME) -lgfortran -lpthread -lm
+LIBFLAME	= -L$(FLAMEPATH) -llapack2flame -lflame $(TOPDIR)/$(LIBNAME) -lgfortran -pthread -lm
 
 
 ifeq ($(F_COMPILER), g77)
@@ -50,9 +50,9 @@ endif
 
 ifeq ($(F_COMPILER), INTEL)
 ifndef SMP
-LIBACML		= -L$(ACMLPATH)/ifort64/lib -Wl,-rpath,$(ACMLPATH)/ifort64/lib -lacml -lacml_mv -lifcoremt_pic -lirc -lm -lpthread -ldl
+LIBACML		= -L$(ACMLPATH)/ifort64/lib -Wl,-rpath,$(ACMLPATH)/ifort64/lib -lacml -lacml_mv -lifcoremt_pic -lirc -lm -pthread -ldl
 else
-LIBACML		= -L$(ACMLPATH)/ifort64_mp/lib -Wl,-rpath,$(ACMLPATH)/ifort64_mp/lib -lacml_mp -lacml_mv -lifcoremt_pic -liomp5 -lirc -lm -lpthread -ldl
+LIBACML		= -L$(ACMLPATH)/ifort64_mp/lib -Wl,-rpath,$(ACMLPATH)/ifort64_mp/lib -lacml_mp -lacml_mv -lifcoremt_pic -liomp5 -lirc -lm -pthread -ldl
 endif
 endif
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -52,7 +52,7 @@ in `Makefile.rule`.
 
 `gcc -o test test.c -I /your_path/OpenBLAS/include/ -L/your_path/OpenBLAS/lib -lopenblas`
 
-If the library is multithreaded, please add `-lpthread`. If the library
+If the library is multithreaded, please add `-pthread`. If the library
 contains LAPACK functions, please add `-lgfortran` or other Fortran libs.
 
 * Link with static library
@@ -66,10 +66,10 @@ default), custom programs statically linked against `libopenblas.a` should also
 link with the pthread library e.g.:
 
 ```
-gcc -static -I/opt/OpenBLAS/include -L/opt/OpenBLAS/lib -o my_program my_program.c -lopenblas -lpthread
+gcc -static -I/opt/OpenBLAS/include -L/opt/OpenBLAS/lib -o my_program my_program.c -lopenblas -pthread
 ```
 
-Failing to add the `-lpthread` flag will cause errors such as:
+Failing to add the `-pthread` flag will cause errors such as:
 
 ```
 /opt/OpenBLAS/libopenblas.a(memory.o): In function `_touch_memory':
@@ -99,7 +99,7 @@ void main()
   printf("\n");
 }
 ```
-`gcc -o test_cblas_open test_cblas_dgemm.c -I /your_path/OpenBLAS/include/ -L/your_path/OpenBLAS/lib -lopenblas -lpthread -lgfortran`
+`gcc -o test_cblas_open test_cblas_dgemm.c -I /your_path/OpenBLAS/include/ -L/your_path/OpenBLAS/lib -lopenblas -pthread -lgfortran`
 
 #### Call BLAS Fortran interface
 

--- a/cmake/os.cmake
+++ b/cmake/os.cmake
@@ -79,7 +79,7 @@ endif ()
 
 if (NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Windows" AND NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Interix")
   if (SMP)
-    set(EXTRALIB "${EXTRALIB} -lpthread")
+    set(EXTRALIB "${EXTRALIB} -pthread")
   endif ()
 endif ()
 


### PR DESCRIPTION
The documentation of [GCC](https://gcc.gnu.org/onlinedocs/gcc-7.1.0/gcc/Preprocessor-Options.html#index-pthread) and [Clang]( https://clang.llvm.org/docs/ClangCommandLineReference.html) state that `-pthread` is to be used during compiling and *linking* for POSIX threads support. Moreover, there is no pthread library in the Android NDK (try to search for `libpthread.*`) meaning there will be linker errors when using `-lpthread` (this flag is given in the pkg-config file, at least for arm-linux-androideabi targets).

Currently, `-pthread` is not used when compiling C code and `-lpthread` is regularly used during linking, possibly leading to errors.

This pull request changes *only* the linker flags for most compilers including the Intel Fortran compiler ([`pthread` documentation](https://software.intel.com/en-us/node/678318)) and the `EXTRALIBS` variable; the linker flags for the PathScale and the Open64 compilers remain unchanged because their manuals ([PathScale manual from 2008](http://www2.physics.uiowa.edu/~ghowes/teach/ihpc10/manuals/PathScaleCompiler.pdf), [Open64 4.5.2 manual](http://amd-dev.wpengine.netdna-cdn.com/wordpress/media/2012/10/open64.pdf)) do not mention this flag.

See the linked Google Groups threads for a discussion on whether `-lpthread` should work during linking:
https://groups.google.com/forum/#!topic/comp.programming.threads/NCEpG0EOCCY
