### PR TITLE
Remove spurious EXTERNAL reference

### DIFF
--- a/lapack-netlib/SRC/dsytrf_aa_2stage.f
+++ b/lapack-netlib/SRC/dsytrf_aa_2stage.f
@@ -191,7 +191,7 @@
       EXTERNAL           LSAME, ILAENV
 *     ..
 *     .. External Subroutines ..
-      EXTERNAL           XERBLA, DCOPY, DLACGV, DLACPY,
+      EXTERNAL           XERBLA, DCOPY, DLACPY,
      $                   DLASET, DGBTRF, DGEMM,  DGETRF, 
      $                   DSYGST, DSWAP, DTRSM 
 *     ..

--- a/lapack-netlib/SRC/ssytrf_aa_2stage.f
+++ b/lapack-netlib/SRC/ssytrf_aa_2stage.f
@@ -191,7 +191,7 @@
       EXTERNAL           LSAME, ILAENV
 *     ..
 *     .. External Subroutines ..
-      EXTERNAL           XERBLA, SCOPY, SLACGV, SLACPY,
+      EXTERNAL           XERBLA, SCOPY, SLACPY,
      $                   SLASET, SGBTRF, SGEMM,  SGETRF, 
      $                   SSYGST, SSWAP, STRSM 
 *     ..


### PR DESCRIPTION
From Reference-LAPACK issue 228, remove spurious EXTERNAL reference to unused and nonexistent function xLACGV that could cause linking problems.