### PR TITLE
Restore the remaining utests

### DIFF
--- a/kernel/x86/KERNEL.NEHALEM
+++ b/kernel/x86/KERNEL.NEHALEM
@@ -1,1 +1,3 @@
 include $(KERNELDIR)/KERNEL.PENRYN
+SSWAPKERNEL  = ../arm/swap.c
+DSWAPKERNEL  = ../arm/swap.c

--- a/utest/CMakeLists.txt
+++ b/utest/CMakeLists.txt
@@ -18,7 +18,7 @@ endif ()
 # crashing on travis cl with an error code suggesting resource not found
 if (NOT MSVC)
 set(OpenBLAS_utest_src
-  $(OpenBLAS_utest_src}
+  ${OpenBLAS_utest_src}
   test_dotu.c
   )
 endif ()

--- a/utest/CMakeLists.txt
+++ b/utest/CMakeLists.txt
@@ -16,13 +16,10 @@ else ()
   )
 endif ()
 
+# known to hang with the native Windows and Android threads
+# FIXME needs checking if this works on any of the other platforms
 if (NOT USE_OPENMP)
-if (NOT OS_WINDOWS)
-set(OpenBLAS_utest_src
-  ${OpenBLAS_utest_src}
-  test_fork.c
-  )
-elseif (OS_CYGWIN_NT)
+if (OS_CYGWIN_NT OR OS_LINUX)
 set(OpenBLAS_utest_src
   ${OpenBLAS_utest_src}
   test_fork.c

--- a/utest/CMakeLists.txt
+++ b/utest/CMakeLists.txt
@@ -8,8 +8,27 @@ else ()
     utest_main.c
     test_amax.c
     test_rotmg.c
+    test_rot.c
+    test_axpy.c
+    test_dotu.c
+    test_dsdot.c
+    test_swap.c
   )
 endif ()
+
+if (NOT USE_OPENMP)
+if (NOT OS_WINDOWS)
+set(OpenBLAS_utest_src
+  ${OpenBLAS_utest_src}
+  test_fork.c
+  )
+elseif (OS_CYGWIN_NT)
+set(OpenBLAS_utest_src
+  ${OpenBLAS_utest_src}
+  test_fork.c
+  )
+endif()
+endif()
 
 if (NOT NO_LAPACK)
 set(OpenBLAS_utest_src

--- a/utest/CMakeLists.txt
+++ b/utest/CMakeLists.txt
@@ -10,9 +10,16 @@ else ()
     test_rotmg.c
     test_rot.c
     test_axpy.c
-    test_dotu.c
     test_dsdot.c
     test_swap.c
+  )
+endif ()
+
+# crashing on travis cl with an error code suggesting resource not found
+if (NOT MSVC)
+set(OpenBLAS_utest_src
+  $(OpenBLAS_utest_src}
+  test_dotu.c
   )
 endif ()
 

--- a/utest/Makefile
+++ b/utest/Makefile
@@ -15,13 +15,11 @@ ifneq ($(NO_LAPACK), 1)
 #OBJS += test_potrs.o
 endif
 
+#this does not work with OpenMP nor with native Windows or Android threads
+# FIXME TBD if this works on OSX, SunOS, POWER and zarch
 ifndef USE_OPENMP
-ifndef OS_WINDOWS
+ifeq ($(OSNAME), $(filter $(OSNAME),Linux CYGWIN_NT))
 OBJS += test_fork.o
-else
-ifdef OS_CYGWIN_NT
-OBJS += test_fork.o
-endif
 endif
 endif
 

--- a/utest/Makefile
+++ b/utest/Makefile
@@ -8,12 +8,8 @@ UTESTBIN=openblas_utest
 
 include $(TOPDIR)/Makefile.system
 
-OBJS=utest_main.o test_amax.o test_rotmg.o test_axpy.o test_dsdot.o test_swap.o test_rot.o
+OBJS=utest_main.o test_amax.o test_rotmg.o test_axpy.o test_dotu.o test_dsdot.o test_swap.o test_rot.o
 #test_rot.o test_swap.o test_axpy.o test_dotu.o test_dsdot.o test_fork.o
-
-ifndef MSVC
-OBJS += test_dotu.o
-endif
 
 ifneq ($(NO_LAPACK), 1)
 OBJS += test_potrs.o

--- a/utest/Makefile
+++ b/utest/Makefile
@@ -8,11 +8,15 @@ UTESTBIN=openblas_utest
 
 include $(TOPDIR)/Makefile.system
 
-OBJS=utest_main.o test_amax.o test_rotmg.o test_axpy.o test_dotu.o test_dsdot.o test_swap.o test_rot.o
+OBJS=utest_main.o test_amax.o test_rotmg.o test_axpy.o test_dsdot.o test_swap.o test_rot.o
 #test_rot.o test_swap.o test_axpy.o test_dotu.o test_dsdot.o test_fork.o
 
+ifndef MSVC
+OBJS += test_dotu.o
+endif
+
 ifneq ($(NO_LAPACK), 1)
-#OBJS += test_potrs.o
+OBJS += test_potrs.o
 endif
 
 #this does not work with OpenMP nor with native Windows or Android threads

--- a/utest/Makefile
+++ b/utest/Makefile
@@ -8,18 +8,20 @@ UTESTBIN=openblas_utest
 
 include $(TOPDIR)/Makefile.system
 
-OBJS=utest_main.o test_amax.o test_rotmg.o
+OBJS=utest_main.o test_amax.o test_rotmg.o test_axpy.o test_dotu.o test_dsdot.o test_swap.o test_rot.o
 #test_rot.o test_swap.o test_axpy.o test_dotu.o test_dsdot.o test_fork.o
 
 ifneq ($(NO_LAPACK), 1)
 #OBJS += test_potrs.o
 endif
 
+ifndef USE_OPENMP
 ifndef OS_WINDOWS
 OBJS += test_fork.o
 else
 ifdef OS_CYGWIN_NT
 OBJS += test_fork.o
+endif
 endif
 endif
 

