### PR TITLE
retire 3DNOW assembly

### DIFF
--- a/kernel/x86/KERNEL.ATHLON
+++ b/kernel/x86/KERNEL.ATHLON
@@ -1,4 +1,4 @@
-SGEMMKERNEL    =  gemm_kernel_2x4_3dnow.S
+# SGEMMKERNEL    =  gemm_kernel_2x4_3dnow.S
 SGEMMINCOPY    =  ../generic/gemm_ncopy_2.c
 SGEMMITCOPY    =  ../generic/gemm_tcopy_2.c
 SGEMMONCOPY    =  ../generic/gemm_ncopy_4.c
@@ -16,7 +16,7 @@ DGEMMINCOPYOBJ =  dgemm_incopy$(TSUFFIX).$(SUFFIX)
 DGEMMITCOPYOBJ =  dgemm_itcopy$(TSUFFIX).$(SUFFIX)
 DGEMMONCOPYOBJ =  dgemm_oncopy$(TSUFFIX).$(SUFFIX)
 DGEMMOTCOPYOBJ =  dgemm_otcopy$(TSUFFIX).$(SUFFIX)
-CGEMMKERNEL    =  zgemm_kernel_1x2_3dnow.S
+# CGEMMKERNEL    =  zgemm_kernel_1x2_3dnow.S
 CGEMMINCOPY    =  ../generic/zgemm_ncopy_1.c
 CGEMMITCOPY    =  ../generic/zgemm_tcopy_1.c
 CGEMMONCOPY    =  ../generic/zgemm_ncopy_2.c


### PR DESCRIPTION
There is no 3DNOW in modern processors (reciting xianyi on absence of this extension in current CPUs)
Leftover 3DNOW prefetch instructions are not used in OpenBLAS assembly.
Impact - respective athlon(32) gets 20% slower at GEMM. Raspberry pi jumps around it in circles today for difference in electricity expense alone.