### PR TITLE
test_fork is not meant to be run (nor expected to work) with OpenMP

### DIFF
--- a/utest/Makefile
+++ b/utest/Makefile
@@ -15,11 +15,13 @@ ifneq ($(NO_LAPACK), 1)
 #OBJS += test_potrs.o
 endif
 
+ifndef USE_OPENMP
 ifndef OS_WINDOWS
 OBJS += test_fork.o
 else
 ifdef OS_CYGWIN_NT
 OBJS += test_fork.o
+endif
 endif
 endif
 


### PR DESCRIPTION
Fixes #1456