--- a/utest/test_axpy.c
+++ b/utest/test_axpy.c
@@ -35,8 +35,8 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 CTEST(axpy,daxpy_inc_0)
 {
-	int i;
-	int N=8,incX=0,incY=0;
+	blasint i;
+	blasint N=8,incX=0,incY=0;
 	double a=0.25;
 	double x1[]={1.0,3.0,5.0,7.0,1.0,3.0,5.0,7.0};
 	double y1[]={2.0,4.0,6.0,8.0,2.0,4.0,6.0,8.0};
@@ -55,8 +55,8 @@ CTEST(axpy,daxpy_inc_0)
 
 CTEST(axpy,zaxpy_inc_0)
 {
-	int i;
-	int N=4,incX=0,incY=0;
+	blasint i;
+	blasint N=4,incX=0,incY=0;
 	double a[2]={0.25,0.5};
 	double x1[]={1.0,3.0,5.0,7.0,1.0,3.0,5.0,7.0};
 	double y1[]={2.0,4.0,6.0,8.0,2.0,4.0,6.0,8.0};
@@ -74,8 +74,8 @@ CTEST(axpy,zaxpy_inc_0)
 
 CTEST(axpy,saxpy_inc_0)
 {
-	int i;
-	int N=8,incX=0,incY=0;
+	blasint i;
+	blasint N=8,incX=0,incY=0;
 	float a=0.25;
 	float x1[]={1.0,3.0,5.0,7.0,1.0,3.0,5.0,7.0};
 	float y1[]={2.0,4.0,6.0,8.0,2.0,4.0,6.0,8.0};
@@ -93,8 +93,8 @@ CTEST(axpy,saxpy_inc_0)
 
 CTEST(axpy,caxpy_inc_0)
 {
-	int i;
-	int N=4,incX=0,incY=0;
+	blasint i;
+	blasint N=4,incX=0,incY=0;
 	float a[2]={0.25,0.5};
 	float x1[]={1.0,3.0,5.0,7.0,1.0,3.0,5.0,7.0};
 	float y1[]={2.0,4.0,6.0,8.0,2.0,4.0,6.0,8.0};

--- a/utest/test_axpy.c
+++ b/utest/test_axpy.c
@@ -31,30 +31,29 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 **********************************************************************************/
 
-#include "common_utest.h"
+#include "openblas_utest.h"
 
-void test_daxpy_inc_0(void)
+CTEST(axpy,daxpy_inc_0)
 {
 	int i;
 	int N=8,incX=0,incY=0;
 	double a=0.25;
 	double x1[]={1.0,3.0,5.0,7.0,1.0,3.0,5.0,7.0};
 	double y1[]={2.0,4.0,6.0,8.0,2.0,4.0,6.0,8.0};
+
 	double x2[]={1.0,3.0,5.0,7.0,1.0,3.0,5.0,7.0};
-	double y2[]={2.0,4.0,6.0,8.0,2.0,4.0,6.0,8.0};
+	double y2[]={4.0,4.0,6.0,8.0,2.0,4.0,6.0,8.0};
 
 	//OpenBLAS
 	BLASFUNC(daxpy)(&N,&a,x1,&incX,y1,&incY);
-	//reference
-	BLASFUNC_REF(daxpy)(&N,&a,x2,&incX,y2,&incY);
 
 	for(i=0; i<N; i++){
-		CU_ASSERT_DOUBLE_EQUAL(x1[i], x2[i], CHECK_EPS);
-		CU_ASSERT_DOUBLE_EQUAL(y1[i], y2[i], CHECK_EPS);
+		ASSERT_DBL_NEAR_TOL(x1[i], x2[i], DOUBLE_EPS);
+		ASSERT_DBL_NEAR_TOL(y1[i], y2[i], DOUBLE_EPS);
 	}
 }
 
-void test_zaxpy_inc_0(void)
+CTEST(axpy,zaxpy_inc_0)
 {
 	int i;
 	int N=4,incX=0,incY=0;
@@ -62,20 +61,18 @@ void test_zaxpy_inc_0(void)
 	double x1[]={1.0,3.0,5.0,7.0,1.0,3.0,5.0,7.0};
 	double y1[]={2.0,4.0,6.0,8.0,2.0,4.0,6.0,8.0};
 	double x2[]={1.0,3.0,5.0,7.0,1.0,3.0,5.0,7.0};
-	double y2[]={2.0,4.0,6.0,8.0,2.0,4.0,6.0,8.0};
+	double y2[]={-3.0,9.0,6.0,8.0,2.0,4.0,6.0,8.0};
 
 	//OpenBLAS
 	BLASFUNC(zaxpy)(&N,a,x1,&incX,y1,&incY);
-	//reference
-	BLASFUNC_REF(zaxpy)(&N,a,x2,&incX,y2,&incY);
 
 	for(i=0; i<2*N; i++){
-		CU_ASSERT_DOUBLE_EQUAL(x1[i], x2[i], CHECK_EPS);
-		CU_ASSERT_DOUBLE_EQUAL(y1[i], y2[i], CHECK_EPS);
+		ASSERT_DBL_NEAR_TOL(x1[i], x2[i], DOUBLE_EPS);
+		ASSERT_DBL_NEAR_TOL(y1[i], y2[i], DOUBLE_EPS);
 	}
 }
 
-void test_saxpy_inc_0(void)
+CTEST(axpy,saxpy_inc_0)
 {
 	int i;
 	int N=8,incX=0,incY=0;
@@ -83,20 +80,18 @@ void test_saxpy_inc_0(void)
 	float x1[]={1.0,3.0,5.0,7.0,1.0,3.0,5.0,7.0};
 	float y1[]={2.0,4.0,6.0,8.0,2.0,4.0,6.0,8.0};
 	float x2[]={1.0,3.0,5.0,7.0,1.0,3.0,5.0,7.0};
-	float y2[]={2.0,4.0,6.0,8.0,2.0,4.0,6.0,8.0};
+	float y2[]={4.0,4.0,6.0,8.0,2.0,4.0,6.0,8.0};
 
 	//OpenBLAS
 	BLASFUNC(saxpy)(&N,&a,x1,&incX,y1,&incY);
-	//reference
-	BLASFUNC_REF(saxpy)(&N,&a,x2,&incX,y2,&incY);
 
 	for(i=0; i<N; i++){
-		CU_ASSERT_DOUBLE_EQUAL(x1[i], x2[i], CHECK_EPS);
-		CU_ASSERT_DOUBLE_EQUAL(y1[i], y2[i], CHECK_EPS);
+		ASSERT_DBL_NEAR_TOL(x1[i], x2[i], DOUBLE_EPS);
+		ASSERT_DBL_NEAR_TOL(y1[i], y2[i], DOUBLE_EPS);
 	}
 }
 
-void test_caxpy_inc_0(void)
+CTEST(axpy,caxpy_inc_0)
 {
 	int i;
 	int N=4,incX=0,incY=0;
@@ -104,15 +99,13 @@ void test_caxpy_inc_0(void)
 	float x1[]={1.0,3.0,5.0,7.0,1.0,3.0,5.0,7.0};
 	float y1[]={2.0,4.0,6.0,8.0,2.0,4.0,6.0,8.0};
 	float x2[]={1.0,3.0,5.0,7.0,1.0,3.0,5.0,7.0};
-	float y2[]={2.0,4.0,6.0,8.0,2.0,4.0,6.0,8.0};
+	float y2[]={-3.0,9.0,6.0,8.0,2.0,4.0,6.0,8.0};
 
 	//OpenBLAS
 	BLASFUNC(caxpy)(&N,a,x1,&incX,y1,&incY);
-	//reference
-	BLASFUNC_REF(caxpy)(&N,a,x2,&incX,y2,&incY);
 
 	for(i=0; i<2*N; i++){
-		CU_ASSERT_DOUBLE_EQUAL(x1[i], x2[i], CHECK_EPS);
-		CU_ASSERT_DOUBLE_EQUAL(y1[i], y2[i], CHECK_EPS);
+		ASSERT_DBL_NEAR_TOL(x1[i], x2[i], DOUBLE_EPS);
+		ASSERT_DBL_NEAR_TOL(y1[i], y2[i], DOUBLE_EPS);
 	}
 }

--- a/utest/test_dotu.c
+++ b/utest/test_dotu.c
@@ -40,9 +40,9 @@ CTEST( zdotu,zdotu_n_1)
 	double x1[]={1.0,1.0};
 	double y1[]={1.0,2.0};
 #ifdef __CTEST_MSVC
-        _Dcomplex result1=openblas_make_complex_double{0.0,0.0};
+        _Dcomplex result1=openblas_make_complex_double(0.0,0.0);
 	_Dcomplex result2=openblas_make_complex_double(-1.0000,3.0000);
-	result1=BLASFUNC(zdotu)(&result1,&N,x1,&incX,y1,&incY);
+	result1=BLASFUNC(zdotu)(&N,x1,&incX,y1,&incY);
 #else
 	_Complex double result1=openblas_make_complex_double(0.0,0.0);
 	_Complex double result2=openblas_make_complex_double(-1.0000,3.0000);
@@ -60,9 +60,9 @@ CTEST(zdotu, zdotu_offset_1)
 	double x1[]={1.0,2.0,3.0,4.0};
 	double y1[]={5.0,6.0,7.0,8.0};
 #ifdef __CTEST_MSVC
-        _Dcomplex result1=openblas_make_complex_double{0.0,0.0};
+        _Dcomplex result1=openblas_make_complex_double(0.0,0.0);
 	_Dcomplex result2=openblas_make_complex_double(-9.0000,32.0000);
-	result1=BLASFUNC(zdotu)(&result1,&N,x1+1,&incX,y1+1,&incY);
+	result1=BLASFUNC(zdotu)(&N,x1+1,&incX,y1+1,&incY);
 #else
 	_Complex double result1=openblas_make_complex_double(0.0,0.0);
 	_Complex double result2=openblas_make_complex_double(-9.0000,32.0000);

--- a/utest/test_dotu.c
+++ b/utest/test_dotu.c
@@ -33,6 +33,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "openblas_utest.h"
 #include <complex.h>
+#include <stdio.h>
 
 CTEST( zdotu,zdotu_n_1)
 {
@@ -40,6 +41,7 @@ CTEST( zdotu,zdotu_n_1)
 	blasint N=1,incX=1,incY=1;
 	double x1[]={1.0,1.0};
 	double y1[]={1.0,2.0};
+fprintf(stderr,"running test zdotu_n_1\n");
 	
 	openblas_complex_double result1=openblas_make_complex_double(0.0,0.0);
         openblas_complex_double result2=openblas_make_complex_double(-1.0000,3.0000);
@@ -58,6 +60,8 @@ CTEST( zdotu,zdotu_n_1)
 #endif
 	
 #endif	
+	fprintf(stderr,"end of test zdotu_n_1\n");
+	return;
 }
 
 CTEST(zdotu, zdotu_offset_1)
@@ -84,4 +88,5 @@ CTEST(zdotu, zdotu_offset_1)
 #endif
 
 #endif
+	return;
 }

--- a/utest/test_dotu.c
+++ b/utest/test_dotu.c
@@ -36,13 +36,11 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 CTEST( zdotu,zdotu_n_1)
 {
-	int N=1,incX=1,incY=1;
+	blasint N=1,incX=1,incY=1;
 	double x1[]={1.0,1.0};
 	double y1[]={1.0,2.0};
-	double x2[]={1.0,1.0};
-	double y2[]={1.0,2.0};
-	_Complex result1=0.0;
-	_Complex result2={-1.0000+3.0000*I};
+	_Complex double result1=openblas_make_complex_double(0.0,0.0);
+	_Complex double result2=openblas_make_complex_double(-1.0000,3.0000);
 	//OpenBLAS
 	result1=BLASFUNC(zdotu)(&N,x1,&incX,y1,&incY);
 
@@ -54,13 +52,11 @@ CTEST( zdotu,zdotu_n_1)
 
 CTEST(zdotu, zdotu_offset_1)
 {
-	int N=1,incX=1,incY=1;
+	blasint N=1,incX=1,incY=1;
 	double x1[]={1.0,2.0,3.0,4.0};
 	double y1[]={5.0,6.0,7.0,8.0};
-	double x2[]={1.0,2.0,3.0,4.0};
-	double y2[]={5.0,6.0,7.0,8.0};
-	_Complex result1=0.0;
-	_Complex result2={-9.0000+32.0000*I};
+	_Complex double result1=openblas_make_complex_double(0.0,0.0);
+	_Complex double result2=openblas_make_complex_double(-9.0000,32.0000);
 	//OpenBLAS
 	result1=BLASFUNC(zdotu)(&N,x1+1,&incX,y1+1,&incY);
 

--- a/utest/test_dotu.c
+++ b/utest/test_dotu.c
@@ -36,7 +36,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 CTEST( zdotu,zdotu_n_1)
 {
-#ifndef RETURN_BY_STACK	
+#ifndef MSVC
 	blasint N=1,incX=1,incY=1;
 	double x1[]={1.0,1.0};
 	double y1[]={1.0,2.0};

--- a/utest/test_dotu.c
+++ b/utest/test_dotu.c
@@ -56,10 +56,13 @@ CTEST( zdotu,zdotu_n_1)
 	ASSERT_DBL_NEAR_TOL(creal(result1), creal(result2), DOUBLE_EPS);
 	ASSERT_DBL_NEAR_TOL(cimag(result1), cimag(result2), DOUBLE_EPS);
 #endif
+	
+#endif	
 }
 
 CTEST(zdotu, zdotu_offset_1)
 {
+#ifndef MSVC	
 	blasint N=1,incX=1,incY=1;
 	double x1[]={1.0,2.0,3.0,4.0};
 	double y1[]={5.0,6.0,7.0,8.0};

--- a/utest/test_dotu.c
+++ b/utest/test_dotu.c
@@ -40,8 +40,8 @@ CTEST( zdotu,zdotu_n_1)
 	double x1[]={1.0,1.0};
 	double y1[]={1.0,2.0};
 #ifdef __CTEST_MSVC
-        _Dcomplex result1=openblas_make_complex_double(0.0,0.0);
-	_Dcomplex result2=openblas_make_complex_double(-1.0000,3.0000);
+        openblas_complex_double result1=openblas_make_complex_double(0.0,0.0);
+	openblas_complex_double result2=openblas_make_complex_double(-1.0000,3.0000);
 	result1=BLASFUNC(zdotu)(&N,x1,&incX,y1,&incY);
 #else
 	_Complex double result1=openblas_make_complex_double(0.0,0.0);

--- a/utest/test_dotu.c
+++ b/utest/test_dotu.c
@@ -48,8 +48,14 @@ CTEST( zdotu,zdotu_n_1)
 	_Complex double result2=openblas_make_complex_double(-1.0000,3.0000);
 	result1=BLASFUNC(zdotu)(&N,x1,&incX,y1,&incY);
 #endif
+
+#ifdef OPENBLAS_COMPLEX_STRUCT
+	ASSERT_DBL_NEAR_TOL(result1.real, result2.real, DOUBLE_EPS);
+	ASSERT_DBL_NEAR_TOL(result1.imag, result2.imag, DOUBLE_EPS);
+#else	
 	ASSERT_DBL_NEAR_TOL(creal(result1), creal(result2), DOUBLE_EPS);
 	ASSERT_DBL_NEAR_TOL(cimag(result1), cimag(result2), DOUBLE_EPS);
+#endif
 //	printf("\%lf,%lf\n",creal(result1),cimag(result1));
 
 }
@@ -68,8 +74,14 @@ CTEST(zdotu, zdotu_offset_1)
 	_Complex double result2=openblas_make_complex_double(-9.0000,32.0000);
 	result1=BLASFUNC(zdotu)(&N,x1+1,&incX,y1+1,&incY);
 #endif
+
+#ifdef OPENBLAS_COMPLEX_STRUCT
+	ASSERT_DBL_NEAR_TOL(result1.real,result2.real,DOUBLE_EPS);
+	ASSERT_DBL_NEAR_TOL(result1.imag,result2.imag,DOUBLE_EPS);
+#else	
 	ASSERT_DBL_NEAR_TOL(creal(result1), creal(result2), DOUBLE_EPS);
 	ASSERT_DBL_NEAR_TOL(cimag(result1), cimag(result2), DOUBLE_EPS);
+#endif
 //	printf("\%lf,%lf\n",creal(result1),cimag(result1));
 
 }

--- a/utest/test_dotu.c
+++ b/utest/test_dotu.c
@@ -31,10 +31,10 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 **********************************************************************************/
 
-#include "common_utest.h"
+#include "openblas_utest.h"
 #include <complex.h>
 
-void test_zdotu_n_1(void)
+CTEST( zdotu,zdotu_n_1)
 {
 	int N=1,incX=1,incY=1;
 	double x1[]={1.0,1.0};
@@ -42,19 +42,17 @@ void test_zdotu_n_1(void)
 	double x2[]={1.0,1.0};
 	double y2[]={1.0,2.0};
 	double _Complex result1=0.0;
-	double _Complex result2=0.0;
+	double _Complex result2={-1.0000+3.0000*I};
 	//OpenBLAS
 	result1=BLASFUNC(zdotu)(&N,x1,&incX,y1,&incY);
-	//reference
-	result2=BLASFUNC_REF(zdotu)(&N,x2,&incX,y2,&incY);
 
-	CU_ASSERT_DOUBLE_EQUAL(creal(result1), creal(result2), CHECK_EPS);
-	CU_ASSERT_DOUBLE_EQUAL(cimag(result1), cimag(result2), CHECK_EPS);
+	ASSERT_DBL_NEAR_TOL(creal(result1), creal(result2), DOUBLE_EPS);
+	ASSERT_DBL_NEAR_TOL(cimag(result1), cimag(result2), DOUBLE_EPS);
 //	printf("\%lf,%lf\n",creal(result1),cimag(result1));
 
 }
 
-void test_zdotu_offset_1(void)
+CTEST(zdotu, zdotu_offset_1)
 {
 	int N=1,incX=1,incY=1;
 	double x1[]={1.0,2.0,3.0,4.0};
@@ -62,14 +60,12 @@ void test_zdotu_offset_1(void)
 	double x2[]={1.0,2.0,3.0,4.0};
 	double y2[]={5.0,6.0,7.0,8.0};
 	double _Complex result1=0.0;
-	double _Complex result2=0.0;
+	double _Complex result2={-9.0000+32.0000*I};
 	//OpenBLAS
 	result1=BLASFUNC(zdotu)(&N,x1+1,&incX,y1+1,&incY);
-	//reference
-	result2=BLASFUNC_REF(zdotu)(&N,x2+1,&incX,y2+1,&incY);
 
-	CU_ASSERT_DOUBLE_EQUAL(creal(result1), creal(result2), CHECK_EPS);
-	CU_ASSERT_DOUBLE_EQUAL(cimag(result1), cimag(result2), CHECK_EPS);
+	ASSERT_DBL_NEAR_TOL(creal(result1), creal(result2), DOUBLE_EPS);
+	ASSERT_DBL_NEAR_TOL(cimag(result1), cimag(result2), DOUBLE_EPS);
 //	printf("\%lf,%lf\n",creal(result1),cimag(result1));
 
 }

--- a/utest/test_dotu.c
+++ b/utest/test_dotu.c
@@ -39,25 +39,22 @@ CTEST( zdotu,zdotu_n_1)
 	blasint N=1,incX=1,incY=1;
 	double x1[]={1.0,1.0};
 	double y1[]={1.0,2.0};
-#ifdef __CTEST_MSVC
-        openblas_complex_double result1=openblas_make_complex_double(0.0,0.0);
-	openblas_complex_double result2=openblas_make_complex_double(-1.0000,3.0000);
-	result1=BLASFUNC(zdotu)(&N,x1,&incX,y1,&incY);
+	
+	openblas_complex_double result1=openblas_make_complex_double(0.0,0.0);
+        openblas_complex_double result2=openblas_make_complex_double(-1.0000,3.0000);
+#ifdef RETURN_BY_STACK
+	BLASFUNC(zdotu)(&result1,&N,x1,&incX,y1,&incY);
 #else
-	_Complex double result1=openblas_make_complex_double(0.0,0.0);
-	_Complex double result2=openblas_make_complex_double(-1.0000,3.0000);
 	result1=BLASFUNC(zdotu)(&N,x1,&incX,y1,&incY);
 #endif
-
+	
 #ifdef OPENBLAS_COMPLEX_STRUCT
 	ASSERT_DBL_NEAR_TOL(result1.real, result2.real, DOUBLE_EPS);
 	ASSERT_DBL_NEAR_TOL(result1.imag, result2.imag, DOUBLE_EPS);
-#else	
+#else
 	ASSERT_DBL_NEAR_TOL(creal(result1), creal(result2), DOUBLE_EPS);
 	ASSERT_DBL_NEAR_TOL(cimag(result1), cimag(result2), DOUBLE_EPS);
 #endif
-//	printf("\%lf,%lf\n",creal(result1),cimag(result1));
-
 }
 
 CTEST(zdotu, zdotu_offset_1)
@@ -65,24 +62,20 @@ CTEST(zdotu, zdotu_offset_1)
 	blasint N=1,incX=1,incY=1;
 	double x1[]={1.0,2.0,3.0,4.0};
 	double y1[]={5.0,6.0,7.0,8.0};
-#ifdef __CTEST_MSVC
-        _Dcomplex result1=openblas_make_complex_double(0.0,0.0);
-	_Dcomplex result2=openblas_make_complex_double(-9.0000,32.0000);
-	result1=BLASFUNC(zdotu)(&N,x1+1,&incX,y1+1,&incY);
+	
+	openblas_complex_double result1=openblas_make_complex_double(0.0,0.0);
+        openblas_complex_double result2=openblas_make_complex_double(-9.0,32.0);
+#ifdef RETURN_BY_STACK
+	BLASFUNC(zdotu)(&result1,&N,x1+1,&incX,y1+1,&incY);
 #else
-	_Complex double result1=openblas_make_complex_double(0.0,0.0);
-	_Complex double result2=openblas_make_complex_double(-9.0000,32.0000);
 	result1=BLASFUNC(zdotu)(&N,x1+1,&incX,y1+1,&incY);
 #endif
-
+	
 #ifdef OPENBLAS_COMPLEX_STRUCT
-	ASSERT_DBL_NEAR_TOL(result1.real,result2.real,DOUBLE_EPS);
-	ASSERT_DBL_NEAR_TOL(result1.imag,result2.imag,DOUBLE_EPS);
-#else	
+	ASSERT_DBL_NEAR_TOL(result1.real, result2.real, DOUBLE_EPS);
+	ASSERT_DBL_NEAR_TOL(result1.imag, result2.imag, DOUBLE_EPS);
+#else
 	ASSERT_DBL_NEAR_TOL(creal(result1), creal(result2), DOUBLE_EPS);
 	ASSERT_DBL_NEAR_TOL(cimag(result1), cimag(result2), DOUBLE_EPS);
 #endif
-//	printf("\%lf,%lf\n",creal(result1),cimag(result1));
-
 }
-

--- a/utest/test_dotu.c
+++ b/utest/test_dotu.c
@@ -36,6 +36,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 CTEST( zdotu,zdotu_n_1)
 {
+#ifndef RETURN_BY_STACK	
 	blasint N=1,incX=1,incY=1;
 	double x1[]={1.0,1.0};
 	double y1[]={1.0,2.0};
@@ -77,5 +78,7 @@ CTEST(zdotu, zdotu_offset_1)
 #else
 	ASSERT_DBL_NEAR_TOL(creal(result1), creal(result2), DOUBLE_EPS);
 	ASSERT_DBL_NEAR_TOL(cimag(result1), cimag(result2), DOUBLE_EPS);
+#endif
+
 #endif
 }

--- a/utest/test_dotu.c
+++ b/utest/test_dotu.c
@@ -39,11 +39,15 @@ CTEST( zdotu,zdotu_n_1)
 	blasint N=1,incX=1,incY=1;
 	double x1[]={1.0,1.0};
 	double y1[]={1.0,2.0};
+#ifdef __CTEST_MSVC
+        _Dcomplex result1=openblas_make_complex_double{0.0,0.0};
+	_Dcomplex result2=openblas_make_complex_double(-1.0000,3.0000);
+	result1=BLASFUNC(zdotu)(&result1,&N,x1,&incX,y1,&incY);
+#else
 	_Complex double result1=openblas_make_complex_double(0.0,0.0);
 	_Complex double result2=openblas_make_complex_double(-1.0000,3.0000);
-	//OpenBLAS
 	result1=BLASFUNC(zdotu)(&N,x1,&incX,y1,&incY);
-
+#endif
 	ASSERT_DBL_NEAR_TOL(creal(result1), creal(result2), DOUBLE_EPS);
 	ASSERT_DBL_NEAR_TOL(cimag(result1), cimag(result2), DOUBLE_EPS);
 //	printf("\%lf,%lf\n",creal(result1),cimag(result1));
@@ -55,11 +59,15 @@ CTEST(zdotu, zdotu_offset_1)
 	blasint N=1,incX=1,incY=1;
 	double x1[]={1.0,2.0,3.0,4.0};
 	double y1[]={5.0,6.0,7.0,8.0};
+#ifdef __CTEST_MSVC
+        _Dcomplex result1=openblas_make_complex_double{0.0,0.0};
+	_Dcomplex result2=openblas_make_complex_double(-9.0000,32.0000);
+	result1=BLASFUNC(zdotu)(&result1,&N,x1+1,&incX,y1+1,&incY);
+#else
 	_Complex double result1=openblas_make_complex_double(0.0,0.0);
 	_Complex double result2=openblas_make_complex_double(-9.0000,32.0000);
-	//OpenBLAS
 	result1=BLASFUNC(zdotu)(&N,x1+1,&incX,y1+1,&incY);
-
+#endif
 	ASSERT_DBL_NEAR_TOL(creal(result1), creal(result2), DOUBLE_EPS);
 	ASSERT_DBL_NEAR_TOL(cimag(result1), cimag(result2), DOUBLE_EPS);
 //	printf("\%lf,%lf\n",creal(result1),cimag(result1));

--- a/utest/test_dotu.c
+++ b/utest/test_dotu.c
@@ -37,11 +37,9 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 CTEST( zdotu,zdotu_n_1)
 {
-#ifndef MSVC
 	blasint N=1,incX=1,incY=1;
 	double x1[]={1.0,1.0};
 	double y1[]={1.0,2.0};
-fprintf(stderr,"running test zdotu_n_1\n");
 	
 	openblas_complex_double result1=openblas_make_complex_double(0.0,0.0);
         openblas_complex_double result2=openblas_make_complex_double(-1.0000,3.0000);
@@ -59,14 +57,10 @@ fprintf(stderr,"running test zdotu_n_1\n");
 	ASSERT_DBL_NEAR_TOL(cimag(result1), cimag(result2), DOUBLE_EPS);
 #endif
 	
-#endif	
-	fprintf(stderr,"end of test zdotu_n_1\n");
-	return;
 }
 
 CTEST(zdotu, zdotu_offset_1)
 {
-#ifndef MSVC	
 	blasint N=1,incX=1,incY=1;
 	double x1[]={1.0,2.0,3.0,4.0};
 	double y1[]={5.0,6.0,7.0,8.0};
@@ -87,6 +81,4 @@ CTEST(zdotu, zdotu_offset_1)
 	ASSERT_DBL_NEAR_TOL(cimag(result1), cimag(result2), DOUBLE_EPS);
 #endif
 
-#endif
-	return;
 }

--- a/utest/test_dotu.c
+++ b/utest/test_dotu.c
@@ -41,8 +41,8 @@ CTEST( zdotu,zdotu_n_1)
 	double y1[]={1.0,2.0};
 	double x2[]={1.0,1.0};
 	double y2[]={1.0,2.0};
-	double _Complex result1=0.0;
-	double _Complex result2={-1.0000+3.0000*I};
+	_Complex result1=0.0;
+	_Complex result2={-1.0000+3.0000*I};
 	//OpenBLAS
 	result1=BLASFUNC(zdotu)(&N,x1,&incX,y1,&incY);
 
@@ -59,8 +59,8 @@ CTEST(zdotu, zdotu_offset_1)
 	double y1[]={5.0,6.0,7.0,8.0};
 	double x2[]={1.0,2.0,3.0,4.0};
 	double y2[]={5.0,6.0,7.0,8.0};
-	double _Complex result1=0.0;
-	double _Complex result2={-9.0000+32.0000*I};
+	_Complex result1=0.0;
+	_Complex result2={-9.0000+32.0000*I};
 	//OpenBLAS
 	result1=BLASFUNC(zdotu)(&N,x1+1,&incX,y1+1,&incY);
 

--- a/utest/test_dsdot.c
+++ b/utest/test_dsdot.c
@@ -35,8 +35,8 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 CTEST(dsdot,dsdot_n_1)
 {
-	float x= 0.172555164;
-	float y= -0.0138700781;
+	float x= 0.172555164F;
+	float y= -0.0138700781F;
 	int incx=1;
 	int incy=1;
 	int n=1;

--- a/utest/test_dsdot.c
+++ b/utest/test_dsdot.c
@@ -31,9 +31,9 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 **********************************************************************************/
 
-#include "common_utest.h"
+#include "openblas_utest.h"
 
-void test_dsdot_n_1()
+CTEST(dsdot,dsdot_n_1)
 {
 	float x= 0.172555164;
 	float y= -0.0138700781;
@@ -41,11 +41,9 @@ void test_dsdot_n_1()
 	int incy=1;
 	int n=1;
 
-	double res1=0.0f, res2=0.0f;
+	double res1=0.0f, res2=-0.00239335360107;
 
 	res1=BLASFUNC(dsdot)(&n, &x, &incx, &y, &incy);
-	res2=BLASFUNC_REF(dsdot)(&n, &x, &incx, &y, &incy);
-
-	CU_ASSERT_DOUBLE_EQUAL(res1, res2, CHECK_EPS);
+	ASSERT_DBL_NEAR_TOL(res1, res2, DOUBLE_EPS);
 
 }

--- a/utest/test_dsdot.c
+++ b/utest/test_dsdot.c
@@ -37,9 +37,9 @@ CTEST(dsdot,dsdot_n_1)
 {
 	float x= 0.172555164F;
 	float y= -0.0138700781F;
-	int incx=1;
-	int incy=1;
-	int n=1;
+	blasint incx=1;
+	blasint incy=1;
+	blasint n=1;
 
 	double res1=0.0f, res2=-0.00239335360107;
 

--- a/utest/test_rot.c
+++ b/utest/test_rot.c
@@ -35,8 +35,8 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 CTEST(rot,drot_inc_0)
 {
-	int i=0;
-	int N=4,incX=0,incY=0;
+	blasint i=0;
+	blasint N=4,incX=0,incY=0;
 	double c=0.25,s=0.5;
 	double x1[]={1.0,3.0,5.0,7.0};
 	double y1[]={2.0,4.0,6.0,8.0};
@@ -55,8 +55,8 @@ CTEST(rot,drot_inc_0)
 
 CTEST(rot,zdrot_inc_0)
 {
-	int i=0;
-	int N=4,incX=0,incY=0;
+	blasint i=0;
+	blasint N=4,incX=0,incY=0;
 	double c=0.25,s=0.5;
 	double x1[]={1.0,3.0,5.0,7.0,1.0,3.0,5.0,7.0};
 	double y1[]={2.0,4.0,6.0,8.0,2.0,4.0,6.0,8.0};
@@ -75,8 +75,8 @@ CTEST(rot,zdrot_inc_0)
 
 CTEST(rot,srot_inc_0)
 {
-	int i=0;
-	int N=4,incX=0,incY=0;
+	blasint i=0;
+	blasint N=4,incX=0,incY=0;
 	float c=0.25,s=0.5;
 	float x1[]={1.0,3.0,5.0,7.0};
 	float y1[]={2.0,4.0,6.0,8.0};
@@ -94,8 +94,8 @@ CTEST(rot,srot_inc_0)
 
 CTEST(rot, csrot_inc_0)
 {
-	int i=0;
-	int N=4,incX=0,incY=0;
+	blasint i=0;
+	blasint N=4,incX=0,incY=0;
 	float c=0.25,s=0.5;
 	float x1[]={1.0,3.0,5.0,7.0,1.0,3.0,5.0,7.0};
 	float y1[]={2.0,4.0,6.0,8.0,2.0,4.0,6.0,8.0};

--- a/utest/test_rot.c
+++ b/utest/test_rot.c
@@ -31,88 +31,82 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 **********************************************************************************/
 
-#include "common_utest.h"
+#include "openblas_utest.h"
 
-void test_drot_inc_0(void)
+CTEST(rot,drot_inc_0)
 {
 	int i=0;
 	int N=4,incX=0,incY=0;
 	double c=0.25,s=0.5;
 	double x1[]={1.0,3.0,5.0,7.0};
 	double y1[]={2.0,4.0,6.0,8.0};
-	double x2[]={1.0,3.0,5.0,7.0};
-	double y2[]={2.0,4.0,6.0,8.0};
+	double x2[]={-0.21484375000000,3.0,5.0,7.0};
+	double y2[]={ 0.03906250000000,4.0,6.0,8.0};
+
 
 	//OpenBLAS
 	BLASFUNC(drot)(&N,x1,&incX,y1,&incY,&c,&s);
-	//reference
-	BLASFUNC_REF(drot)(&N,x2,&incX,y2,&incY,&c,&s);
 
 	for(i=0; i<N; i++){
-		CU_ASSERT_DOUBLE_EQUAL(x1[i], x2[i], CHECK_EPS);
-		CU_ASSERT_DOUBLE_EQUAL(y1[i], y2[i], CHECK_EPS);
+		ASSERT_DBL_NEAR_TOL(x1[i], x2[i], DOUBLE_EPS);
+		ASSERT_DBL_NEAR_TOL(y1[i], y2[i], DOUBLE_EPS);
 	}
 }
 
-void test_zdrot_inc_0(void)
+CTEST(rot,zdrot_inc_0)
 {
 	int i=0;
 	int N=4,incX=0,incY=0;
 	double c=0.25,s=0.5;
 	double x1[]={1.0,3.0,5.0,7.0,1.0,3.0,5.0,7.0};
 	double y1[]={2.0,4.0,6.0,8.0,2.0,4.0,6.0,8.0};
-	double x2[]={1.0,3.0,5.0,7.0,1.0,3.0,5.0,7.0};
-	double y2[]={2.0,4.0,6.0,8.0,2.0,4.0,6.0,8.0};
+	double x2[]={-0.21484375000000,-0.45703125000000 ,5.0,7.0,1.0,3.0,5.0,7.0};
+	double y2[]={ 0.03906250000000, 0.17187500000000 ,6.0,8.0,2.0,4.0,6.0,8.0};
+	
 
 	//OpenBLAS
 	BLASFUNC(zdrot)(&N,x1,&incX,y1,&incY,&c,&s);
-	//reference
-	BLASFUNC_REF(zdrot)(&N,x2,&incX,y2,&incY,&c,&s);
 
 	for(i=0; i<2*N; i++){
-		CU_ASSERT_DOUBLE_EQUAL(x1[i], x2[i], CHECK_EPS);
-		CU_ASSERT_DOUBLE_EQUAL(y1[i], y2[i], CHECK_EPS);
+		ASSERT_DBL_NEAR_TOL(x1[i], x2[i], DOUBLE_EPS);
+		ASSERT_DBL_NEAR_TOL(y1[i], y2[i], DOUBLE_EPS);
 	}
 }
 
-void test_srot_inc_0(void)
+CTEST(rot,srot_inc_0)
 {
 	int i=0;
 	int N=4,incX=0,incY=0;
 	float c=0.25,s=0.5;
 	float x1[]={1.0,3.0,5.0,7.0};
 	float y1[]={2.0,4.0,6.0,8.0};
-	float x2[]={1.0,3.0,5.0,7.0};
-	float y2[]={2.0,4.0,6.0,8.0};
+	float x2[]={-0.21484375000000,3.0,5.0,7.0};
+	float y2[]={ 0.03906250000000,4.0,6.0,8.0};
 
 	//OpenBLAS
 	BLASFUNC(srot)(&N,x1,&incX,y1,&incY,&c,&s);
-	//reference
-	BLASFUNC_REF(srot)(&N,x2,&incX,y2,&incY,&c,&s);
 
 	for(i=0; i<N; i++){
-		CU_ASSERT_DOUBLE_EQUAL(x1[i], x2[i], CHECK_EPS);
-		CU_ASSERT_DOUBLE_EQUAL(y1[i], y2[i], CHECK_EPS);
+		ASSERT_DBL_NEAR_TOL(x1[i], x2[i], SINGLE_EPS);
+		ASSERT_DBL_NEAR_TOL(y1[i], y2[i], SINGLE_EPS);
 	}
 }
 
-void test_csrot_inc_0(void)
+CTEST(rot, csrot_inc_0)
 {
 	int i=0;
 	int N=4,incX=0,incY=0;
 	float c=0.25,s=0.5;
 	float x1[]={1.0,3.0,5.0,7.0,1.0,3.0,5.0,7.0};
 	float y1[]={2.0,4.0,6.0,8.0,2.0,4.0,6.0,8.0};
-	float x2[]={1.0,3.0,5.0,7.0,1.0,3.0,5.0,7.0};
-	float y2[]={2.0,4.0,6.0,8.0,2.0,4.0,6.0,8.0};
-
+	float x2[]={-0.21484375000000,-0.45703125000000 ,5.0,7.0,1.0,3.0,5.0,7.0};
+	float y2[]={ 0.03906250000000, 0.17187500000000 ,6.0,8.0,2.0,4.0,6.0,8.0};
+	
 	//OpenBLAS
 	BLASFUNC(csrot)(&N,x1,&incX,y1,&incY,&c,&s);
-	//reference
-	BLASFUNC_REF(csrot)(&N,x2,&incX,y2,&incY,&c,&s);
 
 	for(i=0; i<2*N; i++){
-		CU_ASSERT_DOUBLE_EQUAL(x1[i], x2[i], CHECK_EPS);
-		CU_ASSERT_DOUBLE_EQUAL(y1[i], y2[i], CHECK_EPS);
+		ASSERT_DBL_NEAR_TOL(x1[i], x2[i], SINGLE_EPS);
+		ASSERT_DBL_NEAR_TOL(y1[i], y2[i], SINGLE_EPS);
 	}
 }

--- a/utest/test_swap.c
+++ b/utest/test_swap.c
@@ -35,8 +35,8 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 CTEST(swap,dswap_inc_0)
 {
-	int i=0;
-	int N=4,incX=0,incY=0;
+	blasint i=0;
+	blasint N=4,incX=0,incY=0;
 	double x1[]={1.0,3.0,5.0,7.0};
 	double y1[]={2.0,4.0,6.0,8.0};
 	double x2[]={1.0,3.0,5.0,7.0};
@@ -53,8 +53,8 @@ CTEST(swap,dswap_inc_0)
 
 CTEST(swap,zswap_inc_0)
 {
-	int i=0;
-	int N=4,incX=0,incY=0;
+	blasint i=0;
+	blasint N=4,incX=0,incY=0;
 	double x1[]={1.0,3.0,5.0,7.0,1.0,3.0,5.0,7.0};
 	double y1[]={2.0,4.0,6.0,8.0,2.0,4.0,6.0,8.0};
 	double x2[]={1.0,3.0,5.0,7.0,1.0,3.0,5.0,7.0};
@@ -71,8 +71,8 @@ CTEST(swap,zswap_inc_0)
 
 CTEST(swap,sswap_inc_0)
 {
-	int i=0;
-	int N=4,incX=0,incY=0;
+	blasint i=0;
+	blasint N=4,incX=0,incY=0;
 	float x1[]={1.0,3.0,5.0,7.0};
 	float y1[]={2.0,4.0,6.0,8.0};
 	float x2[]={1.0,3.0,5.0,7.0};
@@ -89,8 +89,8 @@ CTEST(swap,sswap_inc_0)
 
 CTEST(swap,cswap_inc_0)
 {
-	int i=0;
-	int N=4,incX=0,incY=0;
+	blasint i=0;
+	blasint N=4,incX=0,incY=0;
 	float x1[]={1.0,3.0,5.0,7.0,1.0,3.0,5.0,7.0};
 	float y1[]={2.0,4.0,6.0,8.0,2.0,4.0,6.0,8.0};
 	float x2[]={1.0,3.0,5.0,7.0,1.0,3.0,5.0,7.0};

--- a/utest/test_swap.c
+++ b/utest/test_swap.c
@@ -31,9 +31,9 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 **********************************************************************************/
 
-#include "common_utest.h"
+#include "openblas_utest.h"
 
-void test_dswap_inc_0(void)
+CTEST(swap,dswap_inc_0)
 {
 	int i=0;
 	int N=4,incX=0,incY=0;
@@ -41,19 +41,17 @@ void test_dswap_inc_0(void)
 	double y1[]={2.0,4.0,6.0,8.0};
 	double x2[]={1.0,3.0,5.0,7.0};
 	double y2[]={2.0,4.0,6.0,8.0};
-
+	
 	//OpenBLAS
 	BLASFUNC(dswap)(&N,x1,&incX,y1,&incY);
-	//reference
-	BLASFUNC_REF(dswap)(&N,x2,&incX,y2,&incY);
 
 	for(i=0; i<N; i++){
-		CU_ASSERT_DOUBLE_EQUAL(x1[i], x2[i], CHECK_EPS);
-		CU_ASSERT_DOUBLE_EQUAL(y1[i], y2[i], CHECK_EPS);
+		ASSERT_DBL_NEAR_TOL(x1[i], x2[i], DOUBLE_EPS);
+		ASSERT_DBL_NEAR_TOL(y1[i], y2[i], DOUBLE_EPS);
 	}
 }
 
-void test_zswap_inc_0(void)
+CTEST(swap,zswap_inc_0)
 {
 	int i=0;
 	int N=4,incX=0,incY=0;
@@ -64,16 +62,14 @@ void test_zswap_inc_0(void)
 
 	//OpenBLAS
 	BLASFUNC(zswap)(&N,x1,&incX,y1,&incY);
-	//reference
-	BLASFUNC_REF(zswap)(&N,x2,&incX,y2,&incY);
 
 	for(i=0; i<2*N; i++){
-		CU_ASSERT_DOUBLE_EQUAL(x1[i], x2[i], CHECK_EPS);
-		CU_ASSERT_DOUBLE_EQUAL(y1[i], y2[i], CHECK_EPS);
+		ASSERT_DBL_NEAR_TOL(x1[i], x2[i], DOUBLE_EPS);
+		ASSERT_DBL_NEAR_TOL(y1[i], y2[i], DOUBLE_EPS);
 	}
 }
 
-void test_sswap_inc_0(void)
+CTEST(swap,sswap_inc_0)
 {
 	int i=0;
 	int N=4,incX=0,incY=0;
@@ -84,16 +80,14 @@ void test_sswap_inc_0(void)
 
 	//OpenBLAS
 	BLASFUNC(sswap)(&N,x1,&incX,y1,&incY);
-	//reference
-	BLASFUNC_REF(sswap)(&N,x2,&incX,y2,&incY);
 
 	for(i=0; i<N; i++){
-		CU_ASSERT_DOUBLE_EQUAL(x1[i], x2[i], CHECK_EPS);
-		CU_ASSERT_DOUBLE_EQUAL(y1[i], y2[i], CHECK_EPS);
+		ASSERT_DBL_NEAR_TOL(x1[i], x2[i], SINGLE_EPS);
+		ASSERT_DBL_NEAR_TOL(y1[i], y2[i], SINGLE_EPS);
 	}
 }
 
-void test_cswap_inc_0(void)
+CTEST(swap,cswap_inc_0)
 {
 	int i=0;
 	int N=4,incX=0,incY=0;
@@ -104,11 +98,9 @@ void test_cswap_inc_0(void)
 
 	//OpenBLAS
 	BLASFUNC(cswap)(&N,x1,&incX,y1,&incY);
-	//reference
-	BLASFUNC_REF(cswap)(&N,x2,&incX,y2,&incY);
 
 	for(i=0; i<2*N; i++){
-		CU_ASSERT_DOUBLE_EQUAL(x1[i], x2[i], CHECK_EPS);
-		CU_ASSERT_DOUBLE_EQUAL(y1[i], y2[i], CHECK_EPS);
+		ASSERT_DBL_NEAR_TOL(x1[i], x2[i], SINGLE_EPS);
+		ASSERT_DBL_NEAR_TOL(y1[i], y2[i], SINGLE_EPS);
 	}
 }

--- a/utest/utest_main2.c
+++ b/utest/utest_main2.c
@@ -268,7 +268,7 @@ CTEST( zdotu,zdotu_n_1)
 	double y1[]={1.0,2.0};
         openblas_complex_double result1=openblas_make_complex_double(0.0,0.0);
         openblas_complex_double result2=openblas_make_complex_double(-1.0,3.0);
-#ifdef OPENBLAS_COMPLEX_STRUCT
+#ifndef __clang__
 	BLASFUNC(zdotu)(&result1,&N,x1,&incX,y1,&incY);
 #else
 	result1=BLASFUNC(zdotu)(&N,x1,&incX,y1,&incY);
@@ -290,7 +290,7 @@ CTEST(zdotu, zdotu_offset_1)
 	double y1[]={5.0,6.0,7.0,8.0};
         openblas_complex_double result1=openblas_make_complex_double(0.0,0.0);
         openblas_complex_double result2=openblas_make_complex_double(-9.0,32.0);
-#ifdef OPENBLAS_COMPLEX_STRUCT
+#ifndef __clang__
 	BLASFUNC(zdotu)(&result1,&N,x1+1,&incX,y1+1,&incY);
 #else
 	result1=BLASFUNC(zdotu)(&N,x1+1,&incX,y1+1,&incY);

--- a/utest/utest_main2.c
+++ b/utest/utest_main2.c
@@ -269,7 +269,7 @@ CTEST( zdotu,zdotu_n_1)
         _Dcomplex result1=openblas_make_complex_double(0.0,0.0);
         _Dcomplex result2=openblas_make_complex_double(-1.0,3.0);
 	//OpenBLAS
-	result1=BLASFUNC(zdotu)(&N,x1,&incX,y1,&incY);
+	BLASFUNC(zdotu)(&result1,&N,x1,&incX,y1,&incY);
 
 	ASSERT_DBL_NEAR_TOL(creal(result1), creal(result2), DOUBLE_EPS);
 	ASSERT_DBL_NEAR_TOL(cimag(result1), cimag(result2), DOUBLE_EPS);
@@ -285,7 +285,7 @@ CTEST(zdotu, zdotu_offset_1)
         _Dcomplex result2=openblas_make_complex_double(-9.0,32.0);
        
 	//OpenBLAS
-	result1=BLASFUNC(zdotu)(&N,x1+1,&incX,y1+1,&incY);
+	BLASFUNC(zdotu)(&result1,&N,x1+1,&incX,y1+1,&incY);
 
 	ASSERT_DBL_NEAR_TOL(creal(result1), creal(result2), DOUBLE_EPS);
 	ASSERT_DBL_NEAR_TOL(cimag(result1), cimag(result2), DOUBLE_EPS);

--- a/utest/utest_main2.c
+++ b/utest/utest_main2.c
@@ -266,8 +266,8 @@ CTEST( zdotu,zdotu_n_1)
 	blasint N=1,incX=1,incY=1;
 	double x1[]={1.0,1.0};
 	double y1[]={1.0,2.0};
-        _DComplex result1=openblas_make_complex_double(0.0,0.0);
-        _DComplex result2=openblas_make_complex_double(-1.0,3.0);
+        _Dcomplex result1=openblas_make_complex_double(0.0,0.0);
+        _Dcomplex result2=openblas_make_complex_double(-1.0,3.0);
 	//OpenBLAS
 	result1=BLASFUNC(zdotu)(&N,x1,&incX,y1,&incY);
 
@@ -281,8 +281,8 @@ CTEST(zdotu, zdotu_offset_1)
 	blasint N=1,incX=1,incY=1;
 	double x1[]={1.0,2.0,3.0,4.0};
 	double y1[]={5.0,6.0,7.0,8.0};
-        _DComplex result1=openblas_make_complex_double(0.0,0.0);
-        _DComplex result2=openblas_make_complex_double(-9.0,32.0);
+        _Dcomplex result1=openblas_make_complex_double(0.0,0.0);
+        _Dcomplex result2=openblas_make_complex_double(-9.0,32.0);
        
 	//OpenBLAS
 	result1=BLASFUNC(zdotu)(&N,x1+1,&incX,y1+1,&incY);

--- a/utest/utest_main2.c
+++ b/utest/utest_main2.c
@@ -268,7 +268,7 @@ CTEST( zdotu,zdotu_n_1)
 	double y1[]={1.0,2.0};
         openblas_complex_double result1=openblas_make_complex_double(0.0,0.0);
         openblas_complex_double result2=openblas_make_complex_double(-1.0,3.0);
-#ifndef __clang__
+#ifdef RETURN_BY_STACK
 	BLASFUNC(zdotu)(&result1,&N,x1,&incX,y1,&incY);
 #else
 	result1=BLASFUNC(zdotu)(&N,x1,&incX,y1,&incY);
@@ -290,7 +290,7 @@ CTEST(zdotu, zdotu_offset_1)
 	double y1[]={5.0,6.0,7.0,8.0};
         openblas_complex_double result1=openblas_make_complex_double(0.0,0.0);
         openblas_complex_double result2=openblas_make_complex_double(-9.0,32.0);
-#ifndef __clang__
+#ifdef RETURN_BY_STACK
 	BLASFUNC(zdotu)(&result1,&N,x1+1,&incX,y1+1,&incY);
 #else
 	result1=BLASFUNC(zdotu)(&N,x1+1,&incX,y1+1,&incY);

--- a/utest/utest_main2.c
+++ b/utest/utest_main2.c
@@ -268,9 +268,12 @@ CTEST( zdotu,zdotu_n_1)
 	double y1[]={1.0,2.0};
         openblas_complex_double result1=openblas_make_complex_double(0.0,0.0);
         openblas_complex_double result2=openblas_make_complex_double(-1.0,3.0);
-	//OpenBLAS
+#ifdef __CTEST_MSVC
 	BLASFUNC(zdotu)(&result1,&N,x1,&incX,y1,&incY);
-
+#else
+	result1=BLASFUNC(zdotu)(&N,x1,&incX,y1,&incY);
+#endif
+	
 #ifdef OPENBLAS_COMPLEX_STRUCT
 	ASSERT_DBL_NEAR_TOL(result1.real, result2.real, DOUBLE_EPS);
 	ASSERT_DBL_NEAR_TOL(result1.imag, result2.imag, DOUBLE_EPS);
@@ -287,10 +290,12 @@ CTEST(zdotu, zdotu_offset_1)
 	double y1[]={5.0,6.0,7.0,8.0};
         openblas_complex_double result1=openblas_make_complex_double(0.0,0.0);
         openblas_complex_double result2=openblas_make_complex_double(-9.0,32.0);
-       
-	//OpenBLAS
+#ifdef __CTEST_MSVC
 	BLASFUNC(zdotu)(&result1,&N,x1+1,&incX,y1+1,&incY);
-
+#else
+	result1=BLASFUNC(zdotu)(&N,x1+1,&incX,y1+1,&incY);
+#endif
+	
 #ifdef OPENBLAS_COMPLEX_STRUCT
 	ASSERT_DBL_NEAR_TOL(result1.real, result2.real, DOUBLE_EPS);
 	ASSERT_DBL_NEAR_TOL(result1.imag, result2.imag, DOUBLE_EPS);

--- a/utest/utest_main2.c
+++ b/utest/utest_main2.c
@@ -268,11 +268,11 @@ CTEST( zdotu,zdotu_n_1)
 	double y1[]={1.0,2.0};
         openblas_complex_double result1=openblas_make_complex_double(0.0,0.0);
         openblas_complex_double result2=openblas_make_complex_double(-1.0,3.0);
-//#ifdef __CTEST_MSVC
-//	BLASFUNC(zdotu)(&result1,&N,x1,&incX,y1,&incY);
-//#else
+#ifdef OPENBLAS_COMPLEX_STRUCT
+	BLASFUNC(zdotu)(&result1,&N,x1,&incX,y1,&incY);
+#else
 	result1=BLASFUNC(zdotu)(&N,x1,&incX,y1,&incY);
-//#endif
+#endif
 	
 #ifdef OPENBLAS_COMPLEX_STRUCT
 	ASSERT_DBL_NEAR_TOL(result1.real, result2.real, DOUBLE_EPS);
@@ -290,7 +290,7 @@ CTEST(zdotu, zdotu_offset_1)
 	double y1[]={5.0,6.0,7.0,8.0};
         openblas_complex_double result1=openblas_make_complex_double(0.0,0.0);
         openblas_complex_double result2=openblas_make_complex_double(-9.0,32.0);
-#ifdef __CTEST_MSVC
+#ifdef OPENBLAS_COMPLEX_STRUCT
 	BLASFUNC(zdotu)(&result1,&N,x1+1,&incX,y1+1,&incY);
 #else
 	result1=BLASFUNC(zdotu)(&N,x1+1,&incX,y1+1,&incY);

--- a/utest/utest_main2.c
+++ b/utest/utest_main2.c
@@ -268,11 +268,11 @@ CTEST( zdotu,zdotu_n_1)
 	double y1[]={1.0,2.0};
         openblas_complex_double result1=openblas_make_complex_double(0.0,0.0);
         openblas_complex_double result2=openblas_make_complex_double(-1.0,3.0);
-#ifdef __CTEST_MSVC
-	BLASFUNC(zdotu)(&result1,&N,x1,&incX,y1,&incY);
-#else
+//#ifdef __CTEST_MSVC
+//	BLASFUNC(zdotu)(&result1,&N,x1,&incX,y1,&incY);
+//#else
 	result1=BLASFUNC(zdotu)(&N,x1,&incX,y1,&incY);
-#endif
+//#endif
 	
 #ifdef OPENBLAS_COMPLEX_STRUCT
 	ASSERT_DBL_NEAR_TOL(result1.real, result2.real, DOUBLE_EPS);

--- a/utest/utest_main2.c
+++ b/utest/utest_main2.c
@@ -266,10 +266,8 @@ CTEST( zdotu,zdotu_n_1)
 	int N=1,incX=1,incY=1;
 	double x1[]={1.0,1.0};
 	double y1[]={1.0,2.0};
-	double x2[]={1.0,1.0};
-	double y2[]={1.0,2.0};
-	_Complex result1=0.0;
-        _Complex result2={-1.0000+3.0000*I};
+        _Complex double result1=openblas_make_complex_double(0.0,0.0);
+        _Complex double result2=openblas_make_complex_double(-1.0,3.0);
 	//OpenBLAS
 	result1=BLASFUNC(zdotu)(&N,x1,&incX,y1,&incY);
 
@@ -283,10 +281,9 @@ CTEST(zdotu, zdotu_offset_1)
 	int N=1,incX=1,incY=1;
 	double x1[]={1.0,2.0,3.0,4.0};
 	double y1[]={5.0,6.0,7.0,8.0};
-	double x2[]={1.0,2.0,3.0,4.0};
-	double y2[]={5.0,6.0,7.0,8.0};
-	_Complex result1=0.0;
-	_Complex result2={-9.0000+32.0000*I};
+        _Complex double result1=openblas_make_complex_double(0.0,0.0);
+        _Complex double result2=openblas_make_complex_double(-9.0,32.0);
+       
 	//OpenBLAS
 	result1=BLASFUNC(zdotu)(&N,x1+1,&incX,y1+1,&incY);
 

--- a/utest/utest_main2.c
+++ b/utest/utest_main2.c
@@ -266,8 +266,8 @@ CTEST( zdotu,zdotu_n_1)
 	blasint N=1,incX=1,incY=1;
 	double x1[]={1.0,1.0};
 	double y1[]={1.0,2.0};
-        _Complex double result1=openblas_make_complex_double(0.0,0.0);
-        _Complex double result2=openblas_make_complex_double(-1.0,3.0);
+        _DComplex result1=openblas_make_complex_double(0.0,0.0);
+        _DComplex result2=openblas_make_complex_double(-1.0,3.0);
 	//OpenBLAS
 	result1=BLASFUNC(zdotu)(&N,x1,&incX,y1,&incY);
 
@@ -281,8 +281,8 @@ CTEST(zdotu, zdotu_offset_1)
 	blasint N=1,incX=1,incY=1;
 	double x1[]={1.0,2.0,3.0,4.0};
 	double y1[]={5.0,6.0,7.0,8.0};
-        _Complex double result1=openblas_make_complex_double(0.0,0.0);
-        _Complex double result2=openblas_make_complex_double(-9.0,32.0);
+        _DComplex result1=openblas_make_complex_double(0.0,0.0);
+        _DComplex result2=openblas_make_complex_double(-9.0,32.0);
        
 	//OpenBLAS
 	result1=BLASFUNC(zdotu)(&N,x1+1,&incX,y1+1,&incY);

--- a/utest/utest_main2.c
+++ b/utest/utest_main2.c
@@ -32,6 +32,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 **********************************************************************************/
 
 #include <stdio.h>
+#include <complex.h>
 
 #define CTEST_MAIN
 #define CTEST_SEGFAULT
@@ -180,6 +181,282 @@ CTEST(drotmg, rotmg_D1eqD2_X1eqX2){
 
 	for(i=0; i<5; i++){
 		ASSERT_DBL_NEAR_TOL(te_param[i], tr_param[i], DOUBLE_EPS);
+	}
+}
+
+CTEST(axpy,daxpy_inc_0)
+{
+	int i;
+	int N=8,incX=0,incY=0;
+	double a=0.25;
+	double x1[]={1.0,3.0,5.0,7.0,1.0,3.0,5.0,7.0};
+	double y1[]={2.0,4.0,6.0,8.0,2.0,4.0,6.0,8.0};
+
+	double x2[]={1.0,3.0,5.0,7.0,1.0,3.0,5.0,7.0};
+	double y2[]={4.0,4.0,6.0,8.0,2.0,4.0,6.0,8.0};
+
+	//OpenBLAS
+	BLASFUNC(daxpy)(&N,&a,x1,&incX,y1,&incY);
+
+	for(i=0; i<N; i++){
+		ASSERT_DBL_NEAR_TOL(x1[i], x2[i], DOUBLE_EPS);
+		ASSERT_DBL_NEAR_TOL(y1[i], y2[i], DOUBLE_EPS);
+	}
+}
+
+CTEST(axpy,zaxpy_inc_0)
+{
+	int i;
+	int N=4,incX=0,incY=0;
+	double a[2]={0.25,0.5};
+	double x1[]={1.0,3.0,5.0,7.0,1.0,3.0,5.0,7.0};
+	double y1[]={2.0,4.0,6.0,8.0,2.0,4.0,6.0,8.0};
+	double x2[]={1.0,3.0,5.0,7.0,1.0,3.0,5.0,7.0};
+	double y2[]={-3.0,9.0,6.0,8.0,2.0,4.0,6.0,8.0};
+
+	//OpenBLAS
+	BLASFUNC(zaxpy)(&N,a,x1,&incX,y1,&incY);
+
+	for(i=0; i<2*N; i++){
+		ASSERT_DBL_NEAR_TOL(x1[i], x2[i], DOUBLE_EPS);
+		ASSERT_DBL_NEAR_TOL(y1[i], y2[i], DOUBLE_EPS);
+	}
+}
+
+CTEST(axpy,saxpy_inc_0)
+{
+	int i;
+	int N=8,incX=0,incY=0;
+	float a=0.25;
+	float x1[]={1.0,3.0,5.0,7.0,1.0,3.0,5.0,7.0};
+	float y1[]={2.0,4.0,6.0,8.0,2.0,4.0,6.0,8.0};
+	float x2[]={1.0,3.0,5.0,7.0,1.0,3.0,5.0,7.0};
+	float y2[]={4.0,4.0,6.0,8.0,2.0,4.0,6.0,8.0};
+
+	//OpenBLAS
+	BLASFUNC(saxpy)(&N,&a,x1,&incX,y1,&incY);
+
+	for(i=0; i<N; i++){
+		ASSERT_DBL_NEAR_TOL(x1[i], x2[i], DOUBLE_EPS);
+		ASSERT_DBL_NEAR_TOL(y1[i], y2[i], DOUBLE_EPS);
+	}
+}
+
+CTEST(axpy,caxpy_inc_0)
+{
+	int i;
+	int N=4,incX=0,incY=0;
+	float a[2]={0.25,0.5};
+	float x1[]={1.0,3.0,5.0,7.0,1.0,3.0,5.0,7.0};
+	float y1[]={2.0,4.0,6.0,8.0,2.0,4.0,6.0,8.0};
+	float x2[]={1.0,3.0,5.0,7.0,1.0,3.0,5.0,7.0};
+	float y2[]={-3.0,9.0,6.0,8.0,2.0,4.0,6.0,8.0};
+
+	//OpenBLAS
+	BLASFUNC(caxpy)(&N,a,x1,&incX,y1,&incY);
+
+	for(i=0; i<2*N; i++){
+		ASSERT_DBL_NEAR_TOL(x1[i], x2[i], DOUBLE_EPS);
+		ASSERT_DBL_NEAR_TOL(y1[i], y2[i], DOUBLE_EPS);
+	}
+}
+
+CTEST( zdotu,zdotu_n_1)
+{
+	int N=1,incX=1,incY=1;
+	double x1[]={1.0,1.0};
+	double y1[]={1.0,2.0};
+	double x2[]={1.0,1.0};
+	double y2[]={1.0,2.0};
+	double _Complex result1=0.0;
+	double _Complex result2={-1.0000+3.0000*I};
+	//OpenBLAS
+	result1=BLASFUNC(zdotu)(&N,x1,&incX,y1,&incY);
+
+	ASSERT_DBL_NEAR_TOL(creal(result1), creal(result2), DOUBLE_EPS);
+	ASSERT_DBL_NEAR_TOL(cimag(result1), cimag(result2), DOUBLE_EPS);
+
+}
+
+CTEST(zdotu, zdotu_offset_1)
+{
+	int N=1,incX=1,incY=1;
+	double x1[]={1.0,2.0,3.0,4.0};
+	double y1[]={5.0,6.0,7.0,8.0};
+	double x2[]={1.0,2.0,3.0,4.0};
+	double y2[]={5.0,6.0,7.0,8.0};
+	double _Complex result1=0.0;
+	double _Complex result2={-9.0000+32.0000*I};
+	//OpenBLAS
+	result1=BLASFUNC(zdotu)(&N,x1+1,&incX,y1+1,&incY);
+
+	ASSERT_DBL_NEAR_TOL(creal(result1), creal(result2), DOUBLE_EPS);
+	ASSERT_DBL_NEAR_TOL(cimag(result1), cimag(result2), DOUBLE_EPS);
+
+}
+
+CTEST(dsdot,dsdot_n_1)
+{
+	float x= 0.172555164;
+	float y= -0.0138700781;
+	int incx=1;
+	int incy=1;
+	int n=1;
+
+	double res1=0.0f, res2=-0.00239335360107;
+
+	res1=BLASFUNC(dsdot)(&n, &x, &incx, &y, &incy);
+	ASSERT_DBL_NEAR_TOL(res1, res2, DOUBLE_EPS);
+
+}
+
+CTEST(rot,drot_inc_0)
+{
+	int i=0;
+	int N=4,incX=0,incY=0;
+	double c=0.25,s=0.5;
+	double x1[]={1.0,3.0,5.0,7.0};
+	double y1[]={2.0,4.0,6.0,8.0};
+	double x2[]={-0.21484375000000,3.0,5.0,7.0};
+	double y2[]={ 0.03906250000000,4.0,6.0,8.0};
+
+
+	//OpenBLAS
+	BLASFUNC(drot)(&N,x1,&incX,y1,&incY,&c,&s);
+
+	for(i=0; i<N; i++){
+		ASSERT_DBL_NEAR_TOL(x1[i], x2[i], DOUBLE_EPS);
+		ASSERT_DBL_NEAR_TOL(y1[i], y2[i], DOUBLE_EPS);
+	}
+}
+
+CTEST(rot,zdrot_inc_0)
+{
+	int i=0;
+	int N=4,incX=0,incY=0;
+	double c=0.25,s=0.5;
+	double x1[]={1.0,3.0,5.0,7.0,1.0,3.0,5.0,7.0};
+	double y1[]={2.0,4.0,6.0,8.0,2.0,4.0,6.0,8.0};
+	double x2[]={-0.21484375000000,-0.45703125000000 ,5.0,7.0,1.0,3.0,5.0,7.0};
+	double y2[]={ 0.03906250000000, 0.17187500000000 ,6.0,8.0,2.0,4.0,6.0,8.0};
+	
+
+	//OpenBLAS
+	BLASFUNC(zdrot)(&N,x1,&incX,y1,&incY,&c,&s);
+
+	for(i=0; i<2*N; i++){
+		ASSERT_DBL_NEAR_TOL(x1[i], x2[i], DOUBLE_EPS);
+		ASSERT_DBL_NEAR_TOL(y1[i], y2[i], DOUBLE_EPS);
+	}
+}
+
+CTEST(rot,srot_inc_0)
+{
+	int i=0;
+	int N=4,incX=0,incY=0;
+	float c=0.25,s=0.5;
+	float x1[]={1.0,3.0,5.0,7.0};
+	float y1[]={2.0,4.0,6.0,8.0};
+	float x2[]={-0.21484375000000,3.0,5.0,7.0};
+	float y2[]={ 0.03906250000000,4.0,6.0,8.0};
+
+	//OpenBLAS
+	BLASFUNC(srot)(&N,x1,&incX,y1,&incY,&c,&s);
+
+	for(i=0; i<N; i++){
+		ASSERT_DBL_NEAR_TOL(x1[i], x2[i], SINGLE_EPS);
+		ASSERT_DBL_NEAR_TOL(y1[i], y2[i], SINGLE_EPS);
+	}
+}
+
+CTEST(rot, csrot_inc_0)
+{
+	int i=0;
+	int N=4,incX=0,incY=0;
+	float c=0.25,s=0.5;
+	float x1[]={1.0,3.0,5.0,7.0,1.0,3.0,5.0,7.0};
+	float y1[]={2.0,4.0,6.0,8.0,2.0,4.0,6.0,8.0};
+	float x2[]={-0.21484375000000,-0.45703125000000 ,5.0,7.0,1.0,3.0,5.0,7.0};
+	float y2[]={ 0.03906250000000, 0.17187500000000 ,6.0,8.0,2.0,4.0,6.0,8.0};
+	
+	//OpenBLAS
+	BLASFUNC(csrot)(&N,x1,&incX,y1,&incY,&c,&s);
+
+	for(i=0; i<2*N; i++){
+		ASSERT_DBL_NEAR_TOL(x1[i], x2[i], SINGLE_EPS);
+		ASSERT_DBL_NEAR_TOL(y1[i], y2[i], SINGLE_EPS);
+	}
+}
+
+CTEST(swap,dswap_inc_0)
+{
+	int i=0;
+	int N=4,incX=0,incY=0;
+	double x1[]={1.0,3.0,5.0,7.0};
+	double y1[]={2.0,4.0,6.0,8.0};
+	double x2[]={1.0,3.0,5.0,7.0};
+	double y2[]={2.0,4.0,6.0,8.0};
+	
+	//OpenBLAS
+	BLASFUNC(dswap)(&N,x1,&incX,y1,&incY);
+
+	for(i=0; i<N; i++){
+		ASSERT_DBL_NEAR_TOL(x1[i], x2[i], DOUBLE_EPS);
+		ASSERT_DBL_NEAR_TOL(y1[i], y2[i], DOUBLE_EPS);
+	}
+}
+
+CTEST(swap,zswap_inc_0)
+{
+	int i=0;
+	int N=4,incX=0,incY=0;
+	double x1[]={1.0,3.0,5.0,7.0,1.0,3.0,5.0,7.0};
+	double y1[]={2.0,4.0,6.0,8.0,2.0,4.0,6.0,8.0};
+	double x2[]={1.0,3.0,5.0,7.0,1.0,3.0,5.0,7.0};
+	double y2[]={2.0,4.0,6.0,8.0,2.0,4.0,6.0,8.0};
+
+	//OpenBLAS
+	BLASFUNC(zswap)(&N,x1,&incX,y1,&incY);
+
+	for(i=0; i<2*N; i++){
+		ASSERT_DBL_NEAR_TOL(x1[i], x2[i], DOUBLE_EPS);
+		ASSERT_DBL_NEAR_TOL(y1[i], y2[i], DOUBLE_EPS);
+	}
+}
+
+CTEST(swap,sswap_inc_0)
+{
+	int i=0;
+	int N=4,incX=0,incY=0;
+	float x1[]={1.0,3.0,5.0,7.0};
+	float y1[]={2.0,4.0,6.0,8.0};
+	float x2[]={1.0,3.0,5.0,7.0};
+	float y2[]={2.0,4.0,6.0,8.0};
+
+	//OpenBLAS
+	BLASFUNC(sswap)(&N,x1,&incX,y1,&incY);
+
+	for(i=0; i<N; i++){
+		ASSERT_DBL_NEAR_TOL(x1[i], x2[i], SINGLE_EPS);
+		ASSERT_DBL_NEAR_TOL(y1[i], y2[i], SINGLE_EPS);
+	}
+}
+
+CTEST(swap,cswap_inc_0)
+{
+	int i=0;
+	int N=4,incX=0,incY=0;
+	float x1[]={1.0,3.0,5.0,7.0,1.0,3.0,5.0,7.0};
+	float y1[]={2.0,4.0,6.0,8.0,2.0,4.0,6.0,8.0};
+	float x2[]={1.0,3.0,5.0,7.0,1.0,3.0,5.0,7.0};
+	float y2[]={2.0,4.0,6.0,8.0,2.0,4.0,6.0,8.0};
+
+	//OpenBLAS
+	BLASFUNC(cswap)(&N,x1,&incX,y1,&incY);
+
+	for(i=0; i<2*N; i++){
+		ASSERT_DBL_NEAR_TOL(x1[i], x2[i], SINGLE_EPS);
+		ASSERT_DBL_NEAR_TOL(y1[i], y2[i], SINGLE_EPS);
 	}
 }
 

--- a/utest/utest_main2.c
+++ b/utest/utest_main2.c
@@ -57,7 +57,7 @@ CTEST (drotmg,rotmg){
 	double te_y1, tr_y1;
 	double te_param[5];
 	double tr_param[5];
-	int i=0;
+	blasint i=0;
 	// original test case for libGoto bug fixed by feb2014 rewrite
 	te_d1= 0.21149573940783739;
 	te_d2= 0.046892057172954082;
@@ -104,7 +104,7 @@ CTEST (drotmg,rotmg_issue1452){
 	double te_y1, tr_y1;
 	double te_param[5];
 	double tr_param[5];
-	int i=0;
+	blasint i=0;
 
 	// from issue #1452, buggy version returned 0.000244 for param[3]
 	te_d1 = 5.9e-8;
@@ -149,7 +149,7 @@ CTEST(drotmg, rotmg_D1eqD2_X1eqX2){
 	double te_y1, tr_y1;
 	double te_param[5];
 	double tr_param[5];
-	int i=0;
+	blasint i=0;
 	te_d1= tr_d1=2.;
 	te_d2= tr_d2=2.;
 	te_x1= tr_x1=8.;
@@ -186,8 +186,8 @@ CTEST(drotmg, rotmg_D1eqD2_X1eqX2){
 
 CTEST(axpy,daxpy_inc_0)
 {
-	int i;
-	int N=8,incX=0,incY=0;
+	blasint i;
+	blasint N=8,incX=0,incY=0;
 	double a=0.25;
 	double x1[]={1.0,3.0,5.0,7.0,1.0,3.0,5.0,7.0};
 	double y1[]={2.0,4.0,6.0,8.0,2.0,4.0,6.0,8.0};
@@ -206,8 +206,8 @@ CTEST(axpy,daxpy_inc_0)
 
 CTEST(axpy,zaxpy_inc_0)
 {
-	int i;
-	int N=4,incX=0,incY=0;
+	blasint i;
+	blasint N=4,incX=0,incY=0;
 	double a[2]={0.25,0.5};
 	double x1[]={1.0,3.0,5.0,7.0,1.0,3.0,5.0,7.0};
 	double y1[]={2.0,4.0,6.0,8.0,2.0,4.0,6.0,8.0};
@@ -225,8 +225,8 @@ CTEST(axpy,zaxpy_inc_0)
 
 CTEST(axpy,saxpy_inc_0)
 {
-	int i;
-	int N=8,incX=0,incY=0;
+	blasint i;
+	blasint N=8,incX=0,incY=0;
 	float a=0.25;
 	float x1[]={1.0,3.0,5.0,7.0,1.0,3.0,5.0,7.0};
 	float y1[]={2.0,4.0,6.0,8.0,2.0,4.0,6.0,8.0};
@@ -244,8 +244,8 @@ CTEST(axpy,saxpy_inc_0)
 
 CTEST(axpy,caxpy_inc_0)
 {
-	int i;
-	int N=4,incX=0,incY=0;
+	blasint i;
+	blasint N=4,incX=0,incY=0;
 	float a[2]={0.25,0.5};
 	float x1[]={1.0,3.0,5.0,7.0,1.0,3.0,5.0,7.0};
 	float y1[]={2.0,4.0,6.0,8.0,2.0,4.0,6.0,8.0};
@@ -263,7 +263,7 @@ CTEST(axpy,caxpy_inc_0)
 
 CTEST( zdotu,zdotu_n_1)
 {
-	int N=1,incX=1,incY=1;
+	blasint N=1,incX=1,incY=1;
 	double x1[]={1.0,1.0};
 	double y1[]={1.0,2.0};
         _Complex double result1=openblas_make_complex_double(0.0,0.0);
@@ -278,7 +278,7 @@ CTEST( zdotu,zdotu_n_1)
 
 CTEST(zdotu, zdotu_offset_1)
 {
-	int N=1,incX=1,incY=1;
+	blasint N=1,incX=1,incY=1;
 	double x1[]={1.0,2.0,3.0,4.0};
 	double y1[]={5.0,6.0,7.0,8.0};
         _Complex double result1=openblas_make_complex_double(0.0,0.0);
@@ -296,9 +296,9 @@ CTEST(dsdot,dsdot_n_1)
 {
 	float x= 0.172555164F;
 	float y= -0.0138700781F;
-	int incx=1;
-	int incy=1;
-	int n=1;
+	blasint incx=1;
+	blasint incy=1;
+	blasint n=1;
 
 	double res1=0.0f, res2=-0.00239335360107;
 
@@ -309,8 +309,8 @@ CTEST(dsdot,dsdot_n_1)
 
 CTEST(rot,drot_inc_0)
 {
-	int i=0;
-	int N=4,incX=0,incY=0;
+	blasint i=0;
+	blasint N=4,incX=0,incY=0;
 	double c=0.25,s=0.5;
 	double x1[]={1.0,3.0,5.0,7.0};
 	double y1[]={2.0,4.0,6.0,8.0};
@@ -329,8 +329,8 @@ CTEST(rot,drot_inc_0)
 
 CTEST(rot,zdrot_inc_0)
 {
-	int i=0;
-	int N=4,incX=0,incY=0;
+	blasint i=0;
+	blasint N=4,incX=0,incY=0;
 	double c=0.25,s=0.5;
 	double x1[]={1.0,3.0,5.0,7.0,1.0,3.0,5.0,7.0};
 	double y1[]={2.0,4.0,6.0,8.0,2.0,4.0,6.0,8.0};
@@ -349,8 +349,8 @@ CTEST(rot,zdrot_inc_0)
 
 CTEST(rot,srot_inc_0)
 {
-	int i=0;
-	int N=4,incX=0,incY=0;
+	blasint i=0;
+	blasint N=4,incX=0,incY=0;
 	float c=0.25,s=0.5;
 	float x1[]={1.0,3.0,5.0,7.0};
 	float y1[]={2.0,4.0,6.0,8.0};
@@ -368,8 +368,8 @@ CTEST(rot,srot_inc_0)
 
 CTEST(rot, csrot_inc_0)
 {
-	int i=0;
-	int N=4,incX=0,incY=0;
+	blasint i=0;
+	blasint N=4,incX=0,incY=0;
 	float c=0.25,s=0.5;
 	float x1[]={1.0,3.0,5.0,7.0,1.0,3.0,5.0,7.0};
 	float y1[]={2.0,4.0,6.0,8.0,2.0,4.0,6.0,8.0};
@@ -387,8 +387,8 @@ CTEST(rot, csrot_inc_0)
 
 CTEST(swap,dswap_inc_0)
 {
-	int i=0;
-	int N=4,incX=0,incY=0;
+	blasint i=0;
+	blasint N=4,incX=0,incY=0;
 	double x1[]={1.0,3.0,5.0,7.0};
 	double y1[]={2.0,4.0,6.0,8.0};
 	double x2[]={1.0,3.0,5.0,7.0};
@@ -405,8 +405,8 @@ CTEST(swap,dswap_inc_0)
 
 CTEST(swap,zswap_inc_0)
 {
-	int i=0;
-	int N=4,incX=0,incY=0;
+	blasint i=0;
+	blasint N=4,incX=0,incY=0;
 	double x1[]={1.0,3.0,5.0,7.0,1.0,3.0,5.0,7.0};
 	double y1[]={2.0,4.0,6.0,8.0,2.0,4.0,6.0,8.0};
 	double x2[]={1.0,3.0,5.0,7.0,1.0,3.0,5.0,7.0};
@@ -423,8 +423,8 @@ CTEST(swap,zswap_inc_0)
 
 CTEST(swap,sswap_inc_0)
 {
-	int i=0;
-	int N=4,incX=0,incY=0;
+	blasint i=0;
+	blasint N=4,incX=0,incY=0;
 	float x1[]={1.0,3.0,5.0,7.0};
 	float y1[]={2.0,4.0,6.0,8.0};
 	float x2[]={1.0,3.0,5.0,7.0};
@@ -441,8 +441,8 @@ CTEST(swap,sswap_inc_0)
 
 CTEST(swap,cswap_inc_0)
 {
-	int i=0;
-	int N=4,incX=0,incY=0;
+	blasint i=0;
+	blasint N=4,incX=0,incY=0;
 	float x1[]={1.0,3.0,5.0,7.0,1.0,3.0,5.0,7.0};
 	float y1[]={2.0,4.0,6.0,8.0,2.0,4.0,6.0,8.0};
 	float x2[]={1.0,3.0,5.0,7.0,1.0,3.0,5.0,7.0};

--- a/utest/utest_main2.c
+++ b/utest/utest_main2.c
@@ -271,9 +271,13 @@ CTEST( zdotu,zdotu_n_1)
 	//OpenBLAS
 	BLASFUNC(zdotu)(&result1,&N,x1,&incX,y1,&incY);
 
+#ifdef OPENBLAS_COMPLEX_STRUCT
+	ASSERT_DBL_NEAR_TOL(result1.real, result2.real, DOUBLE_EPS);
+	ASSERT_DBL_NEAR_TOL(result1.imag, result2.imag, DOUBLE_EPS);
+#else
 	ASSERT_DBL_NEAR_TOL(creal(result1), creal(result2), DOUBLE_EPS);
 	ASSERT_DBL_NEAR_TOL(cimag(result1), cimag(result2), DOUBLE_EPS);
-
+#endif
 }
 
 CTEST(zdotu, zdotu_offset_1)
@@ -287,9 +291,13 @@ CTEST(zdotu, zdotu_offset_1)
 	//OpenBLAS
 	BLASFUNC(zdotu)(&result1,&N,x1+1,&incX,y1+1,&incY);
 
+#ifdef OPENBLAS_COMPLEX_STRUCT
+	ASSERT_DBL_NEAR_TOL(result1.real, result2.real, DOUBLE_EPS);
+	ASSERT_DBL_NEAR_TOL(result1.imag, result2.imag, DOUBLE_EPS);
+#else
 	ASSERT_DBL_NEAR_TOL(creal(result1), creal(result2), DOUBLE_EPS);
 	ASSERT_DBL_NEAR_TOL(cimag(result1), cimag(result2), DOUBLE_EPS);
-
+#endif
 }
 
 CTEST(dsdot,dsdot_n_1)
@@ -477,7 +485,7 @@ int main(int argc, const char ** argv){
   CTEST_ADD (swap,dswap_inc_0);
   CTEST_ADD (swap,zswap_inc_0);
   CTEST_ADD (swap,sswap_inc_0);
-  CTEST:ADD (swap,cswap_inc_0);
+  CTEST_ADD (swap,cswap_inc_0);
 
   int num_fail=0;
 

--- a/utest/utest_main2.c
+++ b/utest/utest_main2.c
@@ -268,8 +268,8 @@ CTEST( zdotu,zdotu_n_1)
 	double y1[]={1.0,2.0};
 	double x2[]={1.0,1.0};
 	double y2[]={1.0,2.0};
-	double _Complex result1=0.0;
-	double _Complex result2={-1.0000+3.0000*I};
+	_Complex result1=0.0;
+        _Complex result2={-1.0000+3.0000*I};
 	//OpenBLAS
 	result1=BLASFUNC(zdotu)(&N,x1,&incX,y1,&incY);
 
@@ -285,8 +285,8 @@ CTEST(zdotu, zdotu_offset_1)
 	double y1[]={5.0,6.0,7.0,8.0};
 	double x2[]={1.0,2.0,3.0,4.0};
 	double y2[]={5.0,6.0,7.0,8.0};
-	double _Complex result1=0.0;
-	double _Complex result2={-9.0000+32.0000*I};
+	_Complex result1=0.0;
+	_Complex result2={-9.0000+32.0000*I};
 	//OpenBLAS
 	result1=BLASFUNC(zdotu)(&N,x1+1,&incX,y1+1,&incY);
 
@@ -297,8 +297,8 @@ CTEST(zdotu, zdotu_offset_1)
 
 CTEST(dsdot,dsdot_n_1)
 {
-	float x= 0.172555164;
-	float y= -0.0138700781;
+	float x= 0.172555164F;
+	float y= -0.0138700781F;
 	int incx=1;
 	int incy=1;
 	int n=1;

--- a/utest/utest_main2.c
+++ b/utest/utest_main2.c
@@ -266,8 +266,8 @@ CTEST( zdotu,zdotu_n_1)
 	blasint N=1,incX=1,incY=1;
 	double x1[]={1.0,1.0};
 	double y1[]={1.0,2.0};
-        _Dcomplex result1=openblas_make_complex_double(0.0,0.0);
-        _Dcomplex result2=openblas_make_complex_double(-1.0,3.0);
+        openblas_complex_double result1=openblas_make_complex_double(0.0,0.0);
+        openblas_complex_double result2=openblas_make_complex_double(-1.0,3.0);
 	//OpenBLAS
 	BLASFUNC(zdotu)(&result1,&N,x1,&incX,y1,&incY);
 
@@ -281,8 +281,8 @@ CTEST(zdotu, zdotu_offset_1)
 	blasint N=1,incX=1,incY=1;
 	double x1[]={1.0,2.0,3.0,4.0};
 	double y1[]={5.0,6.0,7.0,8.0};
-        _Dcomplex result1=openblas_make_complex_double(0.0,0.0);
-        _Dcomplex result2=openblas_make_complex_double(-9.0,32.0);
+        openblas_complex_double result1=openblas_make_complex_double(0.0,0.0);
+        openblas_complex_double result2=openblas_make_complex_double(-9.0,32.0);
        
 	//OpenBLAS
 	BLASFUNC(zdotu)(&result1,&N,x1+1,&incX,y1+1,&incY);
@@ -460,6 +460,25 @@ CTEST(swap,cswap_inc_0)
 int main(int argc, const char ** argv){
 
   CTEST_ADD(amax, samax);
+  CTEST_ADD (drotmg,rotmg);
+  CTEST_ADD (drotmg,rotmg_issue1452);
+  CTEST_ADD (drotmg, rotmg_D1eqD2_X1eqX2);
+  CTEST_ADD (axpy,daxpy_inc_0);
+  CTEST_ADD (axpy,zaxpy_inc_0);
+  CTEST_ADD (axpy,saxpy_inc_0);
+  CTEST_ADD (axpy,caxpy_inc_0);
+  CTEST_ADD (zdotu,zdotu_n_1);
+  CTEST_ADD (zdotu, zdotu_offset_1);
+  CTEST_ADD (dsdot,dsdot_n_1);
+  CTEST_ADD (rot,drot_inc_0);
+  CTEST_ADD (rot,zdrot_inc_0);
+  CTEST_ADD (rot,srot_inc_0);
+  CTEST_ADD (rot, csrot_inc_0);
+  CTEST_ADD (swap,dswap_inc_0);
+  CTEST_ADD (swap,zswap_inc_0);
+  CTEST_ADD (swap,sswap_inc_0);
+  CTEST:ADD (swap,cswap_inc_0);
+
   int num_fail=0;
 
   num_fail=ctest_main(argc, argv);


### PR DESCRIPTION
This PR reactivates all the earlier tests that were left out in the test migration from CuTest to ctest at 5a8447e9 , disables the fork test from #1450 on platforms other than Linux and Cygwin (observed to hang on Android/ARMV8) and replaces the 32bit SSWAP/DSWAP kernels on Nehalem with their generic counterparts in response to a failure exposed by the reactivated test.