### PR TITLE
Limit MAX_CPU to 1024 for now

### DIFF
--- a/driver/others/init.c
+++ b/driver/others/init.c
@@ -90,9 +90,11 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #if defined(BIGNUMA)
 // max number of nodes as defined in numa.h
-// max cpus as defined in sched.h
+// max cpus as defined in most sched.h
+// cannot use CPU_SETSIZE directly as some
+// Linux distributors set it to 4096 
 #define MAX_NODES	128
-#define MAX_CPUS	CPU_SETSIZE
+#define MAX_CPUS	1024
 #else
 #define MAX_NODES	16
 #define MAX_CPUS	256


### PR DESCRIPTION
Some Linux distributions (notably SuSE) have raised CPU_SETSIZE to 4096, which causes a crash in the array initialization. Fixes #1348