### PR TITLE
Retire Piledriver/Steamroller/Excavator daxpy microkernels as well

### DIFF
--- a/kernel/x86_64/daxpy.c
+++ b/kernel/x86_64/daxpy.c
@@ -33,15 +33,16 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "daxpy_microk_nehalem-2.c"
 #elif defined(BULLDOZER)
 #include "daxpy_microk_bulldozer-2.c"
+/*
+these appear to be broken, see issue 1332
 #elif defined(STEAMROLLER) || defined(EXCAVATOR)
 #include "daxpy_microk_steamroller-2.c"
 #elif defined(PILEDRIVER)
 #include "daxpy_microk_piledriver-2.c"
 #elif defined(HASWELL) || defined(ZEN)
-/*
-this appears to be broken, see issue 1332
 #include "daxpy_microk_haswell-2.c"
 */
+#elif defined(HASWELL) || defined(ZEN) || defined(PILEDRIVER) || defined(STEAMROLLER) || defined(EXCAVATOR)
 #include "daxpy_microk_sandy-2.c"
 #elif defined(SANDYBRIDGE)
 #include "daxpy_microk_sandy-2.c"


### PR DESCRIPTION
related to issue #1332