### PR TITLE
Revert insidious suppression of the -fopenmp flag in the LAPACK subtree

### DIFF
--- a/lapack-netlib/SRC/Makefile
+++ b/lapack-netlib/SRC/Makefile
@@ -533,7 +533,9 @@ ZLASRC = $(filter-out $(ZLAPACKOBJS),$(ZLASRC_O))
 DSLASRC = $(filter-out $(SLAPACKOBJS),$(DSLASRC_O))
 ZCLASRC = $(filter-out $(CLAPACKOBJS),$(ZCLASRC_O))
 
-OPTS1 = $(filter-out -fopenmp, $(OPTS))
+#from commit 1046, supposedly related to mingw but breaks thread safety
+#in insiduous ways on all platforms when used in place of OPTS below
+#OPTS1 = $(filter-out -fopenmp, $(OPTS))
 #end filter out
 
 
@@ -597,10 +599,10 @@ clean:
 	rm -f *.o DEPRECATED/*.o
 
 .f.o:
-	$(FORTRAN) $(OPTS1) -c -o $@ $<
+	$(FORTRAN) $(OPTS) -c -o $@ $<
 
 .F.o:
-	$(FORTRAN) $(OPTS1) -c $< -o $@
+	$(FORTRAN) $(OPTS) -c $< -o $@
 	
 slaruv.o: slaruv.f ; $(FORTRAN) $(NOOPT) -c -o $@ $<
 dlaruv.o: dlaruv.f ; $(FORTRAN) $(NOOPT) -c -o $@ $<

--- a/lapack-netlib/SRC/chetrd_hb2st.F
+++ b/lapack-netlib/SRC/chetrd_hb2st.F
@@ -512,7 +512,7 @@ C                 END IF
 *
 *                         Call the kernel
 *                             
-#if defined(_OPENMP)
+#if defined(_OPENMP) && _OPENMP >= 201307L
                           IF( TTYPE.NE.1 ) THEN      
 !$OMP TASK DEPEND(in:WORK(MYID+SHIFT-1))
 !$OMP$     DEPEND(in:WORK(MYID-1))

--- a/lapack-netlib/SRC/dsytrd_sb2st.F
+++ b/lapack-netlib/SRC/dsytrd_sb2st.F
@@ -481,7 +481,7 @@
 *
 *                         Call the kernel
 *                             
-#if defined(_OPENMP)
+#if defined(_OPENMP) &&  _OPENMP >= 201307L
                           IF( TTYPE.NE.1 ) THEN      
 !$OMP TASK DEPEND(in:WORK(MYID+SHIFT-1))
 !$OMP$     DEPEND(in:WORK(MYID-1))

--- a/lapack-netlib/SRC/ssytrd_sb2st.F
+++ b/lapack-netlib/SRC/ssytrd_sb2st.F
@@ -481,7 +481,7 @@
 *
 *                         Call the kernel
 *                             
-#if defined(_OPENMP)
+#if defined(_OPENMP) && _OPENMP >= 201307
                           IF( TTYPE.NE.1 ) THEN      
 !$OMP TASK DEPEND(in:WORK(MYID+SHIFT-1))
 !$OMP$     DEPEND(in:WORK(MYID-1))

--- a/lapack-netlib/SRC/zhetrd_hb2st.F
+++ b/lapack-netlib/SRC/zhetrd_hb2st.F
@@ -512,7 +512,8 @@ C                 END IF
 *
 *                         Call the kernel
 *                             
-#if defined(_OPENMP)
+#if defined(_OPENMP) &&  _OPENMP >= 201307L
+
                           IF( TTYPE.NE.1 ) THEN      
 !$OMP TASK DEPEND(in:WORK(MYID+SHIFT-1))
 !$OMP$     DEPEND(in:WORK(MYID-1))


### PR DESCRIPTION
This was added in #1046 citing a problem with mingw, but in effect it quietly reduces thread safety on all non-Windows platforms (while -fopenmp is already disabled for Windows builds through the toplevel Makefile.system). Removing the filter fixes #1425