### PR TITLE
Avoid out-of-bounds accesses in blas_quickdivide on big X86 systems

### DIFF
--- a/common_x86.h
+++ b/common_x86.h
@@ -179,6 +179,10 @@ static __inline int blas_quickdivide(unsigned int x, unsigned int y){
   return result;
 #else
 
+  if ( y > 64) {
+	  result = x/y;
+	  return result;
+  }	  
   y = blas_quick_divide_table[y];
 
   __asm__ __volatile__  ("mull %0" :"=d" (result) :"a"(x), "0" (y));

--- a/common_x86.h
+++ b/common_x86.h
@@ -178,11 +178,13 @@ static __inline int blas_quickdivide(unsigned int x, unsigned int y){
   result = x/y;
   return result;
 #else
-
+#if (MAX_CPU_NUMBER > 64)
   if ( y > 64) {
 	  result = x/y;
 	  return result;
-  }	  
+  }
+#endif
+	
   y = blas_quick_divide_table[y];
 
   __asm__ __volatile__  ("mull %0" :"=d" (result) :"a"(x), "0" (y));

--- a/common_x86_64.h
+++ b/common_x86_64.h
@@ -195,7 +195,9 @@ static __inline int blas_quickdivide(unsigned int x, unsigned int y){
   unsigned int result;
 
   if (y <= 1) return x;
-
+  
+  if (y > 64) return x/y;
+	
   y = blas_quick_divide_table[y];
 
   __asm__ __volatile__  ("mull %0" :"=d" (result) :"a"(x), "0" (y));

--- a/common_x86_64.h
+++ b/common_x86_64.h
@@ -195,11 +195,13 @@ static __inline int blas_quickdivide(unsigned int x, unsigned int y){
   unsigned int result;
 
   if (y <= 1) return x;
-  
+
+#if (MAX_CPU_NUMBER > 64)  
   if (y > 64) { 
 	  result = x / y;
 	  return result;
   }
+#endif
 	
   y = blas_quick_divide_table[y];
 

--- a/common_x86_64.h
+++ b/common_x86_64.h
@@ -196,7 +196,10 @@ static __inline int blas_quickdivide(unsigned int x, unsigned int y){
 
   if (y <= 1) return x;
   
-  if (y > 64) return x/y;
+  if (y > 64) { 
+	  result = x / y;
+	  return result;
+  }
 	
   y = blas_quick_divide_table[y];
 


### PR DESCRIPTION
blas_quick_divide_table holds only 65 entries, leading to spurious reads from memory on larger clusters.
Fixes #1541 and the underlying cause of #1497.