### PR TITLE
fix detection of generic ARMv8 CPUs

### DIFF
--- a/cpuid_arm64.c
+++ b/cpuid_arm64.c
@@ -142,7 +142,7 @@ int detect(void)
   	if(p != NULL)
 	{
 
-		if (strstr(p, "AArch64"))
+		if ((strstr(p, "AArch64")) || (strstr(p, "8")))
 		{
 			return CPU_ARMV8;
 


### PR DESCRIPTION
If I can see right on our systems, then all ARMv8 CPUs have "8" as value for "CPU architecture" in /proc/cpuinfo. This change unblocks building OpenBLAS on APM Mustang system (X-Gene CPU).