### PR TITLE
Improved AVX512 test case for c_check

### DIFF
--- a/c_check
+++ b/c_check
@@ -203,8 +203,8 @@ $binformat    = bin64  if ($data =~ /BINARY_64/);
 
 $no_avx512= 0;
 if (($architecture eq "x86") || ($architecture eq "x86_64")) {
-    $code = '"vaddps %zmm1, %zmm0, %zmm0"'; 
-    print $tmpf "void main(void){ __asm__ volatile($code); }\n";
+    $code = '"vbroadcastss -4 * 4(%rsi), %zmm2"';
+    print $tmpf "int main(void){ __asm__ volatile($code); }\n";
     $args = " -o $tmpf.o -x c $tmpf";
     my @cmd = ("$compiler_name $args");
     system(@cmd) == 0;

--- a/cmake/system_check.cmake
+++ b/cmake/system_check.cmake
@@ -67,7 +67,7 @@ else()
 endif()
 
 if (X86_64 OR X86)
-  file(WRITE ${PROJECT_BINARY_DIR}/avx512.tmp "void main(void){ __asm__ volatile(\"vaddps %zmm1, %zmm0, %zmm0\"); }")
+  file(WRITE ${PROJECT_BINARY_DIR}/avx512.tmp "int main(void){ __asm__ volatile(\"vbroadcastss -4 * 4(%rsi), %zmm2\"); }")
 execute_process(COMMAND ${CMAKE_C_COMPILER} -v -o ${PROJECT_BINARY_DIR}/avx512.o -x c ${PROJECT_BINARY_DIR}/avx512.tmp RESULT_VARIABLE NO_AVX512)
 if (NO_AVX512 EQUAL 1)
 set (CCOMMON_OPT "${CCOMMON_OPT} -DNO_AVX512")


### PR DESCRIPTION
Old versions  of clang managed to accept the original "vaddps" line despite being unable to compile the 
actual SkylakeX assembly in DYNAMIC_ARCH mode.