### PR TITLE
Catch invalid cpu count returned by CPU_COUNT_S

### DIFF
--- a/driver/others/memory.c
+++ b/driver/others/memory.c
@@ -209,7 +209,8 @@ int ret;
   size = CPU_ALLOC_SIZE(nums);
   ret = sched_getaffinity(0,size,cpusetp);
   if (ret!=0) return nums;
-  nums = CPU_COUNT_S(size,cpusetp);
+  ret = CPU_COUNT_S(size,cpusetp);
+  if (ret > 0 && ret < nums) nums = ret;	
   CPU_FREE(cpusetp);
   return nums;
  #endif


### PR DESCRIPTION
mips32 was seen to return zero here, driving nthreads to zero with subsequent fpe in blas_quickdivide