### PR TITLE
Add threading and OpenMP information to output

### DIFF
--- a/driver/others/openblas_get_config.c
+++ b/driver/others/openblas_get_config.c
@@ -54,6 +54,9 @@ static char* openblas_config_str=""
 #ifdef NO_AFFINITY
   "NO_AFFINITY "
 #endif
+#ifdef USE_OPENMP
+  "USE_OPENMP "
+#endif
 #ifndef DYNAMIC_ARCH
   CHAR_CORENAME
 #endif
@@ -61,18 +64,23 @@ static char* openblas_config_str=""
 
 #ifdef DYNAMIC_ARCH
 char *gotoblas_corename();
-static char tmp_config_str[256];
 #endif
 
+static char tmp_config_str[256];
+int openblas_get_parallel();
 
 char* CNAME() {
-#ifndef DYNAMIC_ARCH
-  return openblas_config_str;
-#else
+char tmpstr[20];
   strcpy(tmp_config_str, openblas_config_str);
+#ifdef DYNAMIC_ARCH
   strcat(tmp_config_str, gotoblas_corename());
-  return tmp_config_str;
 #endif
+if (openblas_get_parallel() == 0)
+  sprintf(tmpstr, " SINGLE_THREADED");
+else 
+  snprintf(tmpstr,19," MAX_THREADS=%d",MAX_CPU_NUMBER);
+  strcat(tmp_config_str, tmpstr);
+  return tmp_config_str;
 }
 
 
@@ -83,3 +91,4 @@ char* openblas_get_corename() {
   return gotoblas_corename();
 #endif
 }
+


### PR DESCRIPTION
For #1416 and #1529, more information about the options OpenBLAS was built with is needed. Additionally we may want to add this data to the openblas.pc file (but not all projects use pkgconfig, and as far as I am aware the cmake module for accessing it does not make such "private" declarations available)