### PR TITLE
Clean up spurious unused variables in the kernels

### DIFF
--- a/kernel/generic/zimatcopy_cnc.c
+++ b/kernel/generic/zimatcopy_cnc.c
@@ -35,7 +35,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 int CNAME(BLASLONG rows, BLASLONG cols, FLOAT alpha_r, FLOAT alpha_i, FLOAT *a, BLASLONG lda)
 {
 	BLASLONG i,j,ia;
-	FLOAT *aptr,*bptr; 
+	FLOAT *aptr; 
     FLOAT a0, a1;
 
 	if ( rows <= 0     )  return(0);

--- a/kernel/generic/zimatcopy_rn.c
+++ b/kernel/generic/zimatcopy_rn.c
@@ -34,7 +34,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 int CNAME(BLASLONG rows, BLASLONG cols, FLOAT alpha_r, FLOAT alpha_i, FLOAT *a, BLASLONG lda)
 {
 	BLASLONG i,j,ia;
-	FLOAT *aptr,*bptr;
+	FLOAT *aptr;
     FLOAT a0, a1; 
 
 	if ( rows <= 0     )  return(0);

--- a/kernel/generic/zimatcopy_rnc.c
+++ b/kernel/generic/zimatcopy_rnc.c
@@ -34,7 +34,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 int CNAME(BLASLONG rows, BLASLONG cols, FLOAT alpha_r, FLOAT alpha_i, FLOAT *a, BLASLONG lda)
 {
 	BLASLONG i,j,ia;
-	FLOAT *aptr,*bptr;
+	FLOAT *aptr;
     FLOAT a0, a1; 
 
 	if ( rows <= 0     )  return(0);

--- a/kernel/setparam-ref.c
+++ b/kernel/setparam-ref.c
@@ -684,6 +684,9 @@ static void init_parameter(void) {
 
   int l2 = get_l2_size();
 
+  (void) l2; /* dirty trick to suppress unused variable warning for targets */
+             /* where the GEMM unrolling parameters do not depend on l2 */
+  
   TABLE_NAME.sgemm_q = SGEMM_DEFAULT_Q;
   TABLE_NAME.dgemm_q = DGEMM_DEFAULT_Q;
   TABLE_NAME.cgemm_q = CGEMM_DEFAULT_Q;

--- a/kernel/x86_64/cgemv_n_4.c
+++ b/kernel/x86_64/cgemv_n_4.c
@@ -216,7 +216,6 @@ static void add_y(BLASLONG n, FLOAT *src, FLOAT *dest, BLASLONG inc_dest,FLOAT a
 int CNAME(BLASLONG m, BLASLONG n, BLASLONG dummy1, FLOAT alpha_r,FLOAT alpha_i, FLOAT *a, BLASLONG lda, FLOAT *x, BLASLONG inc_x, FLOAT *y, BLASLONG inc_y, FLOAT *buffer)
 {
 	BLASLONG i;
-	BLASLONG j;
 	FLOAT *a_ptr;
 	FLOAT *x_ptr;
 	FLOAT *y_ptr;

--- a/kernel/x86_64/dgemv_n_4.c
+++ b/kernel/x86_64/dgemv_n_4.c
@@ -204,7 +204,6 @@ static void add_y(BLASLONG n, FLOAT *src, FLOAT *dest, BLASLONG inc_dest)
 int CNAME(BLASLONG m, BLASLONG n, BLASLONG dummy1, FLOAT alpha, FLOAT *a, BLASLONG lda, FLOAT *x, BLASLONG inc_x, FLOAT *y, BLASLONG inc_y, FLOAT *buffer)
 {
 	BLASLONG i;
-	BLASLONG j;
 	FLOAT *a_ptr;
 	FLOAT *x_ptr;
 	FLOAT *y_ptr;

--- a/kernel/x86_64/dsymv_U.c
+++ b/kernel/x86_64/dsymv_U.c
@@ -164,7 +164,6 @@ int CNAME(BLASLONG m, BLASLONG offset, FLOAT alpha, FLOAT *a, BLASLONG lda, FLOA
 	FLOAT temp2;
 	FLOAT *xp, *yp;
 	FLOAT *a0,*a1,*a2,*a3;
-	FLOAT at0,at1,at2,at3;
 	FLOAT tmp1[4];
 	FLOAT tmp2[4];
 

--- a/kernel/x86_64/dtrmm_kernel_4x8_haswell.c
+++ b/kernel/x86_64/dtrmm_kernel_4x8_haswell.c
@@ -167,24 +167,28 @@ int CNAME(BLASLONG bm,BLASLONG bn,BLASLONG bk,FLOAT alpha,FLOAT* ba,FLOAT* bb,FL
 
    FLOAT res4_0;
    FLOAT res4_1;
+/*
    FLOAT res4_2;
    FLOAT res4_3;
-
+*/
    FLOAT res5_0;
    FLOAT res5_1;
+/*
    FLOAT res5_2;
    FLOAT res5_3;
-
+*/
    FLOAT res6_0;
    FLOAT res6_1;
+/*
    FLOAT res6_2;
    FLOAT res6_3;
-
+*/
    FLOAT res7_0;
    FLOAT res7_1;
+/*
    FLOAT res7_2;
    FLOAT res7_3;
-
+*/
    FLOAT a0;
    FLOAT a1;
 

--- a/kernel/x86_64/dtrsm_kernel_LN_bulldozer.c
+++ b/kernel/x86_64/dtrsm_kernel_LN_bulldozer.c
@@ -438,7 +438,9 @@ static inline void solve(BLASLONG m, BLASLONG n, FLOAT *a, FLOAT *b, FLOAT *c, B
       *(cj + i) = bb;
       b ++;
 
+/*
       BLASLONG i1 = i & -4 ;
+*/
       FLOAT t0,t1,t2,t3;
 
       k=0;

--- a/kernel/x86_64/sgemv_n_4.c
+++ b/kernel/x86_64/sgemv_n_4.c
@@ -292,7 +292,6 @@ static void add_y(BLASLONG n, FLOAT *src, FLOAT *dest, BLASLONG inc_dest)
 int CNAME(BLASLONG m, BLASLONG n, BLASLONG dummy1, FLOAT alpha, FLOAT *a, BLASLONG lda, FLOAT *x, BLASLONG inc_x, FLOAT *y, BLASLONG inc_y, FLOAT *buffer)
 {
 	BLASLONG i;
-	BLASLONG j;
 	FLOAT *a_ptr;
 	FLOAT *x_ptr;
 	FLOAT *y_ptr;

--- a/kernel/x86_64/ssymv_U.c
+++ b/kernel/x86_64/ssymv_U.c
@@ -164,7 +164,6 @@ int CNAME(BLASLONG m, BLASLONG offset, FLOAT alpha, FLOAT *a, BLASLONG lda, FLOA
 	FLOAT temp2;
 	FLOAT *xp, *yp;
 	FLOAT *a0,*a1,*a2,*a3;
-	FLOAT at0,at1,at2,at3;
 	FLOAT tmp1[4];
 	FLOAT tmp2[4];
 

--- a/kernel/x86_64/zgemv_n_4.c
+++ b/kernel/x86_64/zgemv_n_4.c
@@ -218,7 +218,6 @@ static void add_y(BLASLONG n, FLOAT *src, FLOAT *dest, BLASLONG inc_dest,FLOAT a
 int CNAME(BLASLONG m, BLASLONG n, BLASLONG dummy1, FLOAT alpha_r,FLOAT alpha_i, FLOAT *a, BLASLONG lda, FLOAT *x, BLASLONG inc_x, FLOAT *y, BLASLONG inc_y, FLOAT *buffer)
 {
 	BLASLONG i;
-	BLASLONG j;
 	FLOAT *a_ptr;
 	FLOAT *x_ptr;
 	FLOAT *y_ptr;


### PR DESCRIPTION
This removes most of the clutter of "unused variable X" warnings encountered in particular when doing dynamic arch builds. ref #1357