### PR TITLE
Return a somewhat sane default value for L2 cache size if cpuid retur…

### DIFF
--- a/kernel/setparam-ref.c
+++ b/kernel/setparam-ref.c
@@ -647,7 +647,9 @@ static int get_l2_size_old(void){
       return 6144;
     }
   }
-  return 0;
+//  return 0;
+fprintf (stderr,"OpenBLAS WARNING - could not determine the L2 cache size on this system, assuming 256k\n");
+return 256;
 }
 #endif
 

--- a/kernel/setparam-ref.c
+++ b/kernel/setparam-ref.c
@@ -662,6 +662,10 @@ static __inline__ int get_l2_size(void){
   l2 = BITMASK(ecx, 16, 0xffff);
 
 #ifndef ARCH_X86
+  if (l2 <= 0) {
+     fprintf (stderr,"OpenBLAS WARNING - could not determine the L2 cache size on this system, assuming 256k\n");
+     return 256;
+  }
   return l2;
 
 #else


### PR DESCRIPTION
…ned something unexpected

Fixes #1610, the KVM hypervisor on Google Chromebooks returning zero for CPUID  0x80000006, causing DYNAMIC_ARCH builds of OpenBLAS to hang