### PR TITLE
Fix compiler warnings in ctest

### DIFF
--- a/ctest/c_cblas1.c
+++ b/ctest/c_cblas1.c
@@ -9,7 +9,7 @@
 #include "common.h"
 #include "cblas_test.h"
 
-void F77_caxpy(const int *N, const void *alpha, void *X,
+void F77_caxpy(const int *N, OPENBLAS_CONST void *alpha, void *X,
                     const int *incX, void *Y, const int *incY)
 {
    cblas_caxpy(*N, alpha, X, *incX, Y, *incY);
@@ -58,13 +58,13 @@ void F77_cswap( const int *N, void *X, const int *incX,
    return;
 }
 
-int F77_icamax(const int *N, const void *X, const int *incX)
+int F77_icamax(const int *N, OPENBLAS_CONST void *X, const int *incX)
 {
    if (*N < 1 || *incX < 1) return(0);
    return (cblas_icamax(*N, X, *incX)+1);
 }
 
-float F77_scnrm2(const int *N, const void *X, const int *incX)
+float F77_scnrm2(const int *N, OPENBLAS_CONST void *X, const int *incX)
 {
    return cblas_scnrm2(*N, X, *incX);
 }

--- a/ctest/c_cblas2.c
+++ b/ctest/c_cblas2.c
@@ -9,9 +9,9 @@
 #include "cblas_test.h"
 
 void F77_cgemv(int *order, char *transp, int *m, int *n,
-          const void *alpha,
-          CBLAS_TEST_COMPLEX *a, int *lda, const void *x, int *incx,
-          const void *beta, void *y, int *incy) {
+          OPENBLAS_CONST void *alpha,
+          CBLAS_TEST_COMPLEX *a, int *lda, OPENBLAS_CONST void *x, int *incx,
+          OPENBLAS_CONST void *beta, void *y, int *incy) {
 
   CBLAS_TEST_COMPLEX *A;
   int i,j,LDA;

--- a/ctest/c_cblat2.f
+++ b/ctest/c_cblat2.f
@@ -349,13 +349,13 @@
            CALL CCHK3( SNAMES( ISNUM ), EPS, THRESH, NOUT, NTRA, TRACE,
      $                  REWI, FATAL, NIDIM, IDIM, NKB, KB, NINC, INC,
      $                  NMAX, INCMAX, A, AA, AS, Y, YY, YS, YT, G, Z,
-     $			0 )
+     $                  0 )
            END IF
            IF (RORDER) THEN
            CALL CCHK3( SNAMES( ISNUM ), EPS, THRESH, NOUT, NTRA, TRACE,
      $                  REWI, FATAL, NIDIM, IDIM, NKB, KB, NINC, INC,
      $                  NMAX, INCMAX, A, AA, AS, Y, YY, YS, YT, G, Z,
-     $			1 )
+     $                  1 )
            END IF
             GO TO 200
 *           Test CGERC, 12, CGERU, 13.
@@ -2660,7 +2660,7 @@
    50    CONTINUE
       END IF
 *
-   60 CONTINUE
+C   60 CONTINUE
       LCERES = .TRUE.
       GO TO 80
    70 CONTINUE

--- a/ctest/c_cblat3.f
+++ b/ctest/c_cblat3.f
@@ -329,13 +329,13 @@
             CALL CCHK3(SNAMES( ISNUM ), EPS, THRESH, NOUT, NTRA, TRACE,
      $                 REWI, FATAL, NIDIM, IDIM, NALF, ALF, NMAX, AB,
      $                 AA, AS, AB( 1, NMAX + 1 ), BB, BS, CT, G, C,
-     $		0 )
+     $          0 )
             END IF
             IF (RORDER) THEN
             CALL CCHK3(SNAMES( ISNUM ), EPS, THRESH, NOUT, NTRA, TRACE,
      $                 REWI, FATAL, NIDIM, IDIM, NALF, ALF, NMAX, AB,
      $                 AA, AS, AB( 1, NMAX + 1 ), BB, BS, CT, G, C,
-     $		1 )
+     $          1 )
             END IF
             GO TO 190
 *           Test CHERK, 06, CSYRK, 07.
@@ -357,13 +357,13 @@
             CALL CCHK5(SNAMES( ISNUM ), EPS, THRESH, NOUT, NTRA, TRACE,
      $                 REWI, FATAL, NIDIM, IDIM, NALF, ALF, NBET, BET,
      $                 NMAX, AB, AA, AS, BB, BS, C, CC, CS, CT, G, W,
-     $		0 )
+     $          0 )
             END IF
             IF (RORDER) THEN
             CALL CCHK5(SNAMES( ISNUM ), EPS, THRESH, NOUT, NTRA, TRACE,
      $                 REWI, FATAL, NIDIM, IDIM, NALF, ALF, NBET, BET,
      $                 NMAX, AB, AA, AS, BB, BS, C, CC, CS, CT, G, W,
-     $		1 )
+     $          1 )
             END IF
             GO TO 190
 *
@@ -707,9 +707,9 @@
  9998 FORMAT(' ******* FATAL ERROR - PARAMETER NUMBER ', I2, ' WAS CH',
      $      'ANGED INCORRECTLY *******' )
  9996 FORMAT( ' ******* ', A12,' FAILED ON CALL NUMBER:' )
- 9995 FORMAT( 1X, I6, ': ', A12,'(''', A1, ''',''', A1, ''',',
-     $     3( I3, ',' ), '(', F4.1, ',', F4.1, '), A,', I3, ', B,', I3,
-     $     ',(', F4.1, ',', F4.1, '), C,', I3, ').' )
+C 9995 FORMAT( 1X, I6, ': ', A12,'(''', A1, ''',''', A1, ''',',
+C     $     3( I3, ',' ), '(', F4.1, ',', F4.1, '), A,', I3, ', B,', I3,
+C     $     ',(', F4.1, ',', F4.1, '), C,', I3, ').' )
  9994 FORMAT(' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
 *
@@ -1033,9 +1033,9 @@
  9998 FORMAT(' ******* FATAL ERROR - PARAMETER NUMBER ', I2, ' WAS CH',
      $      'ANGED INCORRECTLY *******' )
  9996 FORMAT( ' ******* ', A12,' FAILED ON CALL NUMBER:' )
- 9995 FORMAT(1X, I6, ': ', A12,'(', 2( '''', A1, ''',' ), 2( I3, ',' ),
-     $      '(', F4.1, ',', F4.1, '), A,', I3, ', B,', I3, ',(', F4.1,
-     $      ',', F4.1, '), C,', I3, ')    .' )
+C 9995 FORMAT(1X, I6, ': ', A12,'(', 2( '''', A1, ''',' ), 2( I3, ',' ),
+C     $      '(', F4.1, ',', F4.1, '), A,', I3, ', B,', I3, ',(', F4.1,
+C     $      ',', F4.1, '), C,', I3, ')    .' )
  9994 FORMAT(' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
 *
@@ -1385,9 +1385,9 @@
  9998 FORMAT(' ******* FATAL ERROR - PARAMETER NUMBER ', I2, ' WAS CH',
      $      'ANGED INCORRECTLY *******' )
  9996 FORMAT(' ******* ', A12,' FAILED ON CALL NUMBER:' )
- 9995 FORMAT(1X, I6, ': ', A12,'(', 4( '''', A1, ''',' ), 2( I3, ',' ),
-     $     '(', F4.1, ',', F4.1, '), A,', I3, ', B,', I3, ')         ',
-     $      '      .' )
+C 9995 FORMAT(1X, I6, ': ', A12,'(', 4( '''', A1, ''',' ), 2( I3, ',' ),
+C     $     '(', F4.1, ',', F4.1, '), A,', I3, ', B,', I3, ')         ',
+C     $      '      .' )
  9994 FORMAT(' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
 *
@@ -1768,12 +1768,12 @@
      $      'ANGED INCORRECTLY *******' )
  9996 FORMAT( ' ******* ', A12,' FAILED ON CALL NUMBER:' )
  9995 FORMAT( '      THESE ARE THE RESULTS FOR COLUMN ', I3 )
- 9994 FORMAT(1X, I6, ': ', A12,'(', 2( '''', A1, ''',' ), 2( I3, ',' ),
-     $     F4.1, ', A,', I3, ',', F4.1, ', C,', I3, ')               ',
-     $      '          .' )
- 9993 FORMAT(1X, I6, ': ', A12,'(', 2( '''', A1, ''',' ), 2( I3, ',' ),
-     $      '(', F4.1, ',', F4.1, ') , A,', I3, ',(', F4.1, ',', F4.1,
-     $      '), C,', I3, ')          .' )
+C 9994 FORMAT(1X, I6, ': ', A12,'(', 2( '''', A1, ''',' ), 2( I3, ',' ),
+C     $     F4.1, ', A,', I3, ',', F4.1, ', C,', I3, ')               ',
+C     $      '          .' )
+C 9993 FORMAT(1X, I6, ': ', A12,'(', 2( '''', A1, ''',' ), 2( I3, ',' ),
+C     $      '(', F4.1, ',', F4.1, ') , A,', I3, ',(', F4.1, ',', F4.1,
+C     $      '), C,', I3, ')          .' )
  9992 FORMAT(' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
 *
@@ -2221,12 +2221,12 @@
      $      'ANGED INCORRECTLY *******' )
  9996 FORMAT( ' ******* ', A12,' FAILED ON CALL NUMBER:' )
  9995 FORMAT( '      THESE ARE THE RESULTS FOR COLUMN ', I3 )
- 9994 FORMAT(1X, I6, ': ', A12,'(', 2( '''', A1, ''',' ), 2( I3, ',' ),
-     $      '(', F4.1, ',', F4.1, '), A,', I3, ', B,', I3, ',', F4.1,
-     $      ', C,', I3, ')           .' )
- 9993 FORMAT(1X, I6, ': ', A12,'(', 2( '''', A1, ''',' ), 2( I3, ',' ),
-     $      '(', F4.1, ',', F4.1, '), A,', I3, ', B,', I3, ',(', F4.1,
-     $      ',', F4.1, '), C,', I3, ')    .' )
+C 9994 FORMAT(1X, I6, ': ', A12,'(', 2( '''', A1, ''',' ), 2( I3, ',' ),
+C     $      '(', F4.1, ',', F4.1, '), A,', I3, ', B,', I3, ',', F4.1,
+C     $      ', C,', I3, ')           .' )
+C 9993 FORMAT(1X, I6, ': ', A12,'(', 2( '''', A1, ''',' ), 2( I3, ',' ),
+C     $      '(', F4.1, ',', F4.1, '), A,', I3, ', B,', I3, ',(', F4.1,
+C     $      ',', F4.1, '), C,', I3, ')    .' )
  9992 FORMAT(' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
 *
@@ -2702,7 +2702,7 @@
    50    CONTINUE
       END IF
 *
-   60 CONTINUE
+C   60 CONTINUE
       LCERES = .TRUE.
       GO TO 80
    70 CONTINUE

--- a/ctest/c_dblas1.c
+++ b/ctest/c_dblas1.c
@@ -14,7 +14,7 @@ double F77_dasum(const int *N, double *X, const int *incX)
    return cblas_dasum(*N, X, *incX);
 }
 
-void F77_daxpy(const int *N, const double *alpha, const double *X,
+void F77_daxpy(const int *N, const double *alpha, OPENBLAS_CONST double *X,
                     const int *incX, double *Y, const int *incY)
 {
    cblas_daxpy(*N, *alpha, X, *incX, Y, *incY);
@@ -28,13 +28,13 @@ void F77_dcopy(const int *N, double *X, const int *incX,
    return;
 }
 
-double F77_ddot(const int *N, const double *X, const int *incX,
-                const double *Y, const int *incY)
+double F77_ddot(const int *N, OPENBLAS_CONST double *X, const int *incX,
+                OPENBLAS_CONST double *Y, const int *incY)
 {
    return cblas_ddot(*N, X, *incX, Y, *incY);
 }
 
-double F77_dnrm2(const int *N, const double *X, const int *incX)
+double F77_dnrm2(const int *N, OPENBLAS_CONST double *X, const int *incX)
 {
    return cblas_dnrm2(*N, X, *incX);
 }
@@ -72,12 +72,12 @@ double F77_dzasum(const int *N, void *X, const int *incX)
    return cblas_dzasum(*N, X, *incX);
 }
 
-double F77_dznrm2(const int *N, const void *X, const int *incX)
+double F77_dznrm2(const int *N, OPENBLAS_CONST void *X, const int *incX)
 {
    return cblas_dznrm2(*N, X, *incX);
 }
 
-int F77_idamax(const int *N, const double *X, const int *incX)
+int F77_idamax(const int *N, OPENBLAS_CONST double *X, const int *incX)
 {
    if (*N < 1 || *incX < 1) return(0);
    return (cblas_idamax(*N, X, *incX)+1);

--- a/ctest/c_dblat1.f
+++ b/ctest/c_dblat1.f
@@ -211,11 +211,11 @@
             IF (ICASE.EQ.7) THEN
 *              .. DNRM2TEST ..
                STEMP(1) = DTRUE1(NP1)
-               CALL STEST1(DNRM2TEST(N,SX,INCX),STEMP,STEMP,SFAC)
+               CALL STEST1(DNRM2TEST(N,SX,INCX),STEMP(1),STEMP,SFAC)
             ELSE IF (ICASE.EQ.8) THEN
 *              .. DASUMTEST ..
                STEMP(1) = DTRUE3(NP1)
-               CALL STEST1(DASUMTEST(N,SX,INCX),STEMP,STEMP,SFAC)
+               CALL STEST1(DASUMTEST(N,SX,INCX),STEMP(1),STEMP,SFAC)
             ELSE IF (ICASE.EQ.9) THEN
 *              .. DSCALTEST ..
                CALL DSCALTEST(N,SA((INCX-1)*5+NP1),SX,INCX)

--- a/ctest/c_dblat2.f
+++ b/ctest/c_dblat2.f
@@ -345,13 +345,13 @@
             CALL DCHK3( SNAMES( ISNUM ), EPS, THRESH, NOUT, NTRA, TRACE,
      $                  REWI, FATAL, NIDIM, IDIM, NKB, KB, NINC, INC,
      $                  NMAX, INCMAX, A, AA, AS, Y, YY, YS, YT, G, Z,
-     $			0 )
+     $                  0 )
             END IF
             IF (RORDER) THEN
             CALL DCHK3( SNAMES( ISNUM ), EPS, THRESH, NOUT, NTRA, TRACE,
      $                  REWI, FATAL, NIDIM, IDIM, NKB, KB, NINC, INC,
      $                  NMAX, INCMAX, A, AA, AS, Y, YY, YS, YT, G, Z,
-     $			1 )
+     $                  1 )
             END IF
             GO TO 200
 *           Test DGER, 12.
@@ -797,9 +797,9 @@
      $ ' (', I6, ' CALL', 'S)' )
  9998 FORMAT( ' ******* FATAL ERROR - PARAMETER NUMBER ', I2, ' WAS CH',
      $      'ANGED INCORRECTLY *******' )
- 9997 FORMAT( ' ',A12, ' COMPLETED THE COMPUTATIONAL TESTS (', I6, ' C',
-     $      'ALLS)', /' ******* BUT WITH MAXIMUM TEST RATIO', F8.2,
-     $      ' - SUSPECT *******' )
+C 9997 FORMAT( ' ',A12, ' COMPLETED THE COMPUTATIONAL TESTS (', I6, ' C',
+C     $      'ALLS)', /' ******* BUT WITH MAXIMUM TEST RATIO', F8.2,
+C     $      ' - SUSPECT *******' )
  9996 FORMAT( ' ******* ',A12, ' FAILED ON CALL NUMBER:' )
  9995 FORMAT( 1X, I6, ': ',A12, '(', A14, ',', 4( I3, ',' ), F4.1,
      $      ', A,', I3, ',',/ 10x,'X,', I2, ',', F4.1, ', Y,',
@@ -1004,7 +1004,7 @@
      $                           REWIND NTRA
                               CALL CDSBMV( IORDER, UPLO, N, K, ALPHA,
      $                                    AA, LDA, XX, INCX, BETA, YY,
-     $					  INCY )
+     $                                    INCY )
                            ELSE IF( PACKED )THEN
                               IF( TRACE )
      $                           WRITE( NTRA, FMT = 9995 )NC, SNAME,
@@ -1156,9 +1156,9 @@
      $ ' (', I6, ' CALL', 'S)' )
  9998 FORMAT( ' ******* FATAL ERROR - PARAMETER NUMBER ', I2, ' WAS CH',
      $      'ANGED INCORRECTLY *******' )
- 9997 FORMAT( ' ',A12, ' COMPLETED THE COMPUTATIONAL TESTS (', I6, ' C',
-     $      'ALLS)', /' ******* BUT WITH MAXIMUM TEST RATIO', F8.2,
-     $      ' - SUSPECT *******' )
+C 9997 FORMAT( ' ',A12, ' COMPLETED THE COMPUTATIONAL TESTS (', I6, ' C',
+C     $      'ALLS)', /' ******* BUT WITH MAXIMUM TEST RATIO', F8.2,
+C     $      ' - SUSPECT *******' )
  9996 FORMAT( ' ******* ',A12, ' FAILED ON CALL NUMBER:' )
  9995 FORMAT( 1X, I6, ': ',A12, '(', A14, ',', I3, ',', F4.1, ', AP',
      $      ', X,', I2, ',', F4.1, ', Y,', I2, ') .' )
@@ -1191,7 +1191,7 @@
 *     .. Scalar Arguments ..
       DOUBLE PRECISION   EPS, THRESH
       INTEGER            INCMAX, NIDIM, NINC, NKB, NMAX, NOUT, NTRA,
-     $			 IORDER
+     $                   IORDER
       LOGICAL            FATAL, REWI, TRACE
       CHARACTER*12       SNAME
 *     .. Array Arguments ..
@@ -1216,7 +1216,7 @@
       EXTERNAL           LDE, LDERES
 *     .. External Subroutines ..
       EXTERNAL           DMAKE, DMVCH, CDTBMV, CDTBSV, CDTPMV,
-     $			 CDTPSV, CDTRMV,  CDTRSV
+     $                   CDTPSV, CDTRMV,  CDTRSV
 *     .. Intrinsic Functions ..
       INTRINSIC          ABS, MAX
 *     .. Scalars in Common ..
@@ -1544,9 +1544,9 @@
      $ ' (', I6, ' CALL', 'S)' )
  9998 FORMAT( ' ******* FATAL ERROR - PARAMETER NUMBER ', I2, ' WAS CH',
      $      'ANGED INCORRECTLY *******' )
- 9997 FORMAT( ' ',A12, ' COMPLETED THE COMPUTATIONAL TESTS (', I6, ' C',
-     $      'ALLS)', /' ******* BUT WITH MAXIMUM TEST RATIO', F8.2,
-     $      ' - SUSPECT *******' )
+C 9997 FORMAT( ' ',A12, ' COMPLETED THE COMPUTATIONAL TESTS (', I6, ' C',
+C     $      'ALLS)', /' ******* BUT WITH MAXIMUM TEST RATIO', F8.2,
+C     $      ' - SUSPECT *******' )
  9996 FORMAT( ' ******* ',A12, ' FAILED ON CALL NUMBER:' )
  9995 FORMAT( 1X, I6, ': ',A12, '(', 3( A14,',' ),/ 10x, I3, ', AP, ',
      $      'X,', I2, ') .' )
@@ -1579,7 +1579,7 @@
 *     .. Scalar Arguments ..
       DOUBLE PRECISION   EPS, THRESH
       INTEGER            INCMAX, NALF, NIDIM, NINC, NMAX, NOUT, NTRA,
-     $			 IORDER
+     $                   IORDER
       LOGICAL            FATAL, REWI, TRACE
       CHARACTER*12       SNAME
 *     .. Array Arguments ..
@@ -1819,9 +1819,9 @@
      $ ' (', I6, ' CALL', 'S)' )
  9998 FORMAT( ' ******* FATAL ERROR - PARAMETER NUMBER ', I2, ' WAS CH',
      $      'ANGED INCORRECTLY *******' )
- 9997 FORMAT( ' ',A12, ' COMPLETED THE COMPUTATIONAL TESTS (', I6, ' C',
-     $      'ALLS)', /' ******* BUT WITH MAXIMUM TEST RATIO', F8.2,
-     $      ' - SUSPECT *******' )
+C 9997 FORMAT( ' ',A12, ' COMPLETED THE COMPUTATIONAL TESTS (', I6, ' C',
+C     $      'ALLS)', /' ******* BUT WITH MAXIMUM TEST RATIO', F8.2,
+C     $      ' - SUSPECT *******' )
  9996 FORMAT( ' ******* ',A12, ' FAILED ON CALL NUMBER:' )
  9995 FORMAT( '      THESE ARE THE RESULTS FOR COLUMN ', I3 )
  9994 FORMAT( 1X, I6, ': ',A12, '(', 2( I3, ',' ), F4.1, ', X,', I2,
@@ -1851,7 +1851,7 @@
 *     .. Scalar Arguments ..
       DOUBLE PRECISION   EPS, THRESH
       INTEGER            INCMAX, NALF, NIDIM, NINC, NMAX, NOUT, NTRA,
-     $			 IORDER
+     $                   IORDER
       LOGICAL            FATAL, REWI, TRACE
       CHARACTER*12       SNAME
 *     .. Array Arguments ..
@@ -1973,7 +1973,7 @@
                      IF( REWI )
      $                  REWIND NTRA
                      CALL CDSYR( IORDER, UPLO, N, ALPHA, XX, INCX,
-     $				  AA, LDA )
+     $                            AA, LDA )
                   ELSE IF( PACKED )THEN
                      IF( TRACE )
      $                  WRITE( NTRA, FMT = 9994 )NC, SNAME, CUPLO, N,
@@ -2113,9 +2113,9 @@
      $ ' (', I6, ' CALL', 'S)' )
  9998 FORMAT( ' ******* FATAL ERROR - PARAMETER NUMBER ', I2, ' WAS CH',
      $      'ANGED INCORRECTLY *******' )
- 9997 FORMAT( ' ',A12, ' COMPLETED THE COMPUTATIONAL TESTS (', I6, ' C',
-     $      'ALLS)', /' ******* BUT WITH MAXIMUM TEST RATIO', F8.2,
-     $      ' - SUSPECT *******' )
+C 9997 FORMAT( ' ',A12, ' COMPLETED THE COMPUTATIONAL TESTS (', I6, ' C',
+C     $      'ALLS)', /' ******* BUT WITH MAXIMUM TEST RATIO', F8.2,
+C     $      ' - SUSPECT *******' )
  9996 FORMAT( ' ******* ',A12, ' FAILED ON CALL NUMBER:' )
  9995 FORMAT( '      THESE ARE THE RESULTS FOR COLUMN ', I3 )
  9994 FORMAT( 1X, I6, ': ',A12, '(', A14, ',', I3, ',', F4.1, ', X,',
@@ -2147,7 +2147,7 @@
 *     .. Scalar Arguments ..
       DOUBLE PRECISION   EPS, THRESH
       INTEGER            INCMAX, NALF, NIDIM, NINC, NMAX, NOUT, NTRA,
-     $			 IORDER
+     $                   IORDER
       LOGICAL            FATAL, REWI, TRACE
       CHARACTER*12       SNAME
 *     .. Array Arguments ..
@@ -2445,9 +2445,9 @@
      $ ' (', I6, ' CALL', 'S)' )
  9998 FORMAT( ' ******* FATAL ERROR - PARAMETER NUMBER ', I2, ' WAS CH',
      $      'ANGED INCORRECTLY *******' )
- 9997 FORMAT( ' ',A12, ' COMPLETED THE COMPUTATIONAL TESTS (', I6, ' C',
-     $      'ALLS)', /' ******* BUT WITH MAXIMUM TEST RATIO', F8.2,
-     $      ' - SUSPECT *******' )
+C 9997 FORMAT( ' ',A12, ' COMPLETED THE COMPUTATIONAL TESTS (', I6, ' C',
+C     $      'ALLS)', /' ******* BUT WITH MAXIMUM TEST RATIO', F8.2,
+C     $      ' - SUSPECT *******' )
  9996 FORMAT( ' ******* ',A12, ' FAILED ON CALL NUMBER:' )
  9995 FORMAT( '      THESE ARE THE RESULTS FOR COLUMN ', I3 )
  9994 FORMAT( 1X, I6, ': ',A12, '(', A14, ',', I3, ',', F4.1, ', X,',
@@ -2833,7 +2833,7 @@
    50    CONTINUE
       END IF
 *
-   60 CONTINUE
+C   60 CONTINUE
       LDERES = .TRUE.
       GO TO 80
    70 CONTINUE

--- a/ctest/c_dblat3.f
+++ b/ctest/c_dblat3.f
@@ -56,7 +56,7 @@
 *     .. Local Scalars ..
       DOUBLE PRECISION   EPS, ERR, THRESH
       INTEGER            I, ISNUM, J, N, NALF, NBET, NIDIM, NTRA,
-     $			          LAYOUT
+     $                            LAYOUT
       LOGICAL            FATAL, LTESTT, REWI, SAME, SFATAL, TRACE,
      $                   TSTERR, CORDER, RORDER
       CHARACTER*1        TRANSA, TRANSB
@@ -78,7 +78,7 @@
       EXTERNAL           DDIFF, LDE
 *     .. External Subroutines ..
       EXTERNAL           DCHK1, DCHK2, DCHK3, DCHK4, DCHK5, CD3CHKE,
-     $			 DMMCH
+     $                   DMMCH
 *     .. Intrinsic Functions ..
       INTRINSIC          MAX, MIN
 *     .. Scalars in Common ..
@@ -323,13 +323,13 @@
             CALL DCHK3( SNAMES( ISNUM ), EPS, THRESH, NOUT, NTRA, TRACE,
      $                  REWI, FATAL, NIDIM, IDIM, NALF, ALF, NMAX, AB,
      $                  AA, AS, AB( 1, NMAX + 1 ), BB, BS, CT, G, C,
-     $			0 )
+     $                  0 )
             END IF
             IF (RORDER) THEN
             CALL DCHK3( SNAMES( ISNUM ), EPS, THRESH, NOUT, NTRA, TRACE,
      $                  REWI, FATAL, NIDIM, IDIM, NALF, ALF, NMAX, AB,
      $                  AA, AS, AB( 1, NMAX + 1 ), BB, BS, CT, G, C,
-     $			1 )
+     $                  1 )
             END IF
             GO TO 190
 *           Test DSYRK, 05.
@@ -351,13 +351,13 @@
             CALL DCHK5( SNAMES( ISNUM ), EPS, THRESH, NOUT, NTRA, TRACE,
      $                  REWI, FATAL, NIDIM, IDIM, NALF, ALF, NBET, BET,
      $                  NMAX, AB, AA, AS, BB, BS, C, CC, CS, CT, G, W,
-     $			0 )
+     $                  0 )
             END IF
             IF (RORDER) THEN
             CALL DCHK5( SNAMES( ISNUM ), EPS, THRESH, NOUT, NTRA, TRACE,
      $                  REWI, FATAL, NIDIM, IDIM, NALF, ALF, NBET, BET,
      $                  NMAX, AB, AA, AS, BB, BS, C, CC, CS, CT, G, W,
-     $			1 )
+     $                  1 )
             END IF
             GO TO 190
 *
@@ -588,7 +588,7 @@
      $                        REWIND NTRA
                            CALL CDGEMM( IORDER, TRANSA, TRANSB, M, N,
      $                                   K, ALPHA, AA, LDA, BB, LDB,
-     $					 BETA, CC, LDC )
+     $                                   BETA, CC, LDC )
 *
 *                          Check if error-exit was taken incorrectly.
 *
@@ -694,9 +694,9 @@
  9998 FORMAT( ' ******* FATAL ERROR - PARAMETER NUMBER ', I2, ' WAS CH',
      $      'ANGED INCORRECTLY *******' )
  9996 FORMAT( ' ******* ', A12,' FAILED ON CALL NUMBER:' )
- 9995 FORMAT( 1X, I6, ': ', A12,'(''', A1, ''',''', A1, ''',',
-     $      3( I3, ',' ), F4.1, ', A,', I3, ', B,', I3, ',', F4.1, ', ',
-     $      'C,', I3, ').' )
+C 9995 FORMAT( 1X, I6, ': ', A12,'(''', A1, ''',''', A1, ''',',
+C     $      3( I3, ',' ), F4.1, ', A,', I3, ', B,', I3, ',', F4.1, ', ',
+C     $      'C,', I3, ').' )
  9994 FORMAT( ' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
 *
@@ -1007,9 +1007,9 @@
  9998 FORMAT( ' ******* FATAL ERROR - PARAMETER NUMBER ', I2, ' WAS CH',
      $      'ANGED INCORRECTLY *******' )
  9996 FORMAT( ' ******* ', A12,' FAILED ON CALL NUMBER:' )
- 9995 FORMAT( 1X, I6, ': ', A12,'(', 2( '''', A1, ''',' ), 2( I3, ',' ),
-     $      F4.1, ', A,', I3, ', B,', I3, ',', F4.1, ', C,', I3, ')   ',
-     $      ' .' )
+C 9995 FORMAT( 1X, I6, ': ', A12,'(', 2( '''', A1, ''',' ), 2( I3, ',' ),
+C     $      F4.1, ', A,', I3, ', B,', I3, ',', F4.1, ', C,', I3, ')   ',
+C     $      ' .' )
  9994 FORMAT( ' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
 *
@@ -1201,7 +1201,7 @@
      $                           REWIND NTRA
                               CALL CDTRMM( IORDER, SIDE, UPLO, TRANSA,
      $                                    DIAG, M, N, ALPHA, AA, LDA,
-     $					  BB, LDB )
+     $                                    BB, LDB )
                            ELSE IF( SNAME( 10: 11 ).EQ.'sm' )THEN
                               IF( TRACE )
      $                           CALL DPRCN3( NTRA, NC, SNAME, IORDER,
@@ -1211,7 +1211,7 @@
      $                           REWIND NTRA
                               CALL CDTRSM( IORDER, SIDE, UPLO, TRANSA,
      $                                    DIAG, M, N, ALPHA, AA, LDA,
-     $					  BB, LDB )
+     $                                    BB, LDB )
                            END IF
 *
 *                          Check if error-exit was taken incorrectly.
@@ -1355,8 +1355,8 @@
  9998 FORMAT( ' ******* FATAL ERROR - PARAMETER NUMBER ', I2, ' WAS CH',
      $      'ANGED INCORRECTLY *******' )
  9996 FORMAT( ' ******* ', A12,' FAILED ON CALL NUMBER:' )
- 9995 FORMAT( 1X, I6, ': ', A12,'(', 4( '''', A1, ''',' ), 2( I3, ',' ),
-     $      F4.1, ', A,', I3, ', B,', I3, ')        .' )
+C 9995 FORMAT( 1X, I6, ': ', A12,'(', 4( '''', A1, ''',' ), 2( I3, ',' ),
+C     $      F4.1, ', A,', I3, ', B,', I3, ')        .' )
  9994 FORMAT( ' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
 *
@@ -1681,8 +1681,8 @@
      $      'ANGED INCORRECTLY *******' )
  9996 FORMAT( ' ******* ', A12,' FAILED ON CALL NUMBER:' )
  9995 FORMAT( '      THESE ARE THE RESULTS FOR COLUMN ', I3 )
- 9994 FORMAT( 1X, I6, ': ', A12,'(', 2( '''', A1, ''',' ), 2( I3, ',' ),
-     $      F4.1, ', A,', I3, ',', F4.1, ', C,', I3, ')           .' )
+C 9994 FORMAT( 1X, I6, ': ', A12,'(', 2( '''', A1, ''',' ), 2( I3, ',' ),
+C     $      F4.1, ', A,', I3, ',', F4.1, ', C,', I3, ')           .' )
  9993 FORMAT( ' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
 *
@@ -1726,7 +1726,7 @@
       SUBROUTINE DCHK5( SNAME, EPS, THRESH, NOUT, NTRA, TRACE, REWI,
      $                  FATAL, NIDIM, IDIM, NALF, ALF, NBET, BET, NMAX,
      $                  AB, AA, AS, BB, BS, C, CC, CS, CT, G, W,
-     $			IORDER )
+     $                  IORDER )
 *
 *  Tests DSYR2K.
 *
@@ -1888,7 +1888,7 @@
      $                     REWIND NTRA
                         CALL CDSYR2K( IORDER, UPLO, TRANS, N, K,
      $                               ALPHA, AA, LDA, BB, LDB, BETA,
-     $				     CC, LDC )
+     $                               CC, LDC )
 *
 *                       Check if error-exit was taken incorrectly.
 *
@@ -2037,9 +2037,9 @@
      $      'ANGED INCORRECTLY *******' )
  9996 FORMAT( ' ******* ', A12,' FAILED ON CALL NUMBER:' )
  9995 FORMAT( '      THESE ARE THE RESULTS FOR COLUMN ', I3 )
- 9994 FORMAT( 1X, I6, ': ', A12,'(', 2( '''', A1, ''',' ), 2( I3, ',' ),
-     $      F4.1, ', A,', I3, ', B,', I3, ',', F4.1, ', C,', I3, ')   ',
-     $      ' .' )
+C 9994 FORMAT( 1X, I6, ': ', A12,'(', 2( '''', A1, ''',' ), 2( I3, ',' ),
+C     $      F4.1, ', A,', I3, ', B,', I3, ',', F4.1, ', C,', I3, ')   ',
+C     $      ' .' )
  9993 FORMAT( ' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
 *
@@ -2399,7 +2399,7 @@
    50    CONTINUE
       END IF
 *
-   60 CONTINUE
+C   60 CONTINUE
       LDERES = .TRUE.
       GO TO 80
    70 CONTINUE

--- a/ctest/c_sblas1.c
+++ b/ctest/c_sblas1.c
@@ -14,7 +14,7 @@ float F77_sasum(blasint *N, float *X, blasint *incX)
    return cblas_sasum(*N, X, *incX);
 }
 
-void F77_saxpy(blasint *N, const float *alpha, const float *X,
+void F77_saxpy(blasint *N, const float *alpha, OPENBLAS_CONST float *X,
                     blasint *incX, float *Y, blasint *incY)
 {
    cblas_saxpy(*N, *alpha, X, *incX, Y, *incY);
@@ -26,25 +26,25 @@ float F77_scasum(blasint *N, float *X, blasint *incX)
    return cblas_scasum(*N, X, *incX);
 }
 
-float F77_scnrm2(blasint *N, const float *X, blasint *incX)
+float F77_scnrm2(blasint *N, OPENBLAS_CONST float *X, blasint *incX)
 {
    return cblas_scnrm2(*N, X, *incX);
 }
 
-void F77_scopy(blasint *N, const float *X, blasint *incX,
+void F77_scopy(blasint *N, OPENBLAS_CONST float *X, blasint *incX,
                     float *Y, blasint *incY)
 {
    cblas_scopy(*N, X, *incX, Y, *incY);
    return;
 }
 
-float F77_sdot(blasint *N, const float *X, blasint *incX,
-                        const float *Y, blasint *incY)
+float F77_sdot(blasint *N, OPENBLAS_CONST float *X, blasint *incX,
+                        OPENBLAS_CONST float *Y, blasint *incY)
 {
    return cblas_sdot(*N, X, *incX, Y, *incY);
 }
 
-float F77_snrm2(blasint *N, const float *X, blasint *incX)
+float F77_snrm2(blasint *N, OPENBLAS_CONST float *X, blasint *incX)
 {
    return cblas_snrm2(*N, X, *incX);
 }
@@ -76,7 +76,7 @@ void F77_sswap( blasint *N, float *X, blasint *incX,
    return;
 }
 
-int F77_isamax(blasint *N, const float *X, blasint *incX)
+int F77_isamax(blasint *N, OPENBLAS_CONST float *X, blasint *incX)
 {
    if (*N < 1 || *incX < 1) return(0);
    return (cblas_isamax(*N, X, *incX)+1);

--- a/ctest/c_sblat1.f
+++ b/ctest/c_sblat1.f
@@ -211,11 +211,11 @@
             IF (ICASE.EQ.7) THEN
 *              .. SNRM2TEST ..
                STEMP(1) = DTRUE1(NP1)
-               CALL STEST1(SNRM2TEST(N,SX,INCX),STEMP,STEMP,SFAC)
+               CALL STEST1(SNRM2TEST(N,SX,INCX),STEMP(1),STEMP,SFAC)
             ELSE IF (ICASE.EQ.8) THEN
 *              .. SASUMTEST ..
                STEMP(1) = DTRUE3(NP1)
-               CALL STEST1(SASUMTEST(N,SX,INCX),STEMP,STEMP,SFAC)
+               CALL STEST1(SASUMTEST(N,SX,INCX),STEMP(1),STEMP,SFAC)
             ELSE IF (ICASE.EQ.9) THEN
 *              .. SSCALTEST ..
                CALL SSCALTEST(N,SA((INCX-1)*5+NP1),SX,INCX)

--- a/ctest/c_sblat2.f
+++ b/ctest/c_sblat2.f
@@ -345,13 +345,13 @@
             CALL SCHK3( SNAMES( ISNUM ), EPS, THRESH, NOUT, NTRA, TRACE,
      $                  REWI, FATAL, NIDIM, IDIM, NKB, KB, NINC, INC,
      $                  NMAX, INCMAX, A, AA, AS, Y, YY, YS, YT, G, Z,
-     $			0 )
+     $                  0 )
             END IF
             IF (RORDER) THEN
             CALL SCHK3( SNAMES( ISNUM ), EPS, THRESH, NOUT, NTRA, TRACE,
      $                  REWI, FATAL, NIDIM, IDIM, NKB, KB, NINC, INC,
      $                  NMAX, INCMAX, A, AA, AS, Y, YY, YS, YT, G, Z,
-     $			1 )
+     $                  1 )
             END IF
             GO TO 200
 *           Test SGER, 12.
@@ -797,9 +797,9 @@
      $ ' (', I6, ' CALL', 'S)' )
  9998 FORMAT( ' ******* FATAL ERROR - PARAMETER NUMBER ', I2, ' WAS CH',
      $      'ANGED INCORRECTLY *******' )
- 9997 FORMAT( ' ',A12, ' COMPLETED THE COMPUTATIONAL TESTS (', I6, ' C',
-     $      'ALLS)', /' ******* BUT WITH MAXIMUM TEST RATIO', F8.2,
-     $      ' - SUSPECT *******' )
+C 9997 FORMAT( ' ',A12, ' COMPLETED THE COMPUTATIONAL TESTS (', I6, ' C',
+C     $      'ALLS)', /' ******* BUT WITH MAXIMUM TEST RATIO', F8.2,
+C     $      ' - SUSPECT *******' )
  9996 FORMAT( ' ******* ',A12, ' FAILED ON CALL NUMBER:' )
  9995 FORMAT( 1X, I6, ': ',A12, '(', A14, ',', 4( I3, ',' ), F4.1,
      $      ', A,', I3, ',',/ 10x, 'X,', I2, ',', F4.1, ', Y,',
@@ -1004,7 +1004,7 @@
      $                           REWIND NTRA
                               CALL CSSBMV( IORDER, UPLO, N, K, ALPHA,
      $                                    AA, LDA, XX, INCX, BETA, YY,
-     $					  INCY )
+     $                                    INCY )
                            ELSE IF( PACKED )THEN
                               IF( TRACE )
      $                           WRITE( NTRA, FMT = 9995 )NC, SNAME,
@@ -1156,9 +1156,9 @@
      $ ' (', I6, ' CALL', 'S)' )
  9998 FORMAT( ' ******* FATAL ERROR - PARAMETER NUMBER ', I2, ' WAS CH',
      $      'ANGED INCORRECTLY *******' )
- 9997 FORMAT( ' ',A12, ' COMPLETED THE COMPUTATIONAL TESTS (', I6, ' C',
-     $      'ALLS)', /' ******* BUT WITH MAXIMUM TEST RATIO', F8.2,
-     $      ' - SUSPECT *******' )
+C 9997 FORMAT( ' ',A12, ' COMPLETED THE COMPUTATIONAL TESTS (', I6, ' C',
+C     $      'ALLS)', /' ******* BUT WITH MAXIMUM TEST RATIO', F8.2,
+C     $      ' - SUSPECT *******' )
  9996 FORMAT( ' ******* ',A12, ' FAILED ON CALL NUMBER:' )
  9995 FORMAT( 1X, I6, ': ',A12, '(', A14, ',', I3, ',', F4.1, ', AP',
      $      ', X,', I2, ',', F4.1, ', Y,', I2, ') .' )
@@ -1191,7 +1191,7 @@
 *     .. Scalar Arguments ..
       REAL               EPS, THRESH
       INTEGER            INCMAX, NIDIM, NINC, NKB, NMAX, NOUT, NTRA,
-     $			 IORDER
+     $                   IORDER
       LOGICAL            FATAL, REWI, TRACE
       CHARACTER*12       SNAME
 *     .. Array Arguments ..
@@ -1216,7 +1216,7 @@
       EXTERNAL           LSE, LSERES
 *     .. External Subroutines ..
       EXTERNAL           SMAKE, SMVCH, CSTBMV, CSTBSV, CSTPMV,
-     $			 CSTPSV, CSTRMV,  CSTRSV
+     $                   CSTPSV, CSTRMV,  CSTRSV
 *     .. Intrinsic Functions ..
       INTRINSIC          ABS, MAX
 *     .. Scalars in Common ..
@@ -1544,9 +1544,9 @@
      $ ' (', I6, ' CALL', 'S)' )
  9998 FORMAT( ' ******* FATAL ERROR - PARAMETER NUMBER ', I2, ' WAS CH',
      $      'ANGED INCORRECTLY *******' )
- 9997 FORMAT( ' ',A12, ' COMPLETED THE COMPUTATIONAL TESTS (', I6, ' C',
-     $      'ALLS)', /' ******* BUT WITH MAXIMUM TEST RATIO', F8.2,
-     $      ' - SUSPECT *******' )
+C 9997 FORMAT( ' ',A12, ' COMPLETED THE COMPUTATIONAL TESTS (', I6, ' C',
+C     $      'ALLS)', /' ******* BUT WITH MAXIMUM TEST RATIO', F8.2,
+C     $      ' - SUSPECT *******' )
  9996 FORMAT( ' ******* ',A12, ' FAILED ON CALL NUMBER:' )
  9995 FORMAT( 1X, I6, ': ',A12, '(', 3( A14,',' ),/ 10x, I3, ', AP, ',
      $      'X,', I2, ') .' )
@@ -1579,7 +1579,7 @@
 *     .. Scalar Arguments ..
       REAL               EPS, THRESH
       INTEGER            INCMAX, NALF, NIDIM, NINC, NMAX, NOUT, NTRA,
-     $			 IORDER
+     $                   IORDER
       LOGICAL            FATAL, REWI, TRACE
       CHARACTER*12       SNAME
 *     .. Array Arguments ..
@@ -1819,9 +1819,9 @@
      $ ' (', I6, ' CALL', 'S)' )
  9998 FORMAT( ' ******* FATAL ERROR - PARAMETER NUMBER ', I2, ' WAS CH',
      $      'ANGED INCORRECTLY *******' )
- 9997 FORMAT( ' ',A12, ' COMPLETED THE COMPUTATIONAL TESTS (', I6, ' C',
-     $      'ALLS)', /' ******* BUT WITH MAXIMUM TEST RATIO', F8.2,
-     $      ' - SUSPECT *******' )
+C 9997 FORMAT( ' ',A12, ' COMPLETED THE COMPUTATIONAL TESTS (', I6, ' C',
+C     $      'ALLS)', /' ******* BUT WITH MAXIMUM TEST RATIO', F8.2,
+C     $      ' - SUSPECT *******' )
  9996 FORMAT( ' ******* ',A12, ' FAILED ON CALL NUMBER:' )
  9995 FORMAT( '      THESE ARE THE RESULTS FOR COLUMN ', I3 )
  9994 FORMAT( 1X, I6, ': ',A12, '(', 2( I3, ',' ), F4.1, ', X,', I2,
@@ -1851,7 +1851,7 @@
 *     .. Scalar Arguments ..
       REAL               EPS, THRESH
       INTEGER            INCMAX, NALF, NIDIM, NINC, NMAX, NOUT, NTRA,
-     $			 IORDER
+     $                   IORDER
       LOGICAL            FATAL, REWI, TRACE
       CHARACTER*12       SNAME
 *     .. Array Arguments ..
@@ -1973,7 +1973,7 @@
                      IF( REWI )
      $                  REWIND NTRA
                      CALL CSSYR( IORDER, UPLO, N, ALPHA, XX, INCX,
-     $				  AA, LDA )
+     $                            AA, LDA )
                   ELSE IF( PACKED )THEN
                      IF( TRACE )
      $                  WRITE( NTRA, FMT = 9994 )NC, SNAME, CUPLO, N,
@@ -2113,9 +2113,9 @@
      $ ' (', I6, ' CALL', 'S)' )
  9998 FORMAT( ' ******* FATAL ERROR - PARAMETER NUMBER ', I2, ' WAS CH',
      $      'ANGED INCORRECTLY *******' )
- 9997 FORMAT( ' ',A12, ' COMPLETED THE COMPUTATIONAL TESTS (', I6, ' C',
-     $      'ALLS)', /' ******* BUT WITH MAXIMUM TEST RATIO', F8.2,
-     $      ' - SUSPECT *******' )
+C 9997 FORMAT( ' ',A12, ' COMPLETED THE COMPUTATIONAL TESTS (', I6, ' C',
+C     $      'ALLS)', /' ******* BUT WITH MAXIMUM TEST RATIO', F8.2,
+C     $      ' - SUSPECT *******' )
  9996 FORMAT( ' ******* ',A12, ' FAILED ON CALL NUMBER:' )
  9995 FORMAT( '      THESE ARE THE RESULTS FOR COLUMN ', I3 )
  9994 FORMAT( 1X, I6, ': ',A12, '(', A14, ',', I3, ',', F4.1, ', X,',
@@ -2147,7 +2147,7 @@
 *     .. Scalar Arguments ..
       REAL               EPS, THRESH
       INTEGER            INCMAX, NALF, NIDIM, NINC, NMAX, NOUT, NTRA,
-     $			 IORDER
+     $                   IORDER
       LOGICAL            FATAL, REWI, TRACE
       CHARACTER*12       SNAME
 *     .. Array Arguments ..
@@ -2445,9 +2445,9 @@
      $ ' (', I6, ' CALL', 'S)' )
  9998 FORMAT( ' ******* FATAL ERROR - PARAMETER NUMBER ', I2, ' WAS CH',
      $      'ANGED INCORRECTLY *******' )
- 9997 FORMAT( ' ',A12, ' COMPLETED THE COMPUTATIONAL TESTS (', I6, ' C',
-     $      'ALLS)', /' ******* BUT WITH MAXIMUM TEST RATIO', F8.2,
-     $      ' - SUSPECT *******' )
+C 9997 FORMAT( ' ',A12, ' COMPLETED THE COMPUTATIONAL TESTS (', I6, ' C',
+C     $      'ALLS)', /' ******* BUT WITH MAXIMUM TEST RATIO', F8.2,
+C     $      ' - SUSPECT *******' )
  9996 FORMAT( ' ******* ',A12, ' FAILED ON CALL NUMBER:' )
  9995 FORMAT( '      THESE ARE THE RESULTS FOR COLUMN ', I3 )
  9994 FORMAT( 1X, I6, ': ',A12, '(', A14, ',', I3, ',', F4.1, ', X,',
@@ -2833,7 +2833,7 @@
    50    CONTINUE
       END IF
 *
-   60 CONTINUE
+C   60 CONTINUE
       LSERES = .TRUE.
       GO TO 80
    70 CONTINUE

--- a/ctest/c_sblat3.f
+++ b/ctest/c_sblat3.f
@@ -694,9 +694,9 @@
  9998 FORMAT( ' ******* FATAL ERROR - PARAMETER NUMBER ', I2, ' WAS CH',
      $      'ANGED INCORRECTLY *******' )
  9996 FORMAT( ' ******* ', A12,' FAILED ON CALL NUMBER:' )
- 9995 FORMAT( 1X, I6, ': ', A12,'(''', A1, ''',''', A1, ''',',
-     $      3( I3, ',' ), F4.1, ', A,', I3, ', B,', I3, ',', F4.1, ', ',
-     $      'C,', I3, ').' )
+C 9995 FORMAT( 1X, I6, ': ', A12,'(''', A1, ''',''', A1, ''',',
+C     $      3( I3, ',' ), F4.1, ', A,', I3, ', B,', I3, ',', F4.1, ', ',
+C     $      'C,', I3, ').' )
  9994 FORMAT( ' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
 *
@@ -1011,9 +1011,9 @@
  9998 FORMAT( ' ******* FATAL ERROR - PARAMETER NUMBER ', I2, ' WAS CH',
      $      'ANGED INCORRECTLY *******' )
  9996 FORMAT( ' ******* ', A12,' FAILED ON CALL NUMBER:' )
- 9995 FORMAT( 1X, I6, ': ', A12,'(', 2( '''', A1, ''',' ), 2( I3, ',' ),
-     $      F4.1, ', A,', I3, ', B,', I3, ',', F4.1, ', C,', I3, ')   ',
-     $      ' .' )
+C 9995 FORMAT( 1X, I6, ': ', A12,'(', 2( '''', A1, ''',' ), 2( I3, ',' ),
+C     $      F4.1, ', A,', I3, ', B,', I3, ',', F4.1, ', C,', I3, ')   ',
+C     $      ' .' )
  9994 FORMAT( ' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
 *
@@ -1359,8 +1359,8 @@
  9998 FORMAT( ' ******* FATAL ERROR - PARAMETER NUMBER ', I2, ' WAS CH',
      $      'ANGED INCORRECTLY *******' )
  9996 FORMAT( ' ******* ', A12,' FAILED ON CALL NUMBER:' )
- 9995 FORMAT( 1X, I6, ': ', A12,'(', 4( '''', A1, ''',' ), 2( I3, ',' ),
-     $      F4.1, ', A,', I3, ', B,', I3, ')        .' )
+C 9995 FORMAT( 1X, I6, ': ', A12,'(', 4( '''', A1, ''',' ), 2( I3, ',' ),
+C     $      F4.1, ', A,', I3, ', B,', I3, ')        .' )
  9994 FORMAT( ' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
 *
@@ -1686,8 +1686,8 @@
      $      'ANGED INCORRECTLY *******' )
  9996 FORMAT( ' ******* ', A12,' FAILED ON CALL NUMBER:' )
  9995 FORMAT( '      THESE ARE THE RESULTS FOR COLUMN ', I3 )
- 9994 FORMAT( 1X, I6, ': ', A12,'(', 2( '''', A1, ''',' ), 2( I3, ',' ),
-     $      F4.1, ', A,', I3, ',', F4.1, ', C,', I3, ')           .' )
+C 9994 FORMAT( 1X, I6, ': ', A12,'(', 2( '''', A1, ''',' ), 2( I3, ',' ),
+C     $      F4.1, ', A,', I3, ',', F4.1, ', C,', I3, ')           .' )
  9993 FORMAT( ' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
 *
@@ -2041,9 +2041,9 @@
      $      'ANGED INCORRECTLY *******' )
  9996 FORMAT( ' ******* ', A12,' FAILED ON CALL NUMBER:' )
  9995 FORMAT( '      THESE ARE THE RESULTS FOR COLUMN ', I3 )
- 9994 FORMAT( 1X, I6, ': ', A12,'(', 2( '''', A1, ''',' ), 2( I3, ',' ),
-     $      F4.1, ', A,', I3, ', B,', I3, ',', F4.1, ', C,', I3, ')   ',
-     $      ' .' )
+C 9994 FORMAT( 1X, I6, ': ', A12,'(', 2( '''', A1, ''',' ), 2( I3, ',' ),
+C     $      F4.1, ', A,', I3, ', B,', I3, ',', F4.1, ', C,', I3, ')   ',
+C     $      ' .' )
  9993 FORMAT( ' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
 *
@@ -2403,7 +2403,7 @@
    50    CONTINUE
       END IF
 *
-   60 CONTINUE
+C   60 CONTINUE
       LSERES = .TRUE.
       GO TO 80
    70 CONTINUE

--- a/ctest/c_xerbla.c
+++ b/ctest/c_xerbla.c
@@ -131,7 +131,7 @@ void F77_xerbla(char *srname, void *vinfo)
 int    BLASFUNC(xerbla)(char *name, blasint *info, blasint length) {
 
   F77_xerbla(name, info);
-
+  return 0;
 };
 
 

--- a/ctest/c_zblas1.c
+++ b/ctest/c_zblas1.c
@@ -9,7 +9,7 @@
 #include "common.h"
 #include "cblas_test.h"
 
-void F77_zaxpy(const int *N, const void *alpha, void *X,
+void F77_zaxpy(const int *N, OPENBLAS_CONST void *alpha, void *X,
                     const int *incX, void *Y, const int *incY)
 {
    cblas_zaxpy(*N, alpha, X, *incX, Y, *incY);
@@ -23,8 +23,8 @@ void F77_zcopy(const int *N, void *X, const int *incX,
    return;
 }
 
-void F77_zdotc(const int *N, const void *X, const int *incX,
-                     const void *Y, const int *incY,void *dotc)
+void F77_zdotc(const int *N, OPENBLAS_CONST void *X, const int *incX,
+                     OPENBLAS_CONST void *Y, const int *incY,void *dotc)
 {
    cblas_zdotc_sub(*N, X, *incX, Y, *incY, dotc);
    return;
@@ -58,13 +58,13 @@ void F77_zswap( const int *N, void *X, const int *incX,
    return;
 }
 
-int F77_izamax(const int *N, const void *X, const int *incX)
+int F77_izamax(const int *N, OPENBLAS_CONST void *X, const int *incX)
 {
    if (*N < 1 || *incX < 1) return(0);
    return(cblas_izamax(*N, X, *incX)+1);
 }
 
-double F77_dznrm2(const int *N, const void *X, const int *incX)
+double F77_dznrm2(const int *N, OPENBLAS_CONST void *X, const int *incX)
 {
    return cblas_dznrm2(*N, X, *incX);
 }

--- a/ctest/c_zblas2.c
+++ b/ctest/c_zblas2.c
@@ -9,9 +9,9 @@
 #include "cblas_test.h"
 
 void F77_zgemv(int *order, char *transp, int *m, int *n,
-          const void *alpha,
-          CBLAS_TEST_ZOMPLEX *a, int *lda, const void *x, int *incx,
-          const void *beta, void *y, int *incy) {
+          OPENBLAS_CONST void *alpha,
+          CBLAS_TEST_ZOMPLEX *a, int *lda, OPENBLAS_CONST void *x, int *incx,
+          OPENBLAS_CONST void *beta, void *y, int *incy) {
 
   CBLAS_TEST_ZOMPLEX *A;
   int i,j,LDA;

--- a/ctest/c_zblat2.f
+++ b/ctest/c_zblat2.f
@@ -349,13 +349,13 @@
            CALL ZCHK3( SNAMES( ISNUM ), EPS, THRESH, NOUT, NTRA, TRACE,
      $                  REWI, FATAL, NIDIM, IDIM, NKB, KB, NINC, INC,
      $                  NMAX, INCMAX, A, AA, AS, Y, YY, YS, YT, G, Z,
-     $			0 )
+     $                  0 )
            END IF
            IF (RORDER) THEN
            CALL ZCHK3( SNAMES( ISNUM ), EPS, THRESH, NOUT, NTRA, TRACE,
      $                  REWI, FATAL, NIDIM, IDIM, NKB, KB, NINC, INC,
      $                  NMAX, INCMAX, A, AA, AS, Y, YY, YS, YT, G, Z,
-     $			1 )
+     $                  1 )
            END IF
             GO TO 200
 *           Test ZGERC, 12, ZGERU, 13.

--- a/ctest/c_zblat3.f
+++ b/ctest/c_zblat3.f
@@ -330,13 +330,13 @@
             CALL ZCHK3(SNAMES( ISNUM ), EPS, THRESH, NOUT, NTRA, TRACE,
      $                 REWI, FATAL, NIDIM, IDIM, NALF, ALF, NMAX, AB,
      $                 AA, AS, AB( 1, NMAX + 1 ), BB, BS, CT, G, C,
-     $		       0 )
+     $                 0 )
             END IF
             IF (RORDER) THEN
             CALL ZCHK3(SNAMES( ISNUM ), EPS, THRESH, NOUT, NTRA, TRACE,
      $                 REWI, FATAL, NIDIM, IDIM, NALF, ALF, NMAX, AB,
      $                 AA, AS, AB( 1, NMAX + 1 ), BB, BS, CT, G, C,
-     $		       1 )
+     $                 1 )
             END IF
             GO TO 190
 *           Test ZHERK, 06, ZSYRK, 07.
@@ -358,13 +358,13 @@
             CALL ZCHK5(SNAMES( ISNUM ), EPS, THRESH, NOUT, NTRA, TRACE,
      $                 REWI, FATAL, NIDIM, IDIM, NALF, ALF, NBET, BET,
      $                 NMAX, AB, AA, AS, BB, BS, C, CC, CS, CT, G, W,
-     $		       0 )
+     $                 0 )
             END IF
             IF (RORDER) THEN
             CALL ZCHK5(SNAMES( ISNUM ), EPS, THRESH, NOUT, NTRA, TRACE,
      $                 REWI, FATAL, NIDIM, IDIM, NALF, ALF, NBET, BET,
      $                 NMAX, AB, AA, AS, BB, BS, C, CC, CS, CT, G, W,
-     $		       1 )
+     $                 1 )
             END IF
             GO TO 190
 *
@@ -708,9 +708,9 @@
  9998 FORMAT(' ******* FATAL ERROR - PARAMETER NUMBER ', I2, ' WAS CH',
      $      'ANGED INCORRECTLY *******' )
  9996 FORMAT( ' ******* ', A12,' FAILED ON CALL NUMBER:' )
- 9995 FORMAT( 1X, I6, ': ', A12,'(''', A1, ''',''', A1, ''',',
-     $     3( I3, ',' ), '(', F4.1, ',', F4.1, '), A,', I3, ', B,', I3,
-     $     ',(', F4.1, ',', F4.1, '), C,', I3, ').' )
+C 9995 FORMAT( 1X, I6, ': ', A12,'(''', A1, ''',''', A1, ''',',
+C     $     3( I3, ',' ), '(', F4.1, ',', F4.1, '), A,', I3, ', B,', I3,
+C     $     ',(', F4.1, ',', F4.1, '), C,', I3, ').' )
  9994 FORMAT(' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
 *
@@ -1034,9 +1034,9 @@
  9998 FORMAT(' ******* FATAL ERROR - PARAMETER NUMBER ', I2, ' WAS CH',
      $      'ANGED INCORRECTLY *******' )
  9996 FORMAT( ' ******* ', A12,' FAILED ON CALL NUMBER:' )
- 9995 FORMAT(1X, I6, ': ', A12,'(', 2( '''', A1, ''',' ), 2( I3, ',' ),
-     $      '(', F4.1, ',', F4.1, '), A,', I3, ', B,', I3, ',(', F4.1,
-     $      ',', F4.1, '), C,', I3, ')    .' )
+C 9995 FORMAT(1X, I6, ': ', A12,'(', 2( '''', A1, ''',' ), 2( I3, ',' ),
+C     $      '(', F4.1, ',', F4.1, '), A,', I3, ', B,', I3, ',(', F4.1,
+C     $      ',', F4.1, '), C,', I3, ')    .' )
  9994 FORMAT(' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
 *
@@ -1386,9 +1386,9 @@
  9998 FORMAT(' ******* FATAL ERROR - PARAMETER NUMBER ', I2, ' WAS CH',
      $      'ANGED INCORRECTLY *******' )
  9996 FORMAT(' ******* ', A12,' FAILED ON CALL NUMBER:' )
- 9995 FORMAT(1X, I6, ': ', A12,'(', 4( '''', A1, ''',' ), 2( I3, ',' ),
-     $     '(', F4.1, ',', F4.1, '), A,', I3, ', B,', I3, ')         ',
-     $      '      .' )
+C 9995 FORMAT(1X, I6, ': ', A12,'(', 4( '''', A1, ''',' ), 2( I3, ',' ),
+C     $     '(', F4.1, ',', F4.1, '), A,', I3, ', B,', I3, ')         ',
+C     $      '      .' )
  9994 FORMAT(' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
 *
@@ -1769,12 +1769,12 @@
      $      'ANGED INCORRECTLY *******' )
  9996 FORMAT( ' ******* ', A12,' FAILED ON CALL NUMBER:' )
  9995 FORMAT( '      THESE ARE THE RESULTS FOR COLUMN ', I3 )
- 9994 FORMAT(1X, I6, ': ', A12,'(', 2( '''', A1, ''',' ), 2( I3, ',' ),
-     $     F4.1, ', A,', I3, ',', F4.1, ', C,', I3, ')               ',
-     $      '          .' )
- 9993 FORMAT(1X, I6, ': ', A12,'(', 2( '''', A1, ''',' ), 2( I3, ',' ),
-     $      '(', F4.1, ',', F4.1, ') , A,', I3, ',(', F4.1, ',', F4.1,
-     $      '), C,', I3, ')          .' )
+C 9994 FORMAT(1X, I6, ': ', A12,'(', 2( '''', A1, ''',' ), 2( I3, ',' ),
+C     $     F4.1, ', A,', I3, ',', F4.1, ', C,', I3, ')               ',
+C     $      '          .' )
+C 9993 FORMAT(1X, I6, ': ', A12,'(', 2( '''', A1, ''',' ), 2( I3, ',' ),
+C     $      '(', F4.1, ',', F4.1, ') , A,', I3, ',(', F4.1, ',', F4.1,
+C     $      '), C,', I3, ')          .' )
  9992 FORMAT(' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
 *
@@ -2222,12 +2222,12 @@
      $      'ANGED INCORRECTLY *******' )
  9996 FORMAT( ' ******* ', A12,' FAILED ON CALL NUMBER:' )
  9995 FORMAT( '      THESE ARE THE RESULTS FOR COLUMN ', I3 )
- 9994 FORMAT(1X, I6, ': ', A12,'(', 2( '''', A1, ''',' ), 2( I3, ',' ),
-     $      '(', F4.1, ',', F4.1, '), A,', I3, ', B,', I3, ',', F4.1,
-     $      ', C,', I3, ')           .' )
- 9993 FORMAT(1X, I6, ': ', A12,'(', 2( '''', A1, ''',' ), 2( I3, ',' ),
-     $      '(', F4.1, ',', F4.1, '), A,', I3, ', B,', I3, ',(', F4.1,
-     $      ',', F4.1, '), C,', I3, ')    .' )
+C 9994 FORMAT(1X, I6, ': ', A12,'(', 2( '''', A1, ''',' ), 2( I3, ',' ),
+C     $      '(', F4.1, ',', F4.1, '), A,', I3, ', B,', I3, ',', F4.1,
+C     $      ', C,', I3, ')           .' )
+C 9993 FORMAT(1X, I6, ': ', A12,'(', 2( '''', A1, ''',' ), 2( I3, ',' ),
+C     $      '(', F4.1, ',', F4.1, '), A,', I3, ', B,', I3, ',(', F4.1,
+C     $      ',', F4.1, '), C,', I3, ')    .' )
  9992 FORMAT(' ******* FATAL ERROR - ERROR-EXIT TAKEN ON VALID CALL *',
      $      '******' )
 *
@@ -2706,7 +2706,7 @@
    50    CONTINUE
       END IF
 *
-   60 CONTINUE
+C   60 CONTINUE
       LZERES = .TRUE.
       GO TO 80
    70 CONTINUE


### PR DESCRIPTION
Various fixes for const correctness, stray tab characters and unused labels