### PR TITLE
Add workaround for old gcc and clang versions

### DIFF
--- a/driver/others/memory.c
+++ b/driver/others/memory.c
@@ -148,8 +148,15 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define CONSTRUCTOR	__attribute__ ((constructor))
 #define DESTRUCTOR	__attribute__ ((destructor))
 #else
+#if __GNUC__ && INIT_PRIORITY && ((GCC_VERSION >= 40300) || (CLANG_VERSION >= 20900))
 #define CONSTRUCTOR	__attribute__ ((constructor(101)))
 #define DESTRUCTOR	__attribute__ ((destructor(101)))
+#elif __GNUC__ && INIT_PRIORITY
+#define CONSTRUCTOR	__attribute__ ((constructor))
+#define DESTRUCTOR	__attribute__ ((destructor))
+#else
+#define CONSTRUCTOR
+#define DESTRUCTOR
 #endif
 
 #ifdef DYNAMIC_ARCH

--- a/driver/others/memory.c
+++ b/driver/others/memory.c
@@ -150,12 +150,9 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #elif __GNUC__ && INIT_PRIORITY && ((GCC_VERSION >= 40300) || (CLANG_VERSION >= 20900))
 #define CONSTRUCTOR	__attribute__ ((constructor(101)))
 #define DESTRUCTOR	__attribute__ ((destructor(101)))
-#elif __GNUC__ && INIT_PRIORITY
+#else
 #define CONSTRUCTOR	__attribute__ ((constructor))
 #define DESTRUCTOR	__attribute__ ((destructor))
-#else
-#define CONSTRUCTOR
-#define DESTRUCTOR
 #endif
 
 #ifdef DYNAMIC_ARCH

--- a/driver/others/memory.c
+++ b/driver/others/memory.c
@@ -147,8 +147,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #elif (defined(OS_DARWIN) || defined(OS_SUNOS)) && defined(C_GCC)
 #define CONSTRUCTOR	__attribute__ ((constructor))
 #define DESTRUCTOR	__attribute__ ((destructor))
-#else
-#if __GNUC__ && INIT_PRIORITY && ((GCC_VERSION >= 40300) || (CLANG_VERSION >= 20900))
+#elif __GNUC__ && INIT_PRIORITY && ((GCC_VERSION >= 40300) || (CLANG_VERSION >= 20900))
 #define CONSTRUCTOR	__attribute__ ((constructor(101)))
 #define DESTRUCTOR	__attribute__ ((destructor(101)))
 #elif __GNUC__ && INIT_PRIORITY


### PR DESCRIPTION
Old gcc and clang do not handle constructor arguments, finally fix #875 as discussed there, using the fedora patch