### PR TITLE
Use the new zrot.c on POWER8 for crot as well

### DIFF
--- a/kernel/power/KERNEL.POWER8
+++ b/kernel/power/KERNEL.POWER8
@@ -133,7 +133,7 @@ ZNRM2KERNEL  = ../arm/znrm2.c
 #
 SROTKERNEL   = srot.c
 DROTKERNEL   = drot.c
-#CROTKERNEL   = ../arm/zrot.c
+CROTKERNEL   = zrot.c
 ZROTKERNEL   = zrot.c
 #
 SSCALKERNEL  = sscal.c


### PR DESCRIPTION
fixes #1571 (the old zrot.S assembly does not handle incx=0 correctly)