### PR TITLE
Revert "take out unused variables"

### DIFF
--- a/driver/others/memory.c
+++ b/driver/others/memory.c
@@ -180,7 +180,7 @@ int get_num_procs(void) {
 cpu_set_t *cpusetp;
 size_t size;
 int ret;
-// int i,n;
+int i,n;
 
   if (!nums) nums = sysconf(_SC_NPROCESSORS_CONF);
 #if !defined(OS_LINUX)


### PR DESCRIPTION
This reverts commit e5752ff9b322c665a7393d6109c2da7ad6ee2523.

The variables i and n are used in the `#if !__GLIBC_PREREQ(2, 7)`
branch.

Closes gh-1586.