### PR TITLE
Handle INCX=0,INCY=0 case

### DIFF
--- a/kernel/x86/KERNEL.NEHALEM
+++ b/kernel/x86/KERNEL.NEHALEM
@@ -1,3 +1,1 @@
 include $(KERNELDIR)/KERNEL.PENRYN
-SSWAPKERNEL  = ../arm/swap.c
-DSWAPKERNEL  = ../arm/swap.c

--- a/kernel/x86/swap.S
+++ b/kernel/x86/swap.S
@@ -138,6 +138,14 @@
 /* INCX != 1 or INCY != 1 */
 
 .L14:
+	cmpl	$0, %ebx
+	jne	.L141
+	cmpl	$0, %ecx
+	jne	.L141
+/* INCX == 0 and INCY == 0 */	
+	jmp	.L27
+
+.L141	
 	movl	%edx, %eax
 	sarl	$2,   %eax
 	jle	.L28

--- a/kernel/x86/swap.S
+++ b/kernel/x86/swap.S
@@ -145,7 +145,7 @@
 /* INCX == 0 and INCY == 0 */	
 	jmp	.L27
 
-.L141	
+.L141:	
 	movl	%edx, %eax
 	sarl	$2,   %eax
 	jle	.L28


### PR DESCRIPTION
Fixes #1575 (sswap/dswap failing the swap utest on x86) as suggested by atsampson.