### PR TITLE
Add macOS to the Travis testing matrix: Take 2!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ language: c
 jobs:
   include:
     - &test-ubuntu
+      os: linux
       stage: test
       compiler: gcc
       addons:
@@ -57,7 +58,8 @@ jobs:
         - TARGET_BOX=LINUX32
         - BTYPE="BINARY=32"
 
-    - stage: test
+    - os: linux
+      stage: test
       compiler: gcc
       addons:
         apt:
@@ -77,6 +79,7 @@ jobs:
     # which is slower than container-based infrastructure used for jobs
     # that don't require sudo.
     - &test-alpine
+      os: linux
       stage: test
       dist: trusty
       sudo: true
@@ -120,6 +123,7 @@ jobs:
         - BTYPE="BINARY=64 NO_AFFINITY=1 USE_OPENMP=0 NO_LAPACK=0 TARGET=core2"
 
     - &test-cmake
+      os: linux
       stage: test
       compiler: clang
       addons:
@@ -146,6 +150,18 @@ jobs:
       compiler: gcc
       env:
         - CMAKE=1
+
+    - os: osx
+      stage: test
+      osx_image: xcode8
+      before_script:
+        - COMMON_FLAGS="DYNAMIC_ARCH=1 TARGET=NEHALEM NUM_THREADS=32"
+        - brew update
+        - brew install gcc # for gfortran
+      script:
+        - travis_wait 45 make QUIET_MAKE=1 $COMMON_FLAGS $BTYPE
+      env:
+        - BTYPE="BINARY=64 INTERFACE64=1"
 
 # whitelist
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -151,7 +151,8 @@ jobs:
       env:
         - CMAKE=1
 
-    - os: osx
+    - &test-macos
+      os: osx
       stage: test
       osx_image: xcode8
       before_script:
@@ -162,6 +163,10 @@ jobs:
         - travis_wait 45 make QUIET_MAKE=1 $COMMON_FLAGS $BTYPE
       env:
         - BTYPE="BINARY=64 INTERFACE64=1"
+
+    - <<: *test-macos
+      env:
+        - BTYPE="BINARY=32"
 
 # whitelist
 branches:


### PR DESCRIPTION
Don't merge until we're sure that a Travis macOS build made it through.

I'm pretty sure this should fix the invalid YAML syntax issue. The `travis-lint` Ruby gem appears not to have been updated to work with build stages so I haven't been able to verify correctness locally.

Edit: Appears to be working!