### PR TITLE
Update compiler flag for openmp use with ICC

### DIFF
--- a/Makefile.system
+++ b/Makefile.system
@@ -433,7 +433,7 @@ CCOMMON_OPT    += -fopenmp
 endif
 
 ifeq ($(C_COMPILER), INTEL)
-CCOMMON_OPT    += -openmp
+CCOMMON_OPT    += -fopenmp
 endif
 
 ifeq ($(C_COMPILER), PGI)


### PR DESCRIPTION
The deprecated -openmp option was finally removed in favor of -qopenmp or -fopenmp, picking the latter to stay compatible with Intel compiler versions before 2015 (when -q options were introduced). Fixes #1546