### PR TITLE
LAPACKE fixes from lapack PR249

### DIFF
--- a/lapack-netlib/LAPACKE/src/lapacke_clacgv.c
+++ b/lapack-netlib/LAPACKE/src/lapacke_clacgv.c
@@ -39,7 +39,7 @@ lapack_int LAPACKE_clacgv( lapack_int n, lapack_complex_float* x,
 #ifndef LAPACK_DISABLE_NAN_CHECK
     if( LAPACKE_get_nancheck() ) {
         /* Optionally check input matrices for NaNs */
-        if( LAPACKE_c_nancheck( 1+(n-1)*ABS(incx), x, incx ) ) {
+        if( LAPACKE_c_nancheck( n, x, incx ) ) {
             return -2;
         }
     }

--- a/lapack-netlib/LAPACKE/src/lapacke_clarfb.c
+++ b/lapack-netlib/LAPACKE/src/lapacke_clarfb.c
@@ -51,16 +51,21 @@ lapack_int LAPACKE_clarfb( int matrix_layout, char side, char trans, char direct
 #ifndef LAPACK_DISABLE_NAN_CHECK
     if( LAPACKE_get_nancheck() ) {
         /* Optionally check input matrices for NaNs */
-        ncols_v = LAPACKE_lsame( storev, 'c' ) ? k :
-                             ( ( LAPACKE_lsame( storev, 'r' ) &&
-                             LAPACKE_lsame( side, 'l' ) ) ? m :
-                             ( ( LAPACKE_lsame( storev, 'r' ) &&
-                             LAPACKE_lsame( side, 'r' ) ) ? n : 1) );
-        nrows_v = ( LAPACKE_lsame( storev, 'c' ) &&
-                             LAPACKE_lsame( side, 'l' ) ) ? m :
-                             ( ( LAPACKE_lsame( storev, 'c' ) &&
-                             LAPACKE_lsame( side, 'r' ) ) ? n :
-                             ( LAPACKE_lsame( storev, 'r' ) ? k : 1) );
+        lapack_int lrv, lcv;  /* row, column stride */
+        if( matrix_layout == LAPACK_COL_MAJOR ) {
+            lrv = 1;
+            lcv = ldv;
+        } else {
+            lrv = ldv;
+            lcv = 1;
+        }
+        ncols_v =     LAPACKE_lsame( storev, 'c' ) ? k :
+                  ( ( LAPACKE_lsame( storev, 'r' ) && LAPACKE_lsame( side, 'l' ) ) ? m :
+                  ( ( LAPACKE_lsame( storev, 'r' ) && LAPACKE_lsame( side, 'r' ) ) ? n : 1) );
+
+        nrows_v =   ( LAPACKE_lsame( storev, 'c' ) && LAPACKE_lsame( side, 'l' ) ) ? m :
+                  ( ( LAPACKE_lsame( storev, 'c' ) && LAPACKE_lsame( side, 'r' ) ) ? n :
+                    ( LAPACKE_lsame( storev, 'r' ) ? k : 1) );
         if( LAPACKE_cge_nancheck( matrix_layout, m, n, c, ldc ) ) {
             return -13;
         }
@@ -70,8 +75,8 @@ lapack_int LAPACKE_clarfb( int matrix_layout, char side, char trans, char direct
         if( LAPACKE_lsame( storev, 'c' ) && LAPACKE_lsame( direct, 'f' ) ) {
             if( LAPACKE_ctr_nancheck( matrix_layout, 'l', 'u', k, v, ldv ) )
                 return -9;
-            if( LAPACKE_cge_nancheck( matrix_layout, nrows_v-k, ncols_v, &v[k*ldv],
-                ldv ) )
+            if( LAPACKE_cge_nancheck( matrix_layout, nrows_v-k, ncols_v,
+                                      &v[k*lrv], ldv ) )
                 return -9;
         } else if( LAPACKE_lsame( storev, 'c' ) && LAPACKE_lsame( direct, 'b' ) ) {
             if( k > nrows_v ) {
@@ -79,23 +84,23 @@ lapack_int LAPACKE_clarfb( int matrix_layout, char side, char trans, char direct
                 return -8;
             }
             if( LAPACKE_ctr_nancheck( matrix_layout, 'u', 'u', k,
-                &v[(nrows_v-k)*ldv], ldv ) )
+                                      &v[(nrows_v-k)*lrv], ldv ) )
                 return -9;
             if( LAPACKE_cge_nancheck( matrix_layout, nrows_v-k, ncols_v, v, ldv ) )
                 return -9;
         } else if( LAPACKE_lsame( storev, 'r' ) && LAPACKE_lsame( direct, 'f' ) ) {
             if( LAPACKE_ctr_nancheck( matrix_layout, 'u', 'u', k, v, ldv ) )
                 return -9;
-            if( LAPACKE_cge_nancheck( matrix_layout, nrows_v, ncols_v-k, &v[k],
-                ldv ) )
+            if( LAPACKE_cge_nancheck( matrix_layout, nrows_v, ncols_v-k,
+                                      &v[k*lrv], ldv ) )
                 return -9;
-        } else if( LAPACKE_lsame( storev, 'r' ) && LAPACKE_lsame( direct, 'f' ) ) {
+        } else if( LAPACKE_lsame( storev, 'r' ) && LAPACKE_lsame( direct, 'b' ) ) {
             if( k > ncols_v ) {
                 LAPACKE_xerbla( "LAPACKE_clarfb", -8 );
                 return -8;
             }
-            if( LAPACKE_ctr_nancheck( matrix_layout, 'l', 'u', k, &v[ncols_v-k],
-                ldv ) )
+            if( LAPACKE_ctr_nancheck( matrix_layout, 'l', 'u', k,
+                                      &v[(ncols_v-k)*lcv], ldv ) )
                 return -9;
             if( LAPACKE_cge_nancheck( matrix_layout, nrows_v, ncols_v-k, v, ldv ) )
                 return -9;

--- a/lapack-netlib/LAPACKE/src/lapacke_clarfg.c
+++ b/lapack-netlib/LAPACKE/src/lapacke_clarfg.c
@@ -43,7 +43,7 @@ lapack_int LAPACKE_clarfg( lapack_int n, lapack_complex_float* alpha,
         if( LAPACKE_c_nancheck( 1, alpha, 1 ) ) {
             return -2;
         }
-        if( LAPACKE_c_nancheck( 1+(n-2)*ABS(incx), x, incx ) ) {
+        if( LAPACKE_c_nancheck( n-1, x, incx ) ) {
             return -3;
         }
     }

--- a/lapack-netlib/LAPACKE/src/lapacke_clarfx.c
+++ b/lapack-netlib/LAPACKE/src/lapacke_clarfx.c
@@ -38,6 +38,7 @@ lapack_int LAPACKE_clarfx( int matrix_layout, char side, lapack_int m,
                            lapack_complex_float tau, lapack_complex_float* c,
                            lapack_int ldc, lapack_complex_float* work )
 {
+    lapack_int lv;
     if( matrix_layout != LAPACK_COL_MAJOR && matrix_layout != LAPACK_ROW_MAJOR ) {
         LAPACKE_xerbla( "LAPACKE_clarfx", -1 );
         return -1;
@@ -51,7 +52,8 @@ lapack_int LAPACKE_clarfx( int matrix_layout, char side, lapack_int m,
         if( LAPACKE_c_nancheck( 1, &tau, 1 ) ) {
             return -6;
         }
-        if( LAPACKE_c_nancheck( m, v, 1 ) ) {
+        lv = (LAPACKE_lsame( side, 'l' ) ? m : n);
+        if( LAPACKE_c_nancheck( lv, v, 1 ) ) {
             return -5;
         }
     }

--- a/lapack-netlib/LAPACKE/src/lapacke_classq.c
+++ b/lapack-netlib/LAPACKE/src/lapacke_classq.c
@@ -39,7 +39,7 @@ lapack_int LAPACKE_classq( lapack_int n, lapack_complex_float* x,
 #ifndef LAPACK_DISABLE_NAN_CHECK
     if( LAPACKE_get_nancheck() ) {
         /* Optionally check input vector `x` and in/out scalars `scale` and `sumsq` for NaNs */
-        if( LAPACKE_c_nancheck( 1+(n-2)*ABS(incx), x, incx ) ) {
+        if( LAPACKE_c_nancheck( n, x, incx ) ) {
             return -2;
         }
         if( LAPACKE_s_nancheck( 1, scale, 1 ) ) {

--- a/lapack-netlib/LAPACKE/src/lapacke_cunmtr.c
+++ b/lapack-netlib/LAPACKE/src/lapacke_cunmtr.c
@@ -58,7 +58,7 @@ lapack_int LAPACKE_cunmtr( int matrix_layout, char side, char uplo, char trans,
         if( LAPACKE_cge_nancheck( matrix_layout, m, n, c, ldc ) ) {
             return -10;
         }
-        if( LAPACKE_c_nancheck( m-1, tau, 1 ) ) {
+        if( LAPACKE_c_nancheck( r-1, tau, 1 ) ) {
             return -9;
         }
     }

--- a/lapack-netlib/LAPACKE/src/lapacke_cupmtr.c
+++ b/lapack-netlib/LAPACKE/src/lapacke_cupmtr.c
@@ -58,7 +58,7 @@ lapack_int LAPACKE_cupmtr( int matrix_layout, char side, char uplo, char trans,
         if( LAPACKE_cge_nancheck( matrix_layout, m, n, c, ldc ) ) {
             return -9;
         }
-        if( LAPACKE_c_nancheck( m-1, tau, 1 ) ) {
+        if( LAPACKE_c_nancheck( r-1, tau, 1 ) ) {
             return -8;
         }
     }

--- a/lapack-netlib/LAPACKE/src/lapacke_dlarfb.c
+++ b/lapack-netlib/LAPACKE/src/lapacke_dlarfb.c
@@ -50,16 +50,21 @@ lapack_int LAPACKE_dlarfb( int matrix_layout, char side, char trans, char direct
 #ifndef LAPACK_DISABLE_NAN_CHECK
     if( LAPACKE_get_nancheck() ) {
         /* Optionally check input matrices for NaNs */
-        ncols_v = LAPACKE_lsame( storev, 'c' ) ? k :
-                             ( ( LAPACKE_lsame( storev, 'r' ) &&
-                             LAPACKE_lsame( side, 'l' ) ) ? m :
-                             ( ( LAPACKE_lsame( storev, 'r' ) &&
-                             LAPACKE_lsame( side, 'r' ) ) ? n : 1) );
-        nrows_v = ( LAPACKE_lsame( storev, 'c' ) &&
-                             LAPACKE_lsame( side, 'l' ) ) ? m :
-                             ( ( LAPACKE_lsame( storev, 'c' ) &&
-                             LAPACKE_lsame( side, 'r' ) ) ? n :
-                             ( LAPACKE_lsame( storev, 'r' ) ? k : 1) );
+        lapack_int lrv, lcv;  /* row, column stride */
+        if( matrix_layout == LAPACK_COL_MAJOR ) {
+            lrv = 1;
+            lcv = ldv;
+        } else {
+            lrv = ldv;
+            lcv = 1;
+        }
+        ncols_v =     LAPACKE_lsame( storev, 'c' ) ? k :
+                  ( ( LAPACKE_lsame( storev, 'r' ) && LAPACKE_lsame( side, 'l' ) ) ? m :
+                  ( ( LAPACKE_lsame( storev, 'r' ) && LAPACKE_lsame( side, 'r' ) ) ? n : 1) );
+
+        nrows_v =   ( LAPACKE_lsame( storev, 'c' ) && LAPACKE_lsame( side, 'l' ) ) ? m :
+                  ( ( LAPACKE_lsame( storev, 'c' ) && LAPACKE_lsame( side, 'r' ) ) ? n :
+                    ( LAPACKE_lsame( storev, 'r' ) ? k : 1) );
         if( LAPACKE_dge_nancheck( matrix_layout, m, n, c, ldc ) ) {
             return -13;
         }
@@ -69,8 +74,8 @@ lapack_int LAPACKE_dlarfb( int matrix_layout, char side, char trans, char direct
         if( LAPACKE_lsame( storev, 'c' ) && LAPACKE_lsame( direct, 'f' ) ) {
             if( LAPACKE_dtr_nancheck( matrix_layout, 'l', 'u', k, v, ldv ) )
                 return -9;
-            if( LAPACKE_dge_nancheck( matrix_layout, nrows_v-k, ncols_v, &v[k*ldv],
-                ldv ) )
+            if( LAPACKE_dge_nancheck( matrix_layout, nrows_v-k, ncols_v,
+                                      &v[k*lrv], ldv ) )
                 return -9;
         } else if( LAPACKE_lsame( storev, 'c' ) && LAPACKE_lsame( direct, 'b' ) ) {
             if( k > nrows_v ) {
@@ -78,23 +83,23 @@ lapack_int LAPACKE_dlarfb( int matrix_layout, char side, char trans, char direct
                 return -8;
             }
             if( LAPACKE_dtr_nancheck( matrix_layout, 'u', 'u', k,
-                &v[(nrows_v-k)*ldv], ldv ) )
+                                      &v[(nrows_v-k)*lrv], ldv ) )
                 return -9;
             if( LAPACKE_dge_nancheck( matrix_layout, nrows_v-k, ncols_v, v, ldv ) )
                 return -9;
         } else if( LAPACKE_lsame( storev, 'r' ) && LAPACKE_lsame( direct, 'f' ) ) {
             if( LAPACKE_dtr_nancheck( matrix_layout, 'u', 'u', k, v, ldv ) )
                 return -9;
-            if( LAPACKE_dge_nancheck( matrix_layout, nrows_v, ncols_v-k, &v[k],
-                ldv ) )
+            if( LAPACKE_dge_nancheck( matrix_layout, nrows_v, ncols_v-k,
+                                      &v[k*lrv], ldv ) )
                 return -9;
-        } else if( LAPACKE_lsame( storev, 'r' ) && LAPACKE_lsame( direct, 'f' ) ) {
+        } else if( LAPACKE_lsame( storev, 'r' ) && LAPACKE_lsame( direct, 'b' ) ) {
             if( k > ncols_v ) {
                 LAPACKE_xerbla( "LAPACKE_dlarfb", -8 );
                 return -8;
             }
-            if( LAPACKE_dtr_nancheck( matrix_layout, 'l', 'u', k, &v[ncols_v-k],
-                ldv ) )
+            if( LAPACKE_dtr_nancheck( matrix_layout, 'l', 'u', k,
+                                      &v[(ncols_v-k)*lcv], ldv ) )
                 return -9;
             if( LAPACKE_dge_nancheck( matrix_layout, nrows_v, ncols_v-k, v, ldv ) )
                 return -9;

--- a/lapack-netlib/LAPACKE/src/lapacke_dlarfg.c
+++ b/lapack-netlib/LAPACKE/src/lapacke_dlarfg.c
@@ -42,7 +42,7 @@ lapack_int LAPACKE_dlarfg( lapack_int n, double* alpha, double* x,
         if( LAPACKE_d_nancheck( 1, alpha, 1 ) ) {
             return -2;
         }
-        if( LAPACKE_d_nancheck( 1+(n-2)*ABS(incx), x, incx ) ) {
+        if( LAPACKE_d_nancheck( n-1, x, incx ) ) {
             return -3;
         }
     }

--- a/lapack-netlib/LAPACKE/src/lapacke_dlarfx.c
+++ b/lapack-netlib/LAPACKE/src/lapacke_dlarfx.c
@@ -37,6 +37,7 @@ lapack_int LAPACKE_dlarfx( int matrix_layout, char side, lapack_int m,
                            lapack_int n, const double* v, double tau, double* c,
                            lapack_int ldc, double* work )
 {
+    lapack_int lv;
     if( matrix_layout != LAPACK_COL_MAJOR && matrix_layout != LAPACK_ROW_MAJOR ) {
         LAPACKE_xerbla( "LAPACKE_dlarfx", -1 );
         return -1;
@@ -50,7 +51,8 @@ lapack_int LAPACKE_dlarfx( int matrix_layout, char side, lapack_int m,
         if( LAPACKE_d_nancheck( 1, &tau, 1 ) ) {
             return -6;
         }
-        if( LAPACKE_d_nancheck( m, v, 1 ) ) {
+        lv = (LAPACKE_lsame( side, 'l' ) ? m : n);
+        if( LAPACKE_d_nancheck( lv, v, 1 ) ) {
             return -5;
         }
     }

--- a/lapack-netlib/LAPACKE/src/lapacke_dlassq.c
+++ b/lapack-netlib/LAPACKE/src/lapacke_dlassq.c
@@ -38,7 +38,7 @@ lapack_int LAPACKE_dlassq( lapack_int n, double* x, lapack_int incx, double* sca
 #ifndef LAPACK_DISABLE_NAN_CHECK
     if( LAPACKE_get_nancheck() ) {
         /* Optionally check input vector `x` and in/out scalars `scale` and `sumsq` for NaNs */
-        if( LAPACKE_d_nancheck( 1+(n-2)*ABS(incx), x, incx ) ) {
+        if( LAPACKE_d_nancheck( n, x, incx ) ) {
             return -2;
         }
         if( LAPACKE_d_nancheck( 1, scale, 1 ) ) {

--- a/lapack-netlib/LAPACKE/src/lapacke_dopmtr.c
+++ b/lapack-netlib/LAPACKE/src/lapacke_dopmtr.c
@@ -56,7 +56,7 @@ lapack_int LAPACKE_dopmtr( int matrix_layout, char side, char uplo, char trans,
         if( LAPACKE_dge_nancheck( matrix_layout, m, n, c, ldc ) ) {
             return -9;
         }
-        if( LAPACKE_d_nancheck( m-1, tau, 1 ) ) {
+        if( LAPACKE_d_nancheck( r-1, tau, 1 ) ) {
             return -8;
         }
     }

--- a/lapack-netlib/LAPACKE/src/lapacke_dormtr.c
+++ b/lapack-netlib/LAPACKE/src/lapacke_dormtr.c
@@ -57,7 +57,7 @@ lapack_int LAPACKE_dormtr( int matrix_layout, char side, char uplo, char trans,
         if( LAPACKE_dge_nancheck( matrix_layout, m, n, c, ldc ) ) {
             return -10;
         }
-        if( LAPACKE_d_nancheck( m-1, tau, 1 ) ) {
+        if( LAPACKE_d_nancheck( r-1, tau, 1 ) ) {
             return -9;
         }
     }

--- a/lapack-netlib/LAPACKE/src/lapacke_slarfb.c
+++ b/lapack-netlib/LAPACKE/src/lapacke_slarfb.c
@@ -50,16 +50,21 @@ lapack_int LAPACKE_slarfb( int matrix_layout, char side, char trans, char direct
 #ifndef LAPACK_DISABLE_NAN_CHECK
     if( LAPACKE_get_nancheck() ) {
         /* Optionally check input matrices for NaNs */
-        ncols_v = LAPACKE_lsame( storev, 'c' ) ? k :
-                             ( ( LAPACKE_lsame( storev, 'r' ) &&
-                             LAPACKE_lsame( side, 'l' ) ) ? m :
-                             ( ( LAPACKE_lsame( storev, 'r' ) &&
-                             LAPACKE_lsame( side, 'r' ) ) ? n : 1) );
-        nrows_v = ( LAPACKE_lsame( storev, 'c' ) &&
-                             LAPACKE_lsame( side, 'l' ) ) ? m :
-                             ( ( LAPACKE_lsame( storev, 'c' ) &&
-                             LAPACKE_lsame( side, 'r' ) ) ? n :
-                             ( LAPACKE_lsame( storev, 'r' ) ? k : 1) );
+        lapack_int lrv, lcv;  /* row, column stride */
+        if( matrix_layout == LAPACK_COL_MAJOR ) {
+            lrv = 1;
+            lcv = ldv;
+        } else {
+            lrv = ldv;
+            lcv = 1;
+        }
+        ncols_v =     LAPACKE_lsame( storev, 'c' ) ? k :
+                  ( ( LAPACKE_lsame( storev, 'r' ) && LAPACKE_lsame( side, 'l' ) ) ? m :
+                  ( ( LAPACKE_lsame( storev, 'r' ) && LAPACKE_lsame( side, 'r' ) ) ? n : 1) );
+
+        nrows_v =   ( LAPACKE_lsame( storev, 'c' ) && LAPACKE_lsame( side, 'l' ) ) ? m :
+                  ( ( LAPACKE_lsame( storev, 'c' ) && LAPACKE_lsame( side, 'r' ) ) ? n :
+                    ( LAPACKE_lsame( storev, 'r' ) ? k : 1) );
         if( LAPACKE_sge_nancheck( matrix_layout, m, n, c, ldc ) ) {
             return -13;
         }
@@ -69,8 +74,8 @@ lapack_int LAPACKE_slarfb( int matrix_layout, char side, char trans, char direct
         if( LAPACKE_lsame( storev, 'c' ) && LAPACKE_lsame( direct, 'f' ) ) {
             if( LAPACKE_str_nancheck( matrix_layout, 'l', 'u', k, v, ldv ) )
                 return -9;
-            if( LAPACKE_sge_nancheck( matrix_layout, nrows_v-k, ncols_v, &v[k*ldv],
-                ldv ) )
+            if( LAPACKE_sge_nancheck( matrix_layout, nrows_v-k, ncols_v,
+                                      &v[k*lrv], ldv ) )
                 return -9;
         } else if( LAPACKE_lsame( storev, 'c' ) && LAPACKE_lsame( direct, 'b' ) ) {
             if( k > nrows_v ) {
@@ -78,23 +83,23 @@ lapack_int LAPACKE_slarfb( int matrix_layout, char side, char trans, char direct
                 return -8;
             }
             if( LAPACKE_str_nancheck( matrix_layout, 'u', 'u', k,
-                &v[(nrows_v-k)*ldv], ldv ) )
+                                      &v[(nrows_v-k)*lrv], ldv ) )
                 return -9;
             if( LAPACKE_sge_nancheck( matrix_layout, nrows_v-k, ncols_v, v, ldv ) )
                 return -9;
         } else if( LAPACKE_lsame( storev, 'r' ) && LAPACKE_lsame( direct, 'f' ) ) {
             if( LAPACKE_str_nancheck( matrix_layout, 'u', 'u', k, v, ldv ) )
                 return -9;
-            if( LAPACKE_sge_nancheck( matrix_layout, nrows_v, ncols_v-k, &v[k],
-                ldv ) )
+            if( LAPACKE_sge_nancheck( matrix_layout, nrows_v, ncols_v-k,
+                                      &v[k*lrv], ldv ) )
                 return -9;
-        } else if( LAPACKE_lsame( storev, 'r' ) && LAPACKE_lsame( direct, 'f' ) ) {
+        } else if( LAPACKE_lsame( storev, 'r' ) && LAPACKE_lsame( direct, 'b' ) ) {
             if( k > ncols_v ) {
                 LAPACKE_xerbla( "LAPACKE_slarfb", -8 );
                 return -8;
             }
-            if( LAPACKE_str_nancheck( matrix_layout, 'l', 'u', k, &v[ncols_v-k],
-                ldv ) )
+            if( LAPACKE_str_nancheck( matrix_layout, 'l', 'u', k,
+                                      &v[(ncols_v-k)*lcv], ldv ) )
                 return -9;
             if( LAPACKE_sge_nancheck( matrix_layout, nrows_v, ncols_v-k, v, ldv ) )
                 return -9;

--- a/lapack-netlib/LAPACKE/src/lapacke_slarfg.c
+++ b/lapack-netlib/LAPACKE/src/lapacke_slarfg.c
@@ -42,7 +42,7 @@ lapack_int LAPACKE_slarfg( lapack_int n, float* alpha, float* x,
         if( LAPACKE_s_nancheck( 1, alpha, 1 ) ) {
             return -2;
         }
-        if( LAPACKE_s_nancheck( 1+(n-2)*ABS(incx), x, incx ) ) {
+        if( LAPACKE_s_nancheck( n-1, x, incx ) ) {
             return -3;
         }
     }

--- a/lapack-netlib/LAPACKE/src/lapacke_slarfx.c
+++ b/lapack-netlib/LAPACKE/src/lapacke_slarfx.c
@@ -37,6 +37,7 @@ lapack_int LAPACKE_slarfx( int matrix_layout, char side, lapack_int m,
                            lapack_int n, const float* v, float tau, float* c,
                            lapack_int ldc, float* work )
 {
+    lapack_int lv;
     if( matrix_layout != LAPACK_COL_MAJOR && matrix_layout != LAPACK_ROW_MAJOR ) {
         LAPACKE_xerbla( "LAPACKE_slarfx", -1 );
         return -1;
@@ -50,7 +51,8 @@ lapack_int LAPACKE_slarfx( int matrix_layout, char side, lapack_int m,
         if( LAPACKE_s_nancheck( 1, &tau, 1 ) ) {
             return -6;
         }
-        if( LAPACKE_s_nancheck( m, v, 1 ) ) {
+        lv = (LAPACKE_lsame( side, 'l' ) ? m : n);
+        if( LAPACKE_s_nancheck( lv, v, 1 ) ) {
             return -5;
         }
     }

--- a/lapack-netlib/LAPACKE/src/lapacke_slassq.c
+++ b/lapack-netlib/LAPACKE/src/lapacke_slassq.c
@@ -38,7 +38,7 @@ lapack_int LAPACKE_slassq( lapack_int n, float* x, lapack_int incx, float* scale
 #ifndef LAPACK_DISABLE_NAN_CHECK
     if( LAPACKE_get_nancheck() ) {
         /* Optionally check input vector `x` and in/out scalars `scale` and `sumsq` for NaNs */
-        if( LAPACKE_s_nancheck( 1+(n-2)*ABS(incx), x, incx ) ) {
+        if( LAPACKE_s_nancheck( n, x, incx ) ) {
             return -2;
         }
         if( LAPACKE_s_nancheck( 1, scale, 1 ) ) {

--- a/lapack-netlib/LAPACKE/src/lapacke_sopmtr.c
+++ b/lapack-netlib/LAPACKE/src/lapacke_sopmtr.c
@@ -56,7 +56,7 @@ lapack_int LAPACKE_sopmtr( int matrix_layout, char side, char uplo, char trans,
         if( LAPACKE_sge_nancheck( matrix_layout, m, n, c, ldc ) ) {
             return -9;
         }
-        if( LAPACKE_s_nancheck( m-1, tau, 1 ) ) {
+        if( LAPACKE_s_nancheck( r-1, tau, 1 ) ) {
             return -8;
         }
     }

--- a/lapack-netlib/LAPACKE/src/lapacke_sormtr.c
+++ b/lapack-netlib/LAPACKE/src/lapacke_sormtr.c
@@ -57,7 +57,7 @@ lapack_int LAPACKE_sormtr( int matrix_layout, char side, char uplo, char trans,
         if( LAPACKE_sge_nancheck( matrix_layout, m, n, c, ldc ) ) {
             return -10;
         }
-        if( LAPACKE_s_nancheck( m-1, tau, 1 ) ) {
+        if( LAPACKE_s_nancheck( r-1, tau, 1 ) ) {
             return -9;
         }
     }

--- a/lapack-netlib/LAPACKE/src/lapacke_zlacgv.c
+++ b/lapack-netlib/LAPACKE/src/lapacke_zlacgv.c
@@ -39,7 +39,7 @@ lapack_int LAPACKE_zlacgv( lapack_int n, lapack_complex_double* x,
 #ifndef LAPACK_DISABLE_NAN_CHECK
     if( LAPACKE_get_nancheck() ) {
         /* Optionally check input matrices for NaNs */
-        if( LAPACKE_z_nancheck( 1+(n-1)*ABS(incx), x, incx ) ) {
+        if( LAPACKE_z_nancheck( n, x, incx ) ) {
             return -2;
         }
     }

--- a/lapack-netlib/LAPACKE/src/lapacke_zlarfg.c
+++ b/lapack-netlib/LAPACKE/src/lapacke_zlarfg.c
@@ -43,7 +43,7 @@ lapack_int LAPACKE_zlarfg( lapack_int n, lapack_complex_double* alpha,
         if( LAPACKE_z_nancheck( 1, alpha, 1 ) ) {
             return -2;
         }
-        if( LAPACKE_z_nancheck( 1+(n-2)*ABS(incx), x, incx ) ) {
+        if( LAPACKE_z_nancheck( n-1, x, incx ) ) {
             return -3;
         }
     }

--- a/lapack-netlib/LAPACKE/src/lapacke_zlarfx.c
+++ b/lapack-netlib/LAPACKE/src/lapacke_zlarfx.c
@@ -38,6 +38,7 @@ lapack_int LAPACKE_zlarfx( int matrix_layout, char side, lapack_int m,
                            lapack_complex_double tau, lapack_complex_double* c,
                            lapack_int ldc, lapack_complex_double* work )
 {
+    lapack_int lv;
     if( matrix_layout != LAPACK_COL_MAJOR && matrix_layout != LAPACK_ROW_MAJOR ) {
         LAPACKE_xerbla( "LAPACKE_zlarfx", -1 );
         return -1;
@@ -51,7 +52,8 @@ lapack_int LAPACKE_zlarfx( int matrix_layout, char side, lapack_int m,
         if( LAPACKE_z_nancheck( 1, &tau, 1 ) ) {
             return -6;
         }
-        if( LAPACKE_z_nancheck( m, v, 1 ) ) {
+        lv = (LAPACKE_lsame( side, 'l' ) ? m : n);
+        if( LAPACKE_z_nancheck( lv, v, 1 ) ) {
             return -5;
         }
     }

--- a/lapack-netlib/LAPACKE/src/lapacke_zlassq.c
+++ b/lapack-netlib/LAPACKE/src/lapacke_zlassq.c
@@ -39,7 +39,7 @@ lapack_int LAPACKE_zlassq( lapack_int n, lapack_complex_double* x,
 #ifndef LAPACK_DISABLE_NAN_CHECK
     if( LAPACKE_get_nancheck() ) {
         /* Optionally check input vector `x` and in/out scalars `scale` and `sumsq` for NaNs */
-        if( LAPACKE_z_nancheck( 1+(n-2)*ABS(incx), x, incx ) ) {
+        if( LAPACKE_z_nancheck( n, x, incx ) ) {
             return -2;
         }
         if( LAPACKE_d_nancheck( 1, scale, 1 ) ) {

--- a/lapack-netlib/LAPACKE/src/lapacke_zunmtr.c
+++ b/lapack-netlib/LAPACKE/src/lapacke_zunmtr.c
@@ -58,7 +58,7 @@ lapack_int LAPACKE_zunmtr( int matrix_layout, char side, char uplo, char trans,
         if( LAPACKE_zge_nancheck( matrix_layout, m, n, c, ldc ) ) {
             return -10;
         }
-        if( LAPACKE_z_nancheck( m-1, tau, 1 ) ) {
+        if( LAPACKE_z_nancheck( r-1, tau, 1 ) ) {
             return -9;
         }
     }

--- a/lapack-netlib/LAPACKE/src/lapacke_zupmtr.c
+++ b/lapack-netlib/LAPACKE/src/lapacke_zupmtr.c
@@ -58,7 +58,7 @@ lapack_int LAPACKE_zupmtr( int matrix_layout, char side, char uplo, char trans,
         if( LAPACKE_zge_nancheck( matrix_layout, m, n, c, ldc ) ) {
             return -9;
         }
-        if( LAPACKE_z_nancheck( m-1, tau, 1 ) ) {
+        if( LAPACKE_z_nancheck( r-1, tau, 1 ) ) {
             return -8;
         }
     }


### PR DESCRIPTION
Copied from https://github.com/Reference-LAPACK/lapack/pull/249, this fixes out-of-bounds memory accesses in the nancheck calls of the LAPACKE lacgv, lassq,larfg,larfb,larfx and mtr functions