### PR TITLE
Output an error message when shmat() fails

### DIFF
--- a/driver/others/init.c
+++ b/driver/others/init.c
@@ -78,6 +78,8 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <sys/sysinfo.h>
 #include <sys/syscall.h>
+#include <sys/types.h>
+#include <errno.h>
 #include <sys/shm.h>
 #include <fcntl.h>
 #include <sched.h>
@@ -659,8 +661,9 @@ static void open_shmem(void) {
     exit(1);
   }
 
-  if (shmid != -1) common = (shm_t *)shmat(shmid, NULL, 0);
-
+  if (shmid != -1) {
+  if ( (common = shmat(shmid, NULL, 0)) == (void*)-1) perror ("Attaching shared memory segment");
+  }
 #ifdef DEBUG
   fprintf(stderr, "Shared Memory id = %x  Address = %p\n", shmid, common);
 #endif


### PR DESCRIPTION
Observed in #1351 with SELinux as the likely culprit. Without the message, the user saw a segfault with no apparent reason