### PR TITLE
Revert "Use usleep instead of sched_yield by default"

### DIFF
--- a/common.h
+++ b/common.h
@@ -356,7 +356,7 @@ typedef int blasint;
 */
 
 #ifndef YIELDING
-#define YIELDING	usleep(10)
+#define YIELDING	sched_yield()
 #endif
 
 /***


### PR DESCRIPTION
Reverts xianyi/OpenBLAS#1600 due to concerns raised in #900