### PR TITLE
Make: fix installation instructions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,9 @@ SUBDIRS_ALL = $(SUBDIRS) test ctest utest exports benchmark ../laswp ../bench
 .PHONY : all libs netlib $(RELA) test ctest shared install
 .NOTPARALLEL : all libs $(RELA) prof lapack-test install blas-test
 
+# source: https://stackoverflow.com/questions/52674/simplest-way-to-reverse-the-order-of-strings-in-a-make-variable/14260762#14260762
+reverse = $(if $(wordlist 2,2,$(1)),$(call reverse,$(wordlist 2,$(words $(1)),$(1))) $(firstword $(1)),$(1))
+
 all :: libs netlib $(RELA) tests shared
 	@echo
 	@echo " OpenBLAS build complete. ($(LIB_COMPONENTS))"
@@ -82,8 +85,7 @@ ifeq ($(OSNAME), Darwin)
 endif
 	@echo
 	@echo "To install the library, you can run"
-	@echo "  make <ARGS> PREFIX=/path/to/your/installation install"
-	@echo "where '<ARGS>' is the set of argument used for compilation."
+	@echo "  make $(call reverse,$(MAKEFLAGS)) PREFIX=/path/to/your/installation install"
 
 shared :
 ifndef NO_SHARED

--- a/Makefile
+++ b/Makefile
@@ -81,8 +81,9 @@ ifeq ($(OSNAME), Darwin)
 	@echo "install_name_tool -id /new/absolute/path/to/$(LIBDYNNAME) $(LIBDYNNAME)"
 endif
 	@echo
-	@echo "To install the library, you can run \"make PREFIX=/path/to/your/installation install\"."
-	@echo
+	@echo "To install the library, you can run"
+	@echo "  make <ARGS> PREFIX=/path/to/your/installation install"
+	@echo "where '<ARGS>' is the set of argument used for compilation."
 
 shared :
 ifndef NO_SHARED


### PR DESCRIPTION
The installation instructions as shown after successfully compiling
OpenBLAS are wrong because this arguments used during compilation have
to be provided to Make again.