### PR TITLE
Use usleep instead of sched_yield by default

### DIFF
--- a/common.h
+++ b/common.h
@@ -356,7 +356,7 @@ typedef int blasint;
 */
 
 #ifndef YIELDING
-#define YIELDING	sched_yield()
+#define YIELDING	usleep(10)
 #endif
 
 /***


### PR DESCRIPTION
sched_yield only burns cpu cycles, fixes #900,  see also #923, #1560