### PR TITLE
Re-enable DAXPY AVX microkernels  for x86_64

### DIFF
--- a/kernel/x86_64/daxpy.c
+++ b/kernel/x86_64/daxpy.c
@@ -33,17 +33,12 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "daxpy_microk_nehalem-2.c"
 #elif defined(BULLDOZER)
 #include "daxpy_microk_bulldozer-2.c"
-/*
-these appear to be broken, see issue 1332
 #elif defined(STEAMROLLER) || defined(EXCAVATOR)
 #include "daxpy_microk_steamroller-2.c"
 #elif defined(PILEDRIVER)
 #include "daxpy_microk_piledriver-2.c"
 #elif defined(HASWELL) || defined(ZEN)
 #include "daxpy_microk_haswell-2.c"
-*/
-#elif defined(HASWELL) || defined(ZEN) || defined(PILEDRIVER) || defined(STEAMROLLER) || defined(EXCAVATOR)
-#include "daxpy_microk_sandy-2.c"
 #elif defined(SANDYBRIDGE)
 #include "daxpy_microk_sandy-2.c"
 #endif


### PR DESCRIPTION
as the inaccuracies seen in the original testcase for #1332 appear to be due to an artefact that amplifies the very small rounding differences between FMA and discrete multiply+add