### PR TITLE
Generate CHAR_CORENAME for SPARC

### DIFF
--- a/cpuid_sparc.c
+++ b/cpuid_sparc.c
@@ -57,3 +57,8 @@ void get_cpuconfig(void){
 void get_libname(void){
   printf("v9\n");
 }
+
+void get_corename(void){
+  printf("sparc\n");
+}
+

--- a/cpuid_sparc.c
+++ b/cpuid_sparc.c
@@ -58,7 +58,7 @@ void get_libname(void){
   printf("v9\n");
 }
 
-void get_corename(void){
-  printf("sparc\n");
+char *get_corename(void){
+  return "sparc";
 }
 

--- a/getarch.c
+++ b/getarch.c
@@ -1116,7 +1116,7 @@ int main(int argc, char *argv[]){
 #ifdef FORCE
     printf("CORE=%s\n", CORENAME);
 #else
-#if defined(INTEL_AMD) || defined(POWER) || defined(__mips__) || defined(__arm__) || defined(__aarch64__) || defined(ZARCH)
+#if defined(INTEL_AMD) || defined(POWER) || defined(__mips__) || defined(__arm__) || defined(__aarch64__) || defined(ZARCH) || defined(sparc)
     printf("CORE=%s\n", get_corename());
 #endif
 #endif
@@ -1224,7 +1224,7 @@ int main(int argc, char *argv[]){
 #ifdef FORCE
     printf("#define CHAR_CORENAME \"%s\"\n", CORENAME);
 #else
-#if defined(INTEL_AMD) || defined(POWER) || defined(__mips__) || defined(__arm__) || defined(__aarch64__) || defined(ZARCH)
+#if defined(INTEL_AMD) || defined(POWER) || defined(__mips__) || defined(__arm__) || defined(__aarch64__) || defined(ZARCH) || defined(sparc)
     printf("#define CHAR_CORENAME \"%s\"\n", get_corename());
 #endif
 #endif


### PR DESCRIPTION
Should fix #1446, getting automatic target detection working (again?) for the Sparc platform