### PR TITLE
move _Atomic define to common.h

### DIFF
--- a/common.h
+++ b/common.h
@@ -649,6 +649,12 @@ int omp_get_num_procs(void);
 __declspec(dllimport) int __cdecl omp_in_parallel(void);
 __declspec(dllimport) int __cdecl omp_get_num_procs(void);
 #endif
+#if (__STDC_VERSION__ >= 201112L)
+#ifndef _Atomic
+#define _Atomic volatile
+#endif
+#include <stdatomic.h>
+#endif
 #else
 #ifdef __ELF__
 int omp_in_parallel  (void) __attribute__ ((weak));

--- a/driver/others/blas_server_omp.c
+++ b/driver/others/blas_server_omp.c
@@ -36,12 +36,6 @@
 /* or implied, of The University of Texas at Austin.                 */
 /*********************************************************************/
 
-#if __STDC_VERSION__ >= 201112L
-#ifndef _Atomic
-#define _Atomic volatile
-#endif
-#include <stdatomic.h>
-#endif
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
Several places in the code use `_Atomic` when `__STDC_VERSION__ >= 201112L`, but when we enable OpenMP, it will disable _Atomic by default. Then the compiler will complain this:

> /usr/lib/gcc/x86_64-linux-gnu/5/include/stdatomic.h:40:1: sorry, unimplemented: ‘_Atomic’ with OpenMP
 typedef _Atomic _Bool atomic_bool;
 ^
/usr/lib/gcc/x86_64-linux-gnu/5/include/stdatomic.h:41:1: sorry, unimplemented: ‘_Atomic’ with OpenMP
 typedef _Atomic char atomic_char;
...

Here is the reference:
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65467

So we need to define `_Atomic` manually when we `USE_OPENMP` and `__STDC_VERSION__ >= 201112L`