### PR TITLE
Compile with cc rather than gcc whenever possible

### DIFF
--- a/Makefile.system
+++ b/Makefile.system
@@ -17,15 +17,19 @@ NETLIB_LAPACK_DIR = $(TOPDIR)/lapack-netlib
 #   http://stackoverflow.com/questions/4029274/mingw-and-make-variables
 # - Default value is 'cc' which is not always a valid command (e.g. MinGW).
 ifeq ($(origin CC),default)
+
+# Check if $(CC) refers to a valid command and set the value to gcc if not
+ifneq ($(findstring cmd.exe,$(SHELL)),)
+ifeq ($(shell where $(CC) 2>NUL),)
 CC = gcc
-# Change the default compile to clang on Mac OSX.
-# http://stackoverflow.com/questions/714100/os-detecting-makefile
-UNAME_S := $(shell uname -s)
-ifeq ($(UNAME_S),Darwin)
-     CC = clang
-#     EXTRALIB += -Wl,-no_compact_unwind
+endif
+else # POSIX
+ifeq ($(shell command -v $(CC) 2>/dev/null),)
+CC = gcc
 endif
 endif
+
+endif # CC is set to default
 
 # Default Fortran compiler (FC) is selected by f_check.
 

--- a/Makefile.system
+++ b/Makefile.system
@@ -23,11 +23,16 @@ ifneq ($(findstring cmd.exe,$(SHELL)),)
 ifeq ($(shell where $(CC) 2>NUL),)
 CC = gcc
 endif
-else # POSIX
+else # POSIX-ish
 ifeq ($(shell command -v $(CC) 2>/dev/null),)
+ifeq ($(shell uname -s),Darwin)
+CC = clang
+# EXTRALIB += -Wl,-no_compact_unwind
+else
 CC = gcc
-endif
-endif
+endif # Darwin
+endif # CC exists
+endif # Shell is sane
 
 endif # CC is set to default
 


### PR DESCRIPTION
See discussion in #1504 regarding misdetection of the appropriate compiler. This will require some verification, especially from someone familiar with Windows, that the approach taken here is legit.