### PR TITLE
Disable multithreading in ztrmv

### DIFF
--- a/interface/ztrmv.c
+++ b/interface/ztrmv.c
@@ -239,6 +239,9 @@ void CNAME(enum CBLAS_ORDER order, enum CBLAS_UPLO Uplo,
   } else
       nthreads = 1;
 
+/* FIXME TRMV multithreading appears to be broken, see issue 1332*/
+  nthreads = 1;
+
   if(nthreads > 1) {
     buffer_size = n > 16 ? 0 : n * 4 + 40;
   }


### PR DESCRIPTION
BLAS-Tester shows that the same problem exists as with DTRMV (issue #1332)