### PR TITLE
Revert "Fix 32bit HASWELL builds"

### DIFF
--- a/kernel/Makefile.L3
+++ b/kernel/Makefile.L3
@@ -29,9 +29,7 @@ USE_TRMM = 1
 endif
 
 ifeq ($(CORE), HASWELL)
-ifeq ($(ARCH), x86_64)
 USE_TRMM = 1
-endif
 endif
 
 ifeq ($(CORE), ZEN)


### PR DESCRIPTION
Reverts xianyi/OpenBLAS#1333 to fix #1533 
In retrospect I am not sure what led me to my conclusion in 1331 anyway, where the actual TARGET would have been Nehalem rather than Haswell.