### PR TITLE
ARM: do not add linker flag `-lm` unconditionally

### DIFF
--- a/Makefile.system
+++ b/Makefile.system
@@ -242,10 +242,6 @@ EXTRALIB	+= -lm
 NO_EXPRECISION = 1
 endif
 
-ifeq ($(OSNAME), Android)
-EXTRALIB	+= -lm
-endif
-
 ifeq ($(OSNAME), AIX)
 EXTRALIB	+= -lm
 endif


### PR DESCRIPTION
On ARM the required math library depends on whether the soft floating-point ABI is used or not but this is already handled in [`Makefile.system`, lines 499-505](https://github.com/xianyi/OpenBLAS/blob/e6b9b660c38372b52b707a6a670677554fe77efb/Makefile.system#L499-L505).