### PR TITLE
arm64: make iamax kernel buildable by clang

### DIFF
--- a/kernel/arm64/iamax_thunderx2t99.c
+++ b/kernel/arm64/iamax_thunderx2t99.c
@@ -208,7 +208,8 @@ extern int blas_level1_thread_with_return_value(int mode, BLASLONG m, BLASLONG n
 #endif
 
 
-static BLASLONG iamax_compute(BLASLONG n, FLOAT *x, BLASLONG inc_x)
+static BLASLONG __attribute__((noinline)) iamax_compute(BLASLONG n, FLOAT *x,
+								BLASLONG inc_x)
 {
 	BLASLONG index = 0;
 


### PR DESCRIPTION
Here's the patch we had to make to get OpenBLAS to build with clang (and flang) for the thunderx2 target. Basically, prevent the compiler unrolling this function, which contains inline asm with a label that is assumed "local".