### PR TITLE
Fix limited DSDOT precision on arm,aarch64 and zarch

### DIFF
--- a/kernel/arm/KERNEL.ARMV5
+++ b/kernel/arm/KERNEL.ARMV5
@@ -49,6 +49,7 @@ SDOTKERNEL   = ../arm/dot.c
 DDOTKERNEL   = ../arm/dot.c
 CDOTKERNEL   = ../arm/zdot.c
 ZDOTKERNEL   = ../arm/zdot.c
+DSDOTKERNEL  = ../generic/dot.c
 
 SNRM2KERNEL  = ../arm/nrm2.c
 DNRM2KERNEL  = ../arm/nrm2.c

--- a/kernel/arm64/KERNEL.ARMV8
+++ b/kernel/arm64/KERNEL.ARMV8
@@ -49,6 +49,7 @@ SDOTKERNEL   = dot.S
 DDOTKERNEL   = dot.S
 CDOTKERNEL   = zdot.S
 ZDOTKERNEL   = zdot.S
+DSDOTKERNEL  = dot.S
 
 SNRM2KERNEL  = nrm2.S
 DNRM2KERNEL  = nrm2.S

--- a/kernel/arm64/KERNEL.CORTEXA57
+++ b/kernel/arm64/KERNEL.CORTEXA57
@@ -29,6 +29,7 @@ SDOTKERNEL   = dot.S
 DDOTKERNEL   = dot.S
 CDOTKERNEL   = zdot.S
 ZDOTKERNEL   = zdot.S
+DSDOTKERNEL  = dot.S
 
 SNRM2KERNEL  = nrm2.S
 DNRM2KERNEL  = nrm2.S

--- a/kernel/zarch/KERNEL.Z13
+++ b/kernel/zarch/KERNEL.Z13
@@ -49,6 +49,7 @@ SDOTKERNEL   = ../arm/dot.c
 DDOTKERNEL   = ddot.c
 CDOTKERNEL   = ../arm/zdot.c
 ZDOTKERNEL   = zdot.c
+DSDOTKERNEL  = ../generic/dot.c
 
 SNRM2KERNEL  = ../arm/nrm2.c
 DNRM2KERNEL  = ../arm/nrm2.c

--- a/kernel/zarch/KERNEL.ZARCH_GENERIC
+++ b/kernel/zarch/KERNEL.ZARCH_GENERIC
@@ -49,6 +49,7 @@ SDOTKERNEL   = ../arm/dot.c
 DDOTKERNEL   = ../arm/dot.c
 CDOTKERNEL   = ../arm/zdot.c
 ZDOTKERNEL   = ../arm/zdot.c
+DSDOTKERNEL  = ../generic/dot.c
 
 SNRM2KERNEL  = ../arm/nrm2.c
 DNRM2KERNEL  = ../arm/nrm2.c


### PR DESCRIPTION
As shown by the revived test_dsdot utest, the "dsdot" mode of arm/dot.c has poor precision compared to either netlib reference or the improved implementation from generic/dot.c . Use the latter on arm32 and zarch, and use the dsdot mode of the arm64 dot.S. (See #1469)