### PR TITLE
(Plain make) build system fixes for AIX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,9 +28,6 @@ SUBDIRS_ALL = $(SUBDIRS) test ctest utest exports benchmark ../laswp ../bench
 .PHONY : all libs netlib $(RELA) test ctest shared install
 .NOTPARALLEL : all libs $(RELA) prof lapack-test install blas-test
 
-# source: https://stackoverflow.com/questions/52674/simplest-way-to-reverse-the-order-of-strings-in-a-make-variable/14260762#14260762
-reverse = $(if $(wordlist 2,2,$(1)),$(call reverse,$(wordlist 2,$(words $(1)),$(1))) $(firstword $(1)),$(1))
-
 all :: libs netlib $(RELA) tests shared
 	@echo
 	@echo " OpenBLAS build complete. ($(LIB_COMPONENTS))"
@@ -84,8 +81,8 @@ ifeq ($(OSNAME), Darwin)
 	@echo "install_name_tool -id /new/absolute/path/to/$(LIBDYNNAME) $(LIBDYNNAME)"
 endif
 	@echo
-	@echo "To install the library, you can run"
-	@echo "  make $(call reverse,$(MAKEFLAGS)) PREFIX=/path/to/your/installation install"
+	@echo "To install the library, you can run \"make PREFIX=/path/to/your/installation install\"."
+	@echo
 
 shared :
 ifndef NO_SHARED
@@ -245,7 +242,7 @@ ifndef NOFORTRAN
 	-@echo "CC          = $(CC)" >> $(NETLIB_LAPACK_DIR)/make.inc
 	-@echo "override CFLAGS      = $(LAPACK_CFLAGS)" >> $(NETLIB_LAPACK_DIR)/make.inc
 	-@echo "ARCH        = $(AR)" >> $(NETLIB_LAPACK_DIR)/make.inc
-	-@echo "ARCHFLAGS   = -ru" >> $(NETLIB_LAPACK_DIR)/make.inc
+	-@echo "ARCHFLAGS   = $(ARFLAGS) -ru" >> $(NETLIB_LAPACK_DIR)/make.inc
 	-@echo "RANLIB      = $(RANLIB)" >> $(NETLIB_LAPACK_DIR)/make.inc
 	-@echo "LAPACKLIB   = ../$(LIBNAME)" >> $(NETLIB_LAPACK_DIR)/make.inc
 	-@echo "TMGLIB      = ../$(LIBNAME)" >> $(NETLIB_LAPACK_DIR)/make.inc

--- a/Makefile.system
+++ b/Makefile.system
@@ -242,6 +242,10 @@ EXTRALIB	+= -lm
 NO_EXPRECISION = 1
 endif
 
+ifeq ($(OSNAME), Android)
+EXTRALIB	+= -lm
+endif
+
 ifeq ($(OSNAME), AIX)
 EXTRALIB	+= -lm
 endif
@@ -571,10 +575,12 @@ endif
 endif
 
 ifndef BINARY_DEFINED
+ifneq ($(OSNAME), AIX)
 ifdef BINARY64
 CCOMMON_OPT += -m64
 else
 CCOMMON_OPT += -m32
+endif
 endif
 endif
 
@@ -621,10 +627,12 @@ ifeq ($(F_COMPILER), G77)
 CCOMMON_OPT += -DF_INTERFACE_G77
 FCOMMON_OPT += -Wall
 ifndef NO_BINARY_MODE
+ifneq ($(OSNAME), AIX)
 ifdef BINARY64
 FCOMMON_OPT += -m64
 else
 FCOMMON_OPT += -m32
+endif
 endif
 endif
 endif
@@ -632,11 +640,13 @@ endif
 ifeq ($(F_COMPILER), G95)
 CCOMMON_OPT += -DF_INTERFACE_G95
 FCOMMON_OPT += -Wall
+ifneq ($(OSNAME), AIX)
 ifndef NO_BINARY_MODE
 ifdef BINARY64
 FCOMMON_OPT += -m64
 else
 FCOMMON_OPT += -m32
+endif
 endif
 endif
 endif
@@ -660,14 +670,18 @@ FCOMMON_OPT += -mabi=32
 endif
 else
 ifdef BINARY64
+ifneq ($(OSNAME), AIX)
 FCOMMON_OPT += -m64
+endif
 ifdef INTERFACE64
 ifneq ($(INTERFACE64), 0)
 FCOMMON_OPT +=  -fdefault-integer-8
 endif
 endif
 else
+ifneq ($(OSNAME), AIX)
 FCOMMON_OPT += -m32
+endif
 endif
 endif
 ifeq ($(USE_OPENMP), 1)

--- a/f_check
+++ b/f_check
@@ -71,7 +71,7 @@ if ($compiler eq "") {
 
 	if ($data =~ /GNU/) {
 
-	    $data =~ /(\d)\.(\d).(.)/;
+	    $data =~ /(\d)\.(\d).(\d)/;
 	    $major = $1;
 	    $minor = $2;
 
@@ -233,6 +233,10 @@ if (!$?) {
 	if ($?) {
 	    $link = `$compiler $openmp -q32 -v ftest2.f 2>&1 && rm -f a.out a.exe`;
 	}
+        # for AIX
+	if ($?) {
+	    $link = `$compiler $openmp -maix32 -v ftest2.f 2>&1 && rm -f a.out a.exe`;
+	}
        #For gfortran MIPS
 	if ($?) {
     $mips_data = `$compiler_bin -E -dM - < /dev/null`;
@@ -249,6 +253,10 @@ if (!$?) {
 	$link = `$compiler $openmp -m64 -v ftest2.f 2>&1 && rm -f a.out a.exe`;
 	if ($?) {
 	    $link = `$compiler $openmp -q64 -v ftest2.f 2>&1 && rm -f a.out a.exe`;
+	}
+        # for AIX
+	if ($?) {
+	    $link = `$compiler $openmp -maix64 -v ftest2.f 2>&1 && rm -f a.out a.exe`;
 	}
        #For gfortran MIPS
 	if ($?) {

--- a/make.inc
+++ b/make.inc
@@ -1,6 +1,6 @@
 SHELL = /bin/sh
 PLAT = _LINUX
 DRVOPTS  = $(NOOPT)
-ARCHFLAGS= -ru
+#ARCHFLAGS= $(ARFLAGS) -ru
 #RANLIB   = ranlib
 


### PR DESCRIPTION
fixes from #463:
- retry fortran compiler test with aix-specific option if generic -m32/-m64 fails
- pass any custom ARFLAGS to lapack
- no addition of -m32/-m64 to the CFLAGS and FFLAGS on AIX