### PR TITLE
Use generic/dot.c instead of the inferior arm/dot.c for x86 DSDOT

### DIFF
--- a/kernel/x86/KERNEL
+++ b/kernel/x86/KERNEL
@@ -169,7 +169,7 @@ ifndef ZDOTKERNEL
 ZDOTKERNEL   = ../arm/zdot.c
 endif
 
-DSDOTKERNEL   = ../arm/dot.c
+DSDOTKERNEL   = ../generic/dot.c
 
 # Bug in znrm2 assembler kernel
 ifndef ZNRM2KERNEL


### PR DESCRIPTION
to resolve dsdot utest failure seen in #1492