### PR TITLE
Improve performance of GEMM for small matrices when SMP is defined.

### DIFF
--- a/interface/trsm.c
+++ b/interface/trsm.c
@@ -366,12 +366,13 @@ void CNAME(enum CBLAS_ORDER order,
   mode |= (trans << BLAS_TRANSA_SHIFT);
   mode |= (side  << BLAS_RSIDE_SHIFT);
 
-  args.nthreads = num_cpu_avail(3);
   if ( args.m < 2*GEMM_MULTITHREAD_THRESHOLD )
 	args.nthreads = 1;
   else
 	if ( args.n < 2*GEMM_MULTITHREAD_THRESHOLD )
 		args.nthreads = 1;
+  else
+	args.nthreads = num_cpu_avail(3);
 		
 
   if (args.nthreads == 1) {


### PR DESCRIPTION
Always checking num_cpu_avail() regardless of whether threading will actually
be used adds noticeable overhead for small matrices.  Most other uses of
num_cpu_avail() do so only if threading will be used, so do the same here.