### PR TITLE
Fix calculated range limit exceeding actual data size for last thread

### DIFF
--- a/driver/level2/gbmv_thread.c
+++ b/driver/level2/gbmv_thread.c
@@ -233,6 +233,7 @@ int CNAME(BLASLONG m, BLASLONG n, BLASLONG ku, BLASLONG kl, FLOAT *alpha, FLOAT 
 #else
     range_m[num_cpu] = num_cpu * ((n + 15) & ~15);
 #endif
+    if (range_m[num_cpu] > n) range_m[num_cpu] = n;
 
     queue[num_cpu].mode    = mode;
     queue[num_cpu].routine = gbmv_kernel;

--- a/driver/level2/sbmv_thread.c
+++ b/driver/level2/sbmv_thread.c
@@ -246,6 +246,7 @@ int CNAME(BLASLONG n, BLASLONG k, FLOAT *alpha, FLOAT *a, BLASLONG lda, FLOAT *x
 
       range_m[MAX_CPU_NUMBER - num_cpu - 1] = range_m[MAX_CPU_NUMBER - num_cpu] - width;
       range_n[num_cpu] = num_cpu * (((n + 15) & ~15) + 16);
+      if (range_n[num_cpu] > n) range_n[num_cpu] = n;
 
       queue[num_cpu].mode    = mode;
       queue[num_cpu].routine = sbmv_kernel;
@@ -285,6 +286,7 @@ int CNAME(BLASLONG n, BLASLONG k, FLOAT *alpha, FLOAT *a, BLASLONG lda, FLOAT *x
 
       range_m[num_cpu + 1] = range_m[num_cpu] + width;
       range_n[num_cpu] = num_cpu * (((n + 15) & ~15) + 16);
+      if (range_n[num_cpu] > n) range_n[num_cpu] = n;
 
       queue[num_cpu].mode    = mode;
       queue[num_cpu].routine = sbmv_kernel;

--- a/driver/level2/tbmv_thread.c
+++ b/driver/level2/tbmv_thread.c
@@ -288,6 +288,7 @@ int CNAME(BLASLONG n, BLASLONG k, FLOAT *a, BLASLONG lda, FLOAT *x, BLASLONG inc
 
       range_m[MAX_CPU_NUMBER - num_cpu - 1] = range_m[MAX_CPU_NUMBER - num_cpu] - width;
       range_n[num_cpu] = num_cpu * (((n + 15) & ~15) + 16);
+      if (range_n[num_cpu] > n) range_n[num_cpu] = n;
 
       queue[num_cpu].mode    = mode;
       queue[num_cpu].routine = trmv_kernel;
@@ -327,6 +328,7 @@ int CNAME(BLASLONG n, BLASLONG k, FLOAT *a, BLASLONG lda, FLOAT *x, BLASLONG inc
 
       range_m[num_cpu + 1] = range_m[num_cpu] + width;
       range_n[num_cpu] = num_cpu * (((n + 15) & ~15) + 16);
+      if (range_n[num_cpu] > n) range_n[num_cpu] = n;
 
       queue[num_cpu].mode    = mode;
       queue[num_cpu].routine = trmv_kernel;
@@ -356,6 +358,7 @@ int CNAME(BLASLONG n, BLASLONG k, FLOAT *a, BLASLONG lda, FLOAT *x, BLASLONG inc
 
       range_m[num_cpu + 1] = range_m[num_cpu] + width;
       range_n[num_cpu] = num_cpu * (((n + 15) & ~15) + 16);
+      if (range_n[num_cpu] > n) range_n[num_cpu] = n;
 
       queue[num_cpu].mode    = mode;
       queue[num_cpu].routine = trmv_kernel;


### PR DESCRIPTION
Fixes at least the valgrind error from #1089 (though actually the bit operations there or perhaps in the corresponding buffer size calculations should be fixed to avoid this)