### PR TITLE
Work around errors in multithreaded dtrmv

### DIFF
--- a/driver/level2/trmv_U.c
+++ b/driver/level2/trmv_U.c
@@ -54,12 +54,16 @@ int CNAME(BLASLONG m, FLOAT *a, BLASLONG lda, FLOAT *b, BLASLONG incb, FLOAT *bu
     COPY_K(m, b, incb, buffer, 1);
   }
 
-  for (is = 0; is < m; is += DTB_ENTRIES){
+/*FIXME the GEMV unrolling performed here was found to be broken, see issue 1332 */
+/* Multiplying DTB size by 100 is just a quick-and-dirty hack to disable it for now[B */
 
-    min_i = MIN(m - is, DTB_ENTRIES);
+  for (is = 0; is < m; is += DTB_ENTRIES * 100){
+
+    min_i = MIN(m - is, DTB_ENTRIES * 100);
 
 #ifndef TRANSA
     if (is > 0){
+fprintf(stderr,"WARNING unrolling of the trmv_U loop may give wrong results\n");    
       GEMV_N(is, min_i, 0, dp1,
 	     a + is * lda,  lda,
 	     B + is, 1,

--- a/interface/trmv.c
+++ b/interface/trmv.c
@@ -220,6 +220,9 @@ void CNAME(enum CBLAS_ORDER order, enum CBLAS_UPLO Uplo,
 #ifdef SMP
   nthreads = num_cpu_avail(2);
 
+/*FIXME trmv_thread was found to be broken, see issue 1332 */
+  nthreads = 1;
+  
   if (nthreads == 1) {
 #endif
 


### PR DESCRIPTION
as a (hopefully temporary) hotfix for #1332