### PR TITLE
Travis: Rewrite config, build and test also on Alpine Linux (musl libc)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,67 @@
+# XXX: Precise is already deprecated, new default is Trusty.
+# https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming
+dist: precise
+sudo: false
 language: c
+compiler: gcc
+
+jobs:
+  include:
+    - &test-ubuntu
+      stage: test
+      addons:
+        apt:
+          packages:
+            - gfortran
+      script:
+        - set -e
+        - COMMON_FLAGS="DYNAMIC_ARCH=1 TARGET=NEHALEM NUM_THREADS=32"
+        - make QUIET_MAKE=1 $COMMON_FLAGS $BTYPE
+        - make -C test $COMMON_FLAGS $BTYPE
+        - make -C ctest $COMMON_FLAGS $BTYPE
+        - make -C utest $COMMON_FLAGS $BTYPE
+      env:
+        - TARGET_BOX=LINUX64
+        - BTYPE="BINARY=64"
+
+    - <<: *test-ubuntu
+      env:
+        - TARGET_BOX=LINUX64
+        - BTYPE="BINARY=64 USE_OPENMP=1"
+
+    - <<: *test-ubuntu
+      env:
+        - TARGET_BOX=LINUX64
+        - BTYPE="BINARY=64 INTERFACE64=1"
+
+    - <<: *test-ubuntu
+      addons:
+        apt:
+          packages:
+            - gcc-multilib
+            - gfortran-multilib
+      env:
+        - TARGET_BOX=LINUX32
+        - BTYPE="BINARY=32"
+
+    - stage: test
+      addons:
+        apt:
+          packages:
+            - binutils-mingw-w64-x86-64
+            - gcc-mingw-w64-x86-64
+            - gfortran-mingw-w64-x86-64
+      script:
+        - make QUIET_MAKE=1 DYNAMIC_ARCH=1 TARGET=NEHALEM NUM_THREADS=32 $BTYPE
+      env:
+        - TARGET_BOX=WIN64
+        - BTYPE="BINARY=64 HOSTCC=gcc CC=x86_64-w64-mingw32-gcc FC=x86_64-w64-mingw32-gfortran"
+
+# whitelist
+branches:
+  only:
+    - master
+    - develop
 
 notifications:
   webhooks:
@@ -7,32 +70,3 @@ notifications:
     on_success: change  # options: [always|never|change] default: always
     on_failure: always  # options: [always|never|change] default: always
     on_start: never     # options: [always|never|change] default: always
-
-compiler:
-  - gcc
-
-env:
-  - TARGET_BOX=LINUX64 BTYPE="BINARY=64"
-  - TARGET_BOX=LINUX64 BTYPE="BINARY=64 USE_OPENMP=1"
-  - TARGET_BOX=LINUX64 BTYPE="BINARY=64 INTERFACE64=1"
-  - TARGET_BOX=LINUX32 BTYPE="BINARY=32"
-  - TARGET_BOX=WIN64 BTYPE="BINARY=64 HOSTCC=gcc CC=x86_64-w64-mingw32-gcc FC=x86_64-w64-mingw32-gfortran"
-
-before_install:
- - sudo apt-get update -qq
- - sudo apt-get install -qq gfortran
- - if [[ "$TARGET_BOX" == "WIN64" ]]; then sudo apt-get install -qq binutils-mingw-w64-x86-64 gcc-mingw-w64-x86-64 gfortran-mingw-w64-x86-64; fi
- - if [[ "$TARGET_BOX" == "LINUX32" ]]; then sudo apt-get install -qq  gcc-multilib gfortran-multilib; fi
-
-script: 
- - set -e
- - make QUIET_MAKE=1 DYNAMIC_ARCH=1 TARGET=NEHALEM NUM_THREADS=32 $BTYPE
- - if [ "$TARGET_BOX" == "LINUX32" ] || [ "$TARGET_BOX" == "LINUX64" ]; then make -C test DYNAMIC_ARCH=1 TARGET=NEHALEM NUM_THREADS=32 $BTYPE; fi
- - if [ "$TARGET_BOX" == "LINUX32" ] || [ "$TARGET_BOX" == "LINUX64" ]; then make -C ctest DYNAMIC_ARCH=1 TARGET=NEHALEM NUM_THREADS=32 $BTYPE; fi
- - if [ "$TARGET_BOX" == "LINUX32" ] || [ "$TARGET_BOX" == "LINUX64" ]; then make -C utest DYNAMIC_ARCH=1 TARGET=NEHALEM NUM_THREADS=32 $BTYPE; fi
-
-# whitelist
-branches:
-  only:
-    - master
-    - develop

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,7 +87,10 @@ jobs:
         - TARGET_BOX=LINUX64_MUSL
         - BTYPE="BINARY=64"
 
-    - <<: *test-alpine
+    # XXX: This job segfaults in TESTS OF THE COMPLEX LEVEL 3 BLAS,
+    # so it's "allowed to fail" for now (see allow_failures).
+    - &test-alpine-openmp
+      <<: *test-alpine
       env:
         - TARGET_BOX=LINUX64_MUSL
         - BTYPE="BINARY=64 USE_OPENMP=1"

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,7 +77,9 @@ jobs:
       before_script: *common-before
       script:
         - set -e
+        # XXX: Disable some warnings for now to avoid exceeding Travis limit for log size.
         - alpine make QUIET_MAKE=1 $COMMON_FLAGS $BTYPE
+              CFLAGS="-Wno-misleading-indentation -Wno-sign-conversion -Wno-incompatible-pointer-types"
         - alpine make -C test $COMMON_FLAGS $BTYPE
         - alpine make -C ctest $COMMON_FLAGS $BTYPE
         - alpine make -C utest $COMMON_FLAGS $BTYPE

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,10 @@ jobs:
         apt:
           packages:
             - gfortran
+      before_script: &common-before
+        - COMMON_FLAGS="DYNAMIC_ARCH=1 TARGET=NEHALEM NUM_THREADS=32"
       script:
         - set -e
-        - COMMON_FLAGS="DYNAMIC_ARCH=1 TARGET=NEHALEM NUM_THREADS=32"
         - make QUIET_MAKE=1 $COMMON_FLAGS $BTYPE
         - make -C test $COMMON_FLAGS $BTYPE
         - make -C ctest $COMMON_FLAGS $BTYPE
@@ -51,11 +52,57 @@ jobs:
             - binutils-mingw-w64-x86-64
             - gcc-mingw-w64-x86-64
             - gfortran-mingw-w64-x86-64
+      before_script: *common-before
       script:
-        - make QUIET_MAKE=1 DYNAMIC_ARCH=1 TARGET=NEHALEM NUM_THREADS=32 $BTYPE
+        - make QUIET_MAKE=1 $COMMON_FLAGS $BTYPE
       env:
         - TARGET_BOX=WIN64
         - BTYPE="BINARY=64 HOSTCC=gcc CC=x86_64-w64-mingw32-gcc FC=x86_64-w64-mingw32-gfortran"
+
+    # Build & test on Alpine Linux inside chroot, i.e. on system with musl libc.
+    # These jobs needs sudo, so Travis runs them on VM-based infrastructure
+    # which is slower than container-based infrastructure used for jobs
+    # that don't require sudo.
+    - &test-alpine
+      stage: test
+      dist: trusty
+      sudo: true
+      language: minimal
+      before_install:
+        - "wget 'https://raw.githubusercontent.com/alpinelinux/alpine-chroot-install/v0.6.0/alpine-chroot-install' \
+              && echo 'a827a4ba3d0817e7c88bae17fe34e50204983d1e  alpine-chroot-install' | sha1sum -c || exit 1"
+        - alpine() { /alpine/enter-chroot -u "$USER" "$@"; }
+      install:
+        - sudo sh alpine-chroot-install -p 'build-base gfortran perl linux-headers'
+      before_script: *common-before
+      script:
+        - set -e
+        - alpine make QUIET_MAKE=1 $COMMON_FLAGS $BTYPE
+        - alpine make -C test $COMMON_FLAGS $BTYPE
+        - alpine make -C ctest $COMMON_FLAGS $BTYPE
+        - alpine make -C utest $COMMON_FLAGS $BTYPE
+      env:
+        - TARGET_BOX=LINUX64_MUSL
+        - BTYPE="BINARY=64"
+
+    - <<: *test-alpine
+      env:
+        - TARGET_BOX=LINUX64_MUSL
+        - BTYPE="BINARY=64 USE_OPENMP=1"
+
+    - <<: *test-alpine
+      env:
+        - TARGET_BOX=LINUX64_MUSL
+        - BTYPE="BINARY=64 INTERFACE64=1"
+
+    # Build with the same flags as Alpine do in OpenBLAS package.
+    - <<: *test-alpine
+      env:
+        - TARGET_BOX=LINUX64_MUSL
+        - BTYPE="BINARY=64 NO_AFFINITY=1 USE_OPENMP=0 NO_LAPACK=0 TARGET=core2"
+
+  allow_failures:
+    - <<: *test-alpine-openmp
 
 # whitelist
 branches:


### PR DESCRIPTION
1. Refactores `.travis.yml` to use Travis Build Stages. This allows to define jobs with very different configuration in more clean way.
2. Replaces `sudo apt-get` with [APT addon](https://docs.travis-ci.com/user/installing-dependencies/#Installing-Packages-with-the-APT-Addon). Since sudo is not needed anymore, it runs on Travis containers-based infrastructure that is much faster than their VMs infrastructure (used when sudo is needed).
3. Adds jobs that build and test OpenBLAS on Alpine Linux v3.6 (inside chroot), i.e. verify that it works with musl libc. I hope that this will help to avoid errors like #1252 in future.

You’ve been still running on Ubuntu Presty builders, but new default is Trusty ([read more](https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming)). Thus I‘ve explicitly set `dist: presty` to let it stay on Presty, to not change build environment by this commit.

Alpine jobs needs sudo (for chroot), so they run on VMs infrastructure. That’s why they are much slower than other jobs.