### PR TITLE
Revert " Switch mips32 target to USE_TRMM to fix complex TRMM"

### DIFF
--- a/kernel/Makefile.L3
+++ b/kernel/Makefile.L3
@@ -20,10 +20,6 @@ ifeq ($(ARCH), arm64)
 USE_TRMM = 1
 endif
 
-ifeq ($(ARCH), mips)
-USE_TRMM = 1
-endif
-
 ifeq ($(TARGET), LOONGSON3B)
 USE_TRMM = 1
 endif


### PR DESCRIPTION
... as this part of #1543 was just a silly workaround for the issue seen in #1563, caused by #1419