### PR TITLE
Revert "Fix calculated range limit exceeding actual data size for last thread"

### DIFF
--- a/driver/level2/gbmv_thread.c
+++ b/driver/level2/gbmv_thread.c
@@ -233,7 +233,6 @@ int CNAME(BLASLONG m, BLASLONG n, BLASLONG ku, BLASLONG kl, FLOAT *alpha, FLOAT 
 #else
     range_m[num_cpu] = num_cpu * ((n + 15) & ~15);
 #endif
-    if (range_m[num_cpu] > n) range_m[num_cpu] = n;
 
     queue[num_cpu].mode    = mode;
     queue[num_cpu].routine = gbmv_kernel;

--- a/driver/level2/sbmv_thread.c
+++ b/driver/level2/sbmv_thread.c
@@ -246,7 +246,6 @@ int CNAME(BLASLONG n, BLASLONG k, FLOAT *alpha, FLOAT *a, BLASLONG lda, FLOAT *x
 
       range_m[MAX_CPU_NUMBER - num_cpu - 1] = range_m[MAX_CPU_NUMBER - num_cpu] - width;
       range_n[num_cpu] = num_cpu * (((n + 15) & ~15) + 16);
-      if (range_n[num_cpu] > n) range_n[num_cpu] = n;
 
       queue[num_cpu].mode    = mode;
       queue[num_cpu].routine = sbmv_kernel;
@@ -286,7 +285,6 @@ int CNAME(BLASLONG n, BLASLONG k, FLOAT *alpha, FLOAT *a, BLASLONG lda, FLOAT *x
 
       range_m[num_cpu + 1] = range_m[num_cpu] + width;
       range_n[num_cpu] = num_cpu * (((n + 15) & ~15) + 16);
-      if (range_n[num_cpu] > n) range_n[num_cpu] = n;
 
       queue[num_cpu].mode    = mode;
       queue[num_cpu].routine = sbmv_kernel;

--- a/driver/level2/tbmv_thread.c
+++ b/driver/level2/tbmv_thread.c
@@ -288,7 +288,6 @@ int CNAME(BLASLONG n, BLASLONG k, FLOAT *a, BLASLONG lda, FLOAT *x, BLASLONG inc
 
       range_m[MAX_CPU_NUMBER - num_cpu - 1] = range_m[MAX_CPU_NUMBER - num_cpu] - width;
       range_n[num_cpu] = num_cpu * (((n + 15) & ~15) + 16);
-      if (range_n[num_cpu] > n) range_n[num_cpu] = n;
 
       queue[num_cpu].mode    = mode;
       queue[num_cpu].routine = trmv_kernel;
@@ -328,7 +327,6 @@ int CNAME(BLASLONG n, BLASLONG k, FLOAT *a, BLASLONG lda, FLOAT *x, BLASLONG inc
 
       range_m[num_cpu + 1] = range_m[num_cpu] + width;
       range_n[num_cpu] = num_cpu * (((n + 15) & ~15) + 16);
-      if (range_n[num_cpu] > n) range_n[num_cpu] = n;
 
       queue[num_cpu].mode    = mode;
       queue[num_cpu].routine = trmv_kernel;
@@ -358,7 +356,6 @@ int CNAME(BLASLONG n, BLASLONG k, FLOAT *a, BLASLONG lda, FLOAT *x, BLASLONG inc
 
       range_m[num_cpu + 1] = range_m[num_cpu] + width;
       range_n[num_cpu] = num_cpu * (((n + 15) & ~15) + 16);
-      if (range_n[num_cpu] > n) range_n[num_cpu] = n;
 
       queue[num_cpu].mode    = mode;
       queue[num_cpu].routine = trmv_kernel;


### PR DESCRIPTION
Reverts xianyi/OpenBLAS#1254 - at least the changes to tbmv_thread.c appear to have caused accuracy errors (the dreaded "LESS THAN HALF ACCURATE) in the ctest that I somehow happened to miss, sorry.