### PR TITLE
Add 64bit support for Microsoft Visual Studio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,9 +120,12 @@ if (${NO_STATIC} AND ${NO_SHARED})
 endif ()
 
 #Set default output directory
-set( CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib )
-set( CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib )
-
+set( CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib)
+set( CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib)
+if(MSVC)
+set( CMAKE_LIBRARY_OUTPUT_DIRECTORY_DEBUG ${PROJECT_BINARY_DIR}/lib/Debug)
+set( CMAKE_ARCHIVE_OUTPUT_DIRECTORY_RELEASE ${PROJECT_BINARY_DIR}/lib/Release)
+endif ()
 # get obj vars into format that add_library likes: $<TARGET_OBJS:objlib> (see http://www.cmake.org/cmake/help/v3.0/command/add_library.html)
 set(TARGET_OBJS "")
 foreach (SUBDIR ${SUBDIRS})
@@ -142,9 +145,12 @@ if (NOT NO_LAPACKE)
 endif ()
 endif ()
 
-#Only generate .def for dll on MSVC
+# Only generate .def for dll on MSVC and always produce pdb files for debug and release
 if(MSVC)
 set(OpenBLAS_DEF_FILE "${PROJECT_BINARY_DIR}/openblas.def")
+set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /Zi")
+set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} /Zi")
+set(CMAKE_SHARED_LINKER_FLAGS_RELEASE "${CMAKE_SHARED_LINKER_FLAGS_RELEASE} /DEBUG /OPT:REF /OPT:ICF")
 endif()
 
 # add objects to the openblas lib
@@ -159,15 +165,15 @@ set_target_properties( ${OpenBLAS_LIBNAME} PROPERTIES LIBRARY_OUTPUT_NAME_DEBUG 
 foreach (OUTPUTCONFIG ${CMAKE_CONFIGURATION_TYPES})
   string( TOUPPER ${OUTPUTCONFIG} OUTPUTCONFIG )
   
-  set_target_properties( ${OpenBLAS_LIBNAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY_${OUTPUTCONFIG} ${PROJECT_BINARY_DIR}/lib)
-  set_target_properties( ${OpenBLAS_LIBNAME} PROPERTIES LIBRARY_OUTPUT_DIRECTORY_${OUTPUTCONFIG} ${PROJECT_BINARY_DIR}/lib)
-  set_target_properties( ${OpenBLAS_LIBNAME} PROPERTIES ARCHIVE_OUTPUT_DIRECTORY_${OUTPUTCONFIG} ${PROJECT_BINARY_DIR}/lib)
+  set_target_properties( ${OpenBLAS_LIBNAME} PROPERTIES RUNTIME_OUTPUT_DIRECTORY_${OUTPUTCONFIG} ${PROJECT_BINARY_DIR}/lib/${OUTPUTCONFIG} )
+  set_target_properties( ${OpenBLAS_LIBNAME} PROPERTIES LIBRARY_OUTPUT_DIRECTORY_${OUTPUTCONFIG} ${PROJECT_BINARY_DIR}/lib/${OUTPUTCONFIG} )
+  set_target_properties( ${OpenBLAS_LIBNAME} PROPERTIES ARCHIVE_OUTPUT_DIRECTORY_${OUTPUTCONFIG} ${PROJECT_BINARY_DIR}/lib/${OUTPUTCONFIG} )
 endforeach()
 
 enable_testing()
 add_subdirectory(utest)
 
-if(NOT MSVC)
+if (NOT MSVC)
 	#only build shared library for MSVC
 
 	add_library(${OpenBLAS_LIBNAME}_static STATIC ${LA_SOURCES} ${LAPACKE_SOURCES} ${TARGET_OBJS})
@@ -224,10 +230,7 @@ install(TARGETS ${OpenBLAS_LIBNAME}
 	LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} )
 
 # Install include files
-	add_executable(gen_config_h gen_config_h.c)
-	target_compile_definitions(gen_config_h PRIVATE VERSION=\"${OpenBLAS_VERSION}\")
-	message (STATUS "Generating openblas_config.h in ${CMAKE_BINARY_DIR}")
-	GET_TARGET_PROPERTY(GENCONFIG_BIN gen_config_h LOCATION)
+	set (GENCONFIG_BIN ${CMAKE_BINARY_DIR}/gen_config_h${CMAKE_EXECUTABLE_SUFFIX})
 	ADD_CUSTOM_COMMAND(
 	OUTPUT ${CMAKE_BINARY_DIR}/openblas_config.h
 	DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/config.h
@@ -238,19 +241,32 @@ install(TARGETS ${OpenBLAS_LIBNAME}
 	install (FILES ${CMAKE_BINARY_DIR}/openblas_config.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 	message(STATUS "Generating f77blas.h in ${CMAKE_INSTALL_INCLUDEDIR}")
+if (NOT MSVC)
 	ADD_CUSTOM_TARGET(genf77blas
 	COMMAND ${AWK} 'BEGIN{print \"\#ifndef OPENBLAS_F77BLAS_H\" \; print \"\#define OPENBLAS_F77BLAS_H\" \; print \"\#include \\"openblas_config.h\\" \"}; NF {print}; END{print \"\#endif\"}' ${CMAKE_CURRENT_SOURCE_DIR}/common_interface.h > ${CMAKE_BINARY_DIR}/f77blas.h
-
 	DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/config.h
 	)
+else ()
+	ADD_CUSTOM_TARGET(genf77blas
+	COMMAND ${AWK} \"BEGIN{print \\\"\#ifndef OPENBLAS_F77BLAS_H\\\" \; print \\\"\#define OPENBLAS_F77BLAS_H\\\" \; print \\\"\#include \\\\\\"openblas_config.h\\\\\\" \\\"}; NF {print}; END{print \\\"\#endif\\\"}\" ${CMAKE_CURRENT_SOURCE_DIR}/common_interface.h > ${CMAKE_BINARY_DIR}/f77blas.h
+	DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/config.h
+	)
+endif ()
 	install (FILES ${CMAKE_BINARY_DIR}/f77blas.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 if(NOT NO_CBLAS)
 	message (STATUS "Generating cblas.h in ${CMAKE_INSTALL_INCLUDEDIR}")
+  if(NOT MSVC)
 	ADD_CUSTOM_TARGET(gencblas
-	COMMAND sed 's/common/openblas_config/g' ${CMAKE_CURRENT_SOURCE_DIR}/cblas.h > "${CMAKE_BINARY_DIR}/cblas.h"
+	COMMAND ${SED} 's/common/openblas_config/g' ${CMAKE_CURRENT_SOURCE_DIR}/cblas.h > "${CMAKE_BINARY_DIR}/cblas.h"
 	DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/cblas.h
 	)
+  else ()
+	ADD_CUSTOM_TARGET(gencblas
+	COMMAND ${SED} "s/common/openblas_config/g" ${CMAKE_CURRENT_SOURCE_DIR}/cblas.h > "${CMAKE_BINARY_DIR}/cblas.h"
+	DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/cblas.h
+	)
+  endif ()
 	add_dependencies( ${OpenBLAS_LIBNAME} gencblas)
 	install (FILES ${CMAKE_BINARY_DIR}/cblas.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 endif()
@@ -277,3 +293,15 @@ if(PKG_CONFIG_FOUND)
 	configure_file(${PROJECT_SOURCE_DIR}/cmake/openblas.pc.in ${PROJECT_BINARY_DIR}/openblas.pc @ONLY)
 	install (FILES ${PROJECT_BINARY_DIR}/openblas.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig/)
 endif()
+
+# build dependencies graph
+# add_dependencies(genconfig gen_config_h genf77blas gencblas)
+add_dependencies(genconfig genf77blas gencblas)
+add_dependencies(interface genconfig)
+add_dependencies(kernel genconfig)
+add_dependencies(driver_level2 genconfig)
+add_dependencies(driver_level3 genconfig)
+add_dependencies(driver_others genconfig)
+add_dependencies(${OpenBLAS_LIBNAME} kernel driver_level2 driver_level3 driver_others interface)
+add_dependencies(openblas_utest ${OpenBLAS_LIBNAME})
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -241,32 +241,20 @@ install(TARGETS ${OpenBLAS_LIBNAME}
 	install (FILES ${CMAKE_BINARY_DIR}/openblas_config.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 	message(STATUS "Generating f77blas.h in ${CMAKE_INSTALL_INCLUDEDIR}")
-if (NOT MSVC)
+
 	ADD_CUSTOM_TARGET(genf77blas
 	COMMAND ${AWK} 'BEGIN{print \"\#ifndef OPENBLAS_F77BLAS_H\" \; print \"\#define OPENBLAS_F77BLAS_H\" \; print \"\#include \\"openblas_config.h\\" \"}; NF {print}; END{print \"\#endif\"}' ${CMAKE_CURRENT_SOURCE_DIR}/common_interface.h > ${CMAKE_BINARY_DIR}/f77blas.h
 	DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/config.h
 	)
-else ()
-	ADD_CUSTOM_TARGET(genf77blas
-	COMMAND ${AWK} \"BEGIN{print \\\"\#ifndef OPENBLAS_F77BLAS_H\\\" \; print \\\"\#define OPENBLAS_F77BLAS_H\\\" \; print \\\"\#include \\\\\\"openblas_config.h\\\\\\" \\\"}; NF {print}; END{print \\\"\#endif\\\"}\" ${CMAKE_CURRENT_SOURCE_DIR}/common_interface.h > ${CMAKE_BINARY_DIR}/f77blas.h
-	DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/config.h
-	)
-endif ()
 	install (FILES ${CMAKE_BINARY_DIR}/f77blas.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 if(NOT NO_CBLAS)
 	message (STATUS "Generating cblas.h in ${CMAKE_INSTALL_INCLUDEDIR}")
-  if(NOT MSVC)
+
 	ADD_CUSTOM_TARGET(gencblas
 	COMMAND ${SED} 's/common/openblas_config/g' ${CMAKE_CURRENT_SOURCE_DIR}/cblas.h > "${CMAKE_BINARY_DIR}/cblas.h"
 	DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/cblas.h
 	)
-  else ()
-	ADD_CUSTOM_TARGET(gencblas
-	COMMAND ${SED} "s/common/openblas_config/g" ${CMAKE_CURRENT_SOURCE_DIR}/cblas.h > "${CMAKE_BINARY_DIR}/cblas.h"
-	DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/cblas.h
-	)
-  endif ()
 	add_dependencies( ${OpenBLAS_LIBNAME} gencblas)
 	install (FILES ${CMAKE_BINARY_DIR}/cblas.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,7 +237,8 @@ install(TARGETS ${OpenBLAS_LIBNAME}
 	COMMAND ${GENCONFIG_BIN} ${CMAKE_CURRENT_SOURCE_DIR}/config.h ${CMAKE_CURRENT_SOURCE_DIR}/openblas_config_template.h > ${CMAKE_BINARY_DIR}/openblas_config.h
 	)
 	ADD_CUSTOM_TARGET(genconfig DEPENDS openblas_config.h)	
-	add_dependencies( ${OpenBLAS_LIBNAME}  genconfig genf77blas)
+	add_dependencies(genconfig ${OpenBLAS_LIBNAME})
+
 	install (FILES ${CMAKE_BINARY_DIR}/openblas_config.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 	message(STATUS "Generating f77blas.h in ${CMAKE_INSTALL_INCLUDEDIR}")
@@ -246,6 +247,8 @@ install(TARGETS ${OpenBLAS_LIBNAME}
 	COMMAND ${AWK} 'BEGIN{print \"\#ifndef OPENBLAS_F77BLAS_H\" \; print \"\#define OPENBLAS_F77BLAS_H\" \; print \"\#include \\"openblas_config.h\\" \"}; NF {print}; END{print \"\#endif\"}' ${CMAKE_CURRENT_SOURCE_DIR}/common_interface.h > ${CMAKE_BINARY_DIR}/f77blas.h
 	DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/config.h
 	)
+	add_dependencies(genf77blas ${OpenBLAS_LIBNAME})
+
 	install (FILES ${CMAKE_BINARY_DIR}/f77blas.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 if(NOT NO_CBLAS)
@@ -256,7 +259,9 @@ if(NOT NO_CBLAS)
 	COMMAND cp "${CMAKE_BINARY_DIR}/cblas.tmp" "${CMAKE_BINARY_DIR}/cblas.h"
 	DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/cblas.h
 	)
-	add_dependencies( ${OpenBLAS_LIBNAME} gencblas)
+
+	add_dependencies(gencblas ${OpenBLAS_LIBNAME})
+
 	install (FILES ${CMAKE_BINARY_DIR}/cblas.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 endif()
 
@@ -265,7 +270,6 @@ if(NOT NO_LAPACKE)
 	add_dependencies( ${OpenBLAS_LIBNAME} genlapacke)
 	FILE(GLOB_RECURSE INCLUDE_FILES "${CMAKE_CURRENT_SOURCE_DIR}/lapack-netlib/LAPACKE/*.h")
 	install (FILES ${INCLUDE_FILES} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
- 
  
 	ADD_CUSTOM_TARGET(genlapacke
 	COMMAND cp ${CMAKE_CURRENT_SOURCE_DIR}/lapack-netlib/LAPACKE/include/lapacke_mangling_with_flags.h.in "${CMAKE_BINARY_DIR}/lapacke_mangling.h"
@@ -282,15 +286,3 @@ if(PKG_CONFIG_FOUND)
 	configure_file(${PROJECT_SOURCE_DIR}/cmake/openblas.pc.in ${PROJECT_BINARY_DIR}/openblas.pc @ONLY)
 	install (FILES ${PROJECT_BINARY_DIR}/openblas.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig/)
 endif()
-
-# build dependencies graph
-# add_dependencies(genconfig gen_config_h genf77blas gencblas)
-add_dependencies(genconfig genf77blas gencblas)
-add_dependencies(interface genconfig)
-add_dependencies(kernel genconfig)
-add_dependencies(driver_level2 genconfig)
-add_dependencies(driver_level3 genconfig)
-add_dependencies(driver_others genconfig)
-add_dependencies(${OpenBLAS_LIBNAME} kernel driver_level2 driver_level3 driver_others interface)
-add_dependencies(openblas_utest ${OpenBLAS_LIBNAME})
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -252,7 +252,8 @@ if(NOT NO_CBLAS)
 	message (STATUS "Generating cblas.h in ${CMAKE_INSTALL_INCLUDEDIR}")
 
 	ADD_CUSTOM_TARGET(gencblas
-	COMMAND ${SED} 's/common/openblas_config/g' ${CMAKE_CURRENT_SOURCE_DIR}/cblas.h > "${CMAKE_BINARY_DIR}/cblas.h"
+	COMMAND ${SED} 's/common/openblas_config/g' ${CMAKE_CURRENT_SOURCE_DIR}/cblas.h > "${CMAKE_BINARY_DIR}/cblas.tmp"
+	COMMAND cp "${CMAKE_BINARY_DIR}/cblas.tmp" "${CMAKE_BINARY_DIR}/cblas.h"
 	DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/cblas.h
 	)
 	add_dependencies( ${OpenBLAS_LIBNAME} gencblas)

--- a/cmake/system.cmake
+++ b/cmake/system.cmake
@@ -312,6 +312,8 @@ endif ()
 
 set(AWK awk)
 
+set(SED sed)
+
 set(REVISION "-r${OpenBLAS_VERSION}")
 set(MAJOR_VERSION ${OpenBLAS_MAJOR_VERSION})
 

--- a/driver/others/memory.c
+++ b/driver/others/memory.c
@@ -1479,12 +1479,30 @@ static int on_process_term(void)
 #else
 #pragma comment(linker, "/INCLUDE:__tls_used")
 #endif
-#pragma data_seg(push, old_seg)
+
+#ifdef _WIN64
+#pragma const_seg(".CRT$XLB")
+#else
 #pragma data_seg(".CRT$XLB")
+#endif
 static void (APIENTRY *dll_callback)(HINSTANCE h, DWORD ul_reason_for_call, PVOID pv) = DllMain;
+#ifdef _WIN64
+#pragma const_seg()
+#else
+#pragma data_seg()
+#endif
+
+#ifdef _WIN64
+#pragma const_seg(".CRT$XTU")
+#else
 #pragma data_seg(".CRT$XTU")
+#endif
 static int(*p_process_term)(void) = on_process_term;
-#pragma data_seg(pop, old_seg)
+#ifdef _WIN64
+#pragma const_seg()
+#else
+#pragma data_seg()
+#endif
 #endif
 
 #if (defined(C_PGI) || (!defined(C_SUN) && defined(F_INTERFACE_SUN))) && (defined(ARCH_X86) || defined(ARCH_X86_64))

--- a/gen_config_h.c
+++ b/gen_config_h.c
@@ -16,7 +16,7 @@ s=fgets(line,80,fp);
 if (s== NULL) break;
 memset(line2,0,80);
 i=sscanf(line,"#define %70c",line2);
-if (i>0) {
+if (i!=0) {
 	fprintf(stdout,"#define OPENBLAS_%s",line2);
 } else {
 	fprintf(stdout,"\n");

--- a/utest/CMakeLists.txt
+++ b/utest/CMakeLists.txt
@@ -31,7 +31,7 @@ endforeach()
 if (MSVC)
 add_custom_command(TARGET ${OpenBLAS_utest_bin}
           POST_BUILD
-          COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_BINARY_DIR}/lib/${OpenBLAS_LIBNAME}.dll ${CMAKE_CURRENT_BINARY_DIR}/.
+          COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_BINARY_DIR}/lib/$<CONFIG>/${OpenBLAS_LIBNAME}.dll ${CMAKE_CURRENT_BINARY_DIR}/.
 )
 endif()
 


### PR DESCRIPTION
This change adds 64 bit build support for Microsoft Visual Studio. 
Debug and Retail builds are built in separate directories for MSVC.
PDB symbols are generated for both Debug and Retail.
Added dependencies so that building ALL_BUILD in MSVC builds everything in the right order and only needs to be done once.
Fixed an issue with gen_config_h where the Microsoft scanf returns a different value than gnu scanf when hitting the EOL marker.
gen_config_h.exe is built during cmake like getarch.exe and getarch_2nd.exe.  I'm doing this to enable Windows UWP build support later.