### PR TITLE
ARM: recognize gfortran pre-releases

### DIFF
--- a/f_check
+++ b/f_check
@@ -71,7 +71,7 @@ if ($compiler eq "") {
 
 	if ($data =~ /GNU/) {
 
-	    $data =~ /(\d)\.(\d).(\d)/;
+	    $data =~ /(\d)\.(\d).(.)/;
 	    $major = $1;
 	    $minor = $2;
 


### PR DESCRIPTION
Without proper recognition of gfortran versions such as

> GNU Fortran (GCC) 4.9.x 20150123 (prerelease)

OpenBLAS assumes the presence of the G77 compiler. Consequently,
`-lgfortran` is missing from the pkg-config file.

The aforementioned compiler is the gfortran compiler in the Android repo
in a commit tagged as `ndk-r14`, cf. [Paul Mustière's gfortran build
instructions for Android](https://github.com/buffer51/android-gfortran).