### PR TITLE
When forcing USE_THREAD to zero, override USE_OPENMP as well

### DIFF
--- a/Makefile.system
+++ b/Makefile.system
@@ -181,6 +181,7 @@ endif
 
 ifeq ($(NUM_THREADS), 1)
 override USE_THREAD = 0
+override USE_OPENMP = 0
 endif
 
 ifdef USE_THREAD


### PR DESCRIPTION
This avoids an error exit a few lines down as USE_THREAD=0 conflicts with USE_OPENMP=1.
Fixes #1428 - though it may be debatable if it is really necessary to disable multithreading just because the (virtualized) build host does not support it.