### PR TITLE
Address warnings #1357

### DIFF
--- a/driver/level3/level3.c
+++ b/driver/level3/level3.c
@@ -251,11 +251,11 @@ int CNAME(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n,
   if ((k == 0) || (alpha == NULL)) return 0;
 
 #if !defined(XDOUBLE) || !defined(QUAD_PRECISION)
-  if ((alpha[0] == ZERO)
+  if ( alpha[0] == ZERO
 #ifdef COMPLEX
-      && (alpha[1] == ZERO)
+      && alpha[1] == ZERO
 #endif
-      ) return 0;
+	 ) return 0; 
 #else
   if (((alpha[0].x[0] | alpha[0].x[1]
 #ifdef COMPLEX

--- a/driver/level3/level3_syr2k.c
+++ b/driver/level3/level3_syr2k.c
@@ -154,9 +154,9 @@ int CNAME(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, FLOAT *sa, FLO
 
   if ((k == 0) || (alpha == NULL)) return 0;
 
-  if ((alpha[0] == ZERO)
+  if (alpha[0] == ZERO
 #ifdef COMPLEX
-      && (alpha[1] == ZERO)
+      && alpha[1] == ZERO
 #endif
       ) return 0;
 

--- a/driver/level3/level3_syrk.c
+++ b/driver/level3/level3_syrk.c
@@ -158,9 +158,9 @@ int CNAME(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, FLOAT *sa, FLO
 
   if ((k == 0) || (alpha == NULL)) return 0;
 
-  if ((alpha[0] == ZERO)
+  if (alpha[0] == ZERO
 #if defined(COMPLEX) && !defined(HERK)
-      && (alpha[1] == ZERO)
+      && alpha[1] == ZERO
 #endif
       ) return 0;
 

--- a/driver/level3/level3_syrk_threaded.c
+++ b/driver/level3/level3_syrk_threaded.c
@@ -200,9 +200,9 @@ static int inner_thread(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, 
 
   if ((k == 0) || (alpha == NULL)) return 0;
 
-  if ((alpha[0] == ZERO)
+  if (alpha[0] == ZERO
 #if defined(COMPLEX) && !defined(HERK)
-      && (alpha[1] == ZERO)
+      && alpha[1] == ZERO
 #endif
       ) return 0;
 

--- a/driver/level3/level3_thread.c
+++ b/driver/level3/level3_thread.c
@@ -295,9 +295,9 @@ static int inner_thread(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, 
 
   /* Return early if no more computation is needed */
   if ((k == 0) || (alpha == NULL)) return 0;
-  if ((alpha[0] == ZERO)
+  if (alpha[0] == ZERO
 #ifdef COMPLEX
-      && (alpha[1] == ZERO)
+      && alpha[1] == ZERO
 #endif
       ) return 0;
 

--- a/driver/others/init.c
+++ b/driver/others/init.c
@@ -237,7 +237,7 @@ static inline void get_cpumap(int node, unsigned long * node_info) {
     if(k!=0){
       name[k]='\0';
       affinity[count++] = strtoul(name, &dummy, 16);
-      k=0;
+      // k=0;
     }
     // 0-63bit -> node_info[0], 64-128bit -> node_info[1] ....
     // revert the sequence
@@ -293,7 +293,7 @@ static inline void get_share(int cpu, int level, unsigned long * share) {
     if(k!=0){
       name[k]='\0';
       affinity[count++] = strtoul(name, &dummy, 16);
-      k=0;
+      // k=0;
     }
     // 0-63bit -> node_info[0], 64-128bit -> node_info[1] ....
     // revert the sequence

--- a/kernel/generic/laswp_ncopy_8.c
+++ b/kernel/generic/laswp_ncopy_8.c
@@ -288,7 +288,7 @@ int CNAME(BLASLONG n, BLASLONG k1, BLASLONG k2, FLOAT *a, BLASLONG lda, blasint 
       i++;
     } while (i <= k2);
 
-    a += lda;
+    // a += lda;
   }
 
   return 0;

--- a/kernel/generic/neg_tcopy_16.c
+++ b/kernel/generic/neg_tcopy_16.c
@@ -379,7 +379,7 @@ int CNAME(BLASLONG m, BLASLONG n, FLOAT *a, BLASLONG lda, FLOAT *b){
     if (m & 1){
       ctemp01 = *(aoffset1 +  0);
       *(boffset +  0) = -ctemp01;
-      boffset   += 1;
+      // boffset   += 1;
     }
   }
 

--- a/kernel/generic/neg_tcopy_8.c
+++ b/kernel/generic/neg_tcopy_8.c
@@ -719,10 +719,10 @@ int CNAME(BLASLONG m, BLASLONG n, FLOAT *a, BLASLONG lda, FLOAT *b){
 
   if (m & 1){
     aoffset1  = aoffset;
-    aoffset += lda;
+    // aoffset += lda;
 
     boffset1  = boffset;
-    boffset  += 8;
+    // boffset  += 8;
 
     i = (n >> 3);
     if (i > 0){
@@ -762,7 +762,7 @@ int CNAME(BLASLONG m, BLASLONG n, FLOAT *a, BLASLONG lda, FLOAT *b){
        *(boffset2 +  1) = -ctemp02;
        *(boffset2 +  2) = -ctemp03;
        *(boffset2 +  3) = -ctemp04;
-       boffset2 += 4;
+       // boffset2 += 4;
      }
 
      if (n & 2){
@@ -772,7 +772,7 @@ int CNAME(BLASLONG m, BLASLONG n, FLOAT *a, BLASLONG lda, FLOAT *b){
 
        *(boffset3 +  0) = -ctemp01;
        *(boffset3 +  1) = -ctemp02;
-       boffset3 += 2;
+       // boffset3 += 2;
      }
 
      if (n & 1){

--- a/kernel/generic/trmm_lncopy_8.c
+++ b/kernel/generic/trmm_lncopy_8.c
@@ -635,7 +635,7 @@ int CNAME(BLASLONG m, BLASLONG n, FLOAT *a, BLASLONG lda, BLASLONG posX, BLASLON
 	    data05 = *(ao1 + 4);
 	    data06 = *(ao1 + 5);
 	    data07 = *(ao1 + 6);
-	    data08 = *(ao1 + 7);
+	    // data08 = *(ao1 + 7);
 
 	    if (i >= 2) {
 #ifndef UNIT
@@ -646,7 +646,7 @@ int CNAME(BLASLONG m, BLASLONG n, FLOAT *a, BLASLONG lda, BLASLONG posX, BLASLON
 	      data13 = *(ao2 + 4);
 	      data14 = *(ao2 + 5);
 	      data15 = *(ao2 + 6);
-	      data16 = *(ao2 + 7);
+	      // data16 = *(ao2 + 7);
 	    }
 
 	    if (i >= 3) {
@@ -657,7 +657,7 @@ int CNAME(BLASLONG m, BLASLONG n, FLOAT *a, BLASLONG lda, BLASLONG posX, BLASLON
 	      data21 = *(ao3 + 4);
 	      data22 = *(ao3 + 5);
 	      data23 = *(ao3 + 6);
-	      data24 = *(ao3 + 7);
+	      // data24 = *(ao3 + 7);
 	    }
 
 	    if (i >= 4) {
@@ -667,7 +667,7 @@ int CNAME(BLASLONG m, BLASLONG n, FLOAT *a, BLASLONG lda, BLASLONG posX, BLASLON
 	      data29 = *(ao4 + 4);
 	      data30 = *(ao4 + 5);
 	      data31 = *(ao4 + 6);
-	      data32 = *(ao4 + 7);
+	      // data32 = *(ao4 + 7);
 	    }
 
 	    if (i >= 5) {
@@ -676,7 +676,7 @@ int CNAME(BLASLONG m, BLASLONG n, FLOAT *a, BLASLONG lda, BLASLONG posX, BLASLON
 #endif
 	      data38 = *(ao5 + 5);
 	      data39 = *(ao5 + 6);
-	      data40 = *(ao5 + 7);
+	      // data40 = *(ao5 + 7);
 	    }
 
 	    if (i >= 6) {
@@ -684,14 +684,14 @@ int CNAME(BLASLONG m, BLASLONG n, FLOAT *a, BLASLONG lda, BLASLONG posX, BLASLON
 	      data46 = *(ao6 + 5);
 #endif
 	      data47 = *(ao6 + 6);
-	      data48 = *(ao6 + 7);
+	      // data48 = *(ao6 + 7);
 	    }
 
 	    if (i >= 7) {
 #ifndef UNIT
 	      data55 = *(ao7 + 6);
 #endif
-	      data56 = *(ao7 + 7);
+	      // data56 = *(ao7 + 7);
 	    }
 
 #ifdef UNIT
@@ -1032,14 +1032,14 @@ int CNAME(BLASLONG m, BLASLONG n, FLOAT *a, BLASLONG lda, BLASLONG posX, BLASLON
 #endif
 	    data02 = *(ao1 + 1);
 	    data03 = *(ao1 + 2);
-	    data04 = *(ao1 + 3);
+	    // data04 = *(ao1 + 3);
 
 	    if (i >= 2) {
 #ifndef UNIT
 	      data10 = *(ao2 + 1);
 #endif
 	      data11 = *(ao2 + 2);
-	      data12 = *(ao2 + 3);
+	      // data12 = *(ao2 + 3);
 
 	    }
 
@@ -1047,7 +1047,7 @@ int CNAME(BLASLONG m, BLASLONG n, FLOAT *a, BLASLONG lda, BLASLONG posX, BLASLON
 #ifndef UNIT
 	      data19 = *(ao3 + 2);
 #endif
-	      data20 = *(ao3 + 3);
+	      // data20 = *(ao3 + 3);
 	    }
 
 #ifdef UNIT

--- a/kernel/generic/trmm_utcopy_8.c
+++ b/kernel/generic/trmm_utcopy_8.c
@@ -685,7 +685,7 @@ int CNAME(BLASLONG m, BLASLONG n, FLOAT *a, BLASLONG lda, BLASLONG posX, BLASLON
 	    data33 = *(ao5 + 0);
 	    data41 = *(ao6 + 0);
 	    data49 = *(ao7 + 0);
-	    data57 = *(ao8 + 0);
+	    // data57 = *(ao8 + 0);
 
 	    if (i >= 2) {
 #ifndef UNIT
@@ -696,7 +696,7 @@ int CNAME(BLASLONG m, BLASLONG n, FLOAT *a, BLASLONG lda, BLASLONG posX, BLASLON
 	      data34 = *(ao5 + 1);
 	      data42 = *(ao6 + 1);
 	      data50 = *(ao7 + 1);
-	      data58 = *(ao8 + 1);
+	      // data58 = *(ao8 + 1);
 	    }
 
 	    if (i >= 3) {
@@ -707,7 +707,7 @@ int CNAME(BLASLONG m, BLASLONG n, FLOAT *a, BLASLONG lda, BLASLONG posX, BLASLON
 	      data35 = *(ao5 + 2);
 	      data43 = *(ao6 + 2);
 	      data51 = *(ao7 + 2);
-	      data59 = *(ao8 + 2);
+	      // data59 = *(ao8 + 2);
 	    }
 
 	    if (i >= 4) {
@@ -717,7 +717,7 @@ int CNAME(BLASLONG m, BLASLONG n, FLOAT *a, BLASLONG lda, BLASLONG posX, BLASLON
 	      data36 = *(ao5 + 3);
 	      data44 = *(ao6 + 3);
 	      data52 = *(ao7 + 3);
-	      data60 = *(ao8 + 3);
+	      // data60 = *(ao8 + 3);
 	    }
 
 	    if (i >= 5) {
@@ -726,7 +726,7 @@ int CNAME(BLASLONG m, BLASLONG n, FLOAT *a, BLASLONG lda, BLASLONG posX, BLASLON
 #endif
 	      data45 = *(ao6 + 4);
 	      data53 = *(ao7 + 4);
-	      data61 = *(ao8 + 4);
+	      // data61 = *(ao8 + 4);
 	    }
 
 	    if (i >= 6) {
@@ -734,14 +734,14 @@ int CNAME(BLASLONG m, BLASLONG n, FLOAT *a, BLASLONG lda, BLASLONG posX, BLASLON
 	      data46 = *(ao6 + 5);
 #endif
 	      data54 = *(ao7 + 5);
-	      data62 = *(ao8 + 5);
+	      // data62 = *(ao8 + 5);
 	    }
 
 	    if (i >= 7) {
 #ifndef UNIT
 	      data55 = *(ao7 + 6);
 #endif
-	      data63 = *(ao8 + 6);
+	      // data63 = *(ao8 + 6);
 	    }
 
 #ifdef UNIT
@@ -1074,27 +1074,27 @@ int CNAME(BLASLONG m, BLASLONG n, FLOAT *a, BLASLONG lda, BLASLONG posX, BLASLON
 	    }
 	  } else {
 
-#ifndef UNIT
+/* #ifndef UNIT
 	    data01 = *(ao1 + 0);
-#endif
+#endif */
 	    data09 = *(ao2 + 0);
 	    data17 = *(ao3 + 0);
-	    data25 = *(ao4 + 0);
+	    // data25 = *(ao4 + 0);
 
 	    if (i >= 2) {
-#ifndef UNIT
+/* #ifndef UNIT
 	      data10 = *(ao2 + 1);
-#endif
+#endif */
 	      data18 = *(ao3 + 1);
-	      data26 = *(ao4 + 1);
+	      // data26 = *(ao4 + 1);
 	    }
 
-	    if (i >= 3) {
+/* 	    if (i >= 3) {
 #ifndef UNIT
 	      data19 = *(ao3 + 2);
 #endif
 	      data27 = *(ao4 + 2);
-	    }
+	    } */
 
 #ifndef UNIT
 	    b[ 0] = ONE;

--- a/kernel/generic/trsm_uncopy_8.c
+++ b/kernel/generic/trsm_uncopy_8.c
@@ -628,13 +628,13 @@ int CNAME(BLASLONG m, BLASLONG n, FLOAT *a, BLASLONG lda, BLASLONG offset, FLOAT
 
       if (ii < jj) {
 	data01 = *(a1 + 0);
-	data02 = *(a1 + 1);
+	// data02 = *(a1 + 1);
 	data09 = *(a2 + 0);
-	data10 = *(a2 + 1);
+	// data10 = *(a2 + 1);
 	data17 = *(a3 + 0);
-	data18 = *(a3 + 1);
+	// data18 = *(a3 + 1);
 	data25 = *(a4 + 0);
-	data26 = *(a4 + 1);
+	// data26 = *(a4 + 1);
 
 	*(b +  0) = data01;
 	*(b +  1) = data09;

--- a/kernel/generic/trsm_utcopy_8.c
+++ b/kernel/generic/trsm_utcopy_8.c
@@ -649,14 +649,14 @@ int CNAME(BLASLONG m, BLASLONG n, FLOAT *a, BLASLONG lda, BLASLONG offset, FLOAT
 
     if (m & 2) {
       if (ii == jj) {
-#ifndef UNIT
+/* #ifndef UNIT
 	data01 = *(a1 + 0);
 #endif
 
 	data09 = *(a2 + 0);
 #ifndef UNIT
 	data10 = *(a2 + 1);
-#endif
+#endif */
       }
 
       if (ii > jj) {

--- a/kernel/generic/zlaswp_ncopy_2.c
+++ b/kernel/generic/zlaswp_ncopy_2.c
@@ -372,7 +372,7 @@ int CNAME(BLASLONG n, BLASLONG k1, BLASLONG k2, FLOAT *a, BLASLONG lda, blasint 
 	*(b1 + 0) = A1;
 	*(b1 + 1) = A2;
       }
-      buffer += 2;
+      // buffer += 2;
     }
   }
 

--- a/kernel/generic/zlaswp_ncopy_4.c
+++ b/kernel/generic/zlaswp_ncopy_4.c
@@ -702,7 +702,7 @@ int CNAME(BLASLONG n, BLASLONG k1, BLASLONG k2, FLOAT *a, BLASLONG lda, blasint 
 	*(b1 + 0) = A1;
 	*(b1 + 1) = A2;
       }
-      buffer += 2;
+      // buffer += 2;
     }
   }
 

--- a/kernel/generic/zneg_tcopy_2.c
+++ b/kernel/generic/zneg_tcopy_2.c
@@ -140,7 +140,7 @@ int CNAME(BLASLONG m, BLASLONG n, FLOAT *a, BLASLONG lda, FLOAT *b){
 	*(b_offset1 + 6) = -ctemp11;
 	*(b_offset1 + 7) = -ctemp12;
 
-	b_offset1 += m * 4;
+	// b_offset1 += m * 4;
 	a_offset1 += 4;
 	a_offset2 += 4;
       }
@@ -204,7 +204,7 @@ int CNAME(BLASLONG m, BLASLONG n, FLOAT *a, BLASLONG lda, FLOAT *b){
       *(b_offset + 2) = -ctemp3;
       *(b_offset + 3) = -ctemp4;
 
-      b_offset += m * 4;
+      // b_offset += m * 4;
       a_offset += 4;
     }
 

--- a/kernel/generic/zneg_tcopy_4.c
+++ b/kernel/generic/zneg_tcopy_4.c
@@ -233,10 +233,10 @@ int CNAME(BLASLONG m, BLASLONG n, FLOAT *a, BLASLONG lda, FLOAT *b){
 	*(boffset3 +  6) = -ctemp07;
 	*(boffset3 +  7) = -ctemp08;
 
-	aoffset1 += 2;
+	/* aoffset1 += 2;
 	aoffset2 += 2;
 	aoffset3 += 2;
-	aoffset4 += 2;
+	aoffset4 += 2; */
 
 	boffset3 += 8;
       }
@@ -293,8 +293,8 @@ int CNAME(BLASLONG m, BLASLONG n, FLOAT *a, BLASLONG lda, FLOAT *b){
 
 	aoffset1 += 8;
 	aoffset2 += 8;
-	aoffset3 += 8;
-	aoffset4 += 8;
+	/* aoffset3 += 8;
+	aoffset4 += 8; */
 
 	boffset1 += m * 8;
 	i --;
@@ -338,8 +338,8 @@ int CNAME(BLASLONG m, BLASLONG n, FLOAT *a, BLASLONG lda, FLOAT *b){
       *(boffset3 +  2) = -ctemp03;
       *(boffset3 +  3) = -ctemp04;
 
-      aoffset1 += 2;
-      aoffset2 += 2;
+      /* aoffset1 += 2;
+      aoffset2 += 2; */
       boffset3 += 4;
     }
   }
@@ -387,7 +387,7 @@ int CNAME(BLASLONG m, BLASLONG n, FLOAT *a, BLASLONG lda, FLOAT *b){
       *(boffset2 +  3) = -ctemp04;
 
       aoffset1 += 4;
-      boffset2 += 4;
+      // boffset2 += 4;
     }
 
     if (n & 1){

--- a/kernel/generic/zneg_tcopy_8.c
+++ b/kernel/generic/zneg_tcopy_8.c
@@ -324,7 +324,7 @@ int CNAME(BLASLONG m, BLASLONG n, FLOAT *a, BLASLONG lda, FLOAT *b){
   if (n & 1){
     aoffset1  = aoffset;
     aoffset2  = aoffset + lda;
-    aoffset += 2;
+    // aoffset += 2;
 
     i = (m >> 1);
     if (i > 0){
@@ -353,7 +353,7 @@ int CNAME(BLASLONG m, BLASLONG n, FLOAT *a, BLASLONG lda, FLOAT *b){
 
       *(boffset +  0) = -ctemp01;
       *(boffset +  1) = -ctemp02;
-      boffset   += 2;
+      // boffset   += 2;
     }
   }
 

--- a/kernel/x86_64/dgemv_n_4.c
+++ b/kernel/x86_64/dgemv_n_4.c
@@ -281,8 +281,8 @@ int CNAME(BLASLONG m, BLASLONG n, BLASLONG dummy1, FLOAT alpha, FLOAT *a, BLASLO
 			if ( n2 & 1 )
 			{
 				dgemv_kernel_4x1(NB,a_ptr,x_ptr,ybuffer,&alpha);
-				a_ptr += lda;
-				x_ptr += 1;	
+				/* a_ptr += lda;
+				x_ptr += 1; */
 
 			}
 

--- a/kernel/x86_64/dgemv_t_4.c
+++ b/kernel/x86_64/dgemv_t_4.c
@@ -393,9 +393,9 @@ int CNAME(BLASLONG m, BLASLONG n, BLASLONG dummy1, FLOAT alpha, FLOAT *a, BLASLO
 		{
 
 			dgemv_kernel_4x1(NB,a_ptr,xbuffer,ybuffer);
-			a_ptr  += lda;
+			// a_ptr  += lda;
 			*y_ptr += ybuffer[0] * alpha;
-			y_ptr  += inc_y;
+			// y_ptr  += inc_y;
 
 		}
 		a += NB;

--- a/lapack/getrf/getrf_single.c
+++ b/lapack/getrf/getrf_single.c
@@ -51,7 +51,7 @@ blasint CNAME(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, FLOAT *sa,
   BLASLONG jjs, min_jj;
   blasint *ipiv, iinfo, info;
   BLASLONG jb, mn, blocking;
-  FLOAT *a, *offsetA, *offsetB;
+  FLOAT *a, *offsetA; //, *offsetB;
   BLASLONG range_N[2];
 
   FLOAT *sbb;
@@ -99,7 +99,7 @@ blasint CNAME(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, FLOAT *sa,
     if (jb > blocking) jb = blocking;
 
     offsetA = a +  j       * lda * COMPSIZE;
-    offsetB = a + (j + jb) * lda * COMPSIZE;
+    // offsetB = a + (j + jb) * lda * COMPSIZE;
 
     range_N[0] = offset + j;
     range_N[1] = offset + j + jb;

--- a/lapack/trti2/ztrti2_L.c
+++ b/lapack/trti2/ztrti2_L.c
@@ -67,8 +67,6 @@ blasint CNAME(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, FLOAT *sa,
 
   for (j = n - 1; j >= 0; j--) {
 
-    ajj_r =  ONE;
-    ajj_i =  ZERO;
 
 #ifndef UNIT
     ajj_r = *(a + (j + j * lda) * COMPSIZE + 0);
@@ -88,6 +86,9 @@ blasint CNAME(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, FLOAT *sa,
 
   *(a + (j + j * lda) * COMPSIZE + 0) = ajj_r;
   *(a + (j + j * lda) * COMPSIZE + 1) = ajj_i;
+#else
+    ajj_r =  ONE;
+    ajj_i =  ZERO;
 #endif
 
   ZTRMV (n - j - 1,

--- a/lapack/trti2/ztrti2_U.c
+++ b/lapack/trti2/ztrti2_U.c
@@ -67,8 +67,6 @@ blasint CNAME(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, FLOAT *sa,
 
   for (j = 0; j < n; j++) {
 
-    ajj_r =  ONE;
-    ajj_i =  ZERO;
 
 #ifndef UNIT
     ajj_r = *(a + (j + j * lda) * COMPSIZE + 0);
@@ -89,6 +87,9 @@ blasint CNAME(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, FLOAT *sa,
 
   *(a + (j + j * lda) * COMPSIZE + 0) = ajj_r;
   *(a + (j + j * lda) * COMPSIZE + 1) = ajj_i;
+#else
+    ajj_r =  ONE;
+    ajj_i =  ZERO;
 #endif
 
   ZTRMV (j,


### PR DESCRIPTION
This is last in #1357 series. Makes OpenBLAS code compile with GCC without spitting a single line of warning. i.e `make CC=gcc DYNAMIC_ARCH=1 NO_CBLAS=1 FC=DISABLED` .

PS @luotao1 : this addresses warnings in OpenBLAS code, but does not touch imported upstream/reference lapack code.