### PR TITLE
Use Sandybridge daxpy kernel on Haswell and Zen for now

### DIFF
--- a/kernel/x86_64/daxpy.c
+++ b/kernel/x86_64/daxpy.c
@@ -38,7 +38,11 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #elif defined(PILEDRIVER)
 #include "daxpy_microk_piledriver-2.c"
 #elif defined(HASWELL) || defined(ZEN)
+/*
+this appears to be broken, see issue 1332
 #include "daxpy_microk_haswell-2.c"
+*/
+#include "daxpy_microk_sandy-2.c"
 #elif defined(SANDYBRIDGE)
 #include "daxpy_microk_sandy-2.c"
 #endif


### PR DESCRIPTION
The testcase from #1332 exposes a problem in daxpy_microk_haswell-2.c that is not seen with
any of the other Intel x86_64 microkernels. Assembly programmer needed for actual fix.