### PR TITLE
Make gfortran link libomp for clang in the tests; avoid two typical gotchas with NOFORTRAN

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,15 @@ ifeq ($(BUILD_RELAPACK), 1)
 RELA = re_lapack
 endif
 
+ifeq ($(NOFORTRAN), 0)
+undefine NOFORTRAN
+endif
+
+ifeq ($(NO_FORTRAN), 1)
+undefine NO_FORTRAN
+NOFORTRAN=1
+endif
+
 LAPACK_NOOPT := $(filter-out -O0 -O1 -O2 -O3 -Ofast,$(LAPACK_FFLAGS))
 
 SUBDIRS_ALL = $(SUBDIRS) test ctest utest exports benchmark ../laswp ../bench

--- a/Makefile
+++ b/Makefile
@@ -21,13 +21,15 @@ ifeq ($(BUILD_RELAPACK), 1)
 RELA = re_lapack
 endif
 
-ifeq ($(NOFORTRAN), 0)
-undefine NOFORTRAN
-endif
-
 ifeq ($(NO_FORTRAN), 1)
-undefine NO_FORTRAN
-NOFORTRAN=1
+define NOFORTRAN
+1
+endef
+define NO_LAPACK
+1
+endef
+export NOFORTRAN
+export NO_LAPACK
 endif
 
 LAPACK_NOOPT := $(filter-out -O0 -O1 -O2 -O3 -Ofast,$(LAPACK_FFLAGS))
@@ -56,7 +58,7 @@ endif
 endif
 
 	@echo "  C compiler       ... $(C_COMPILER)  (command line : $(CC))"
-ifndef NOFORTRAN
+ifneq ($(NOFORTRAN), $(filter $(NOFORTRAN), 1 2))
 	@echo "  Fortran compiler ... $(F_COMPILER)  (command line : $(FC))"
 endif
 ifneq ($(OSNAME), AIX)
@@ -117,7 +119,7 @@ endif
 endif
 
 tests :
-ifndef NOFORTRAN
+ifneq ($(NOFORTRAN), $(filter $(NOFORTRAN), 1 2))
 	touch $(LIBNAME)
 ifndef NO_FBLAS
 	$(MAKE) -C test all
@@ -219,7 +221,7 @@ netlib :
 
 else
 netlib : lapack_prebuild
-ifndef NOFORTRAN
+ifneq ($(NOFORTRAN), $(filter $(NOFORTRAN), 1 2))
 	@$(MAKE) -C $(NETLIB_LAPACK_DIR) lapacklib
 	@$(MAKE) -C $(NETLIB_LAPACK_DIR) tmglib
 endif
@@ -240,7 +242,7 @@ prof_lapack : lapack_prebuild
 	@$(MAKE) -C $(NETLIB_LAPACK_DIR) lapack_prof
 
 lapack_prebuild :
-ifndef NOFORTRAN
+ifneq ($(NOFORTRAN), $(filter $(NOFORTRAN), 1 2))
 	-@echo "FORTRAN     = $(FC)" > $(NETLIB_LAPACK_DIR)/make.inc
 	-@echo "OPTS        = $(LAPACK_FFLAGS)" >> $(NETLIB_LAPACK_DIR)/make.inc
 	-@echo "POPTS       = $(LAPACK_FPFLAGS)" >> $(NETLIB_LAPACK_DIR)/make.inc
@@ -283,21 +285,21 @@ endif
 endif
 
 large.tgz :
-ifndef NOFORTRAN
+ifneq ($(NOFORTRAN), $(filter $(NOFORTRAN), 1 2))
 	if [ ! -a $< ]; then
 	-wget http://www.netlib.org/lapack/timing/large.tgz;
 	fi
 endif
 
 timing.tgz :
-ifndef NOFORTRAN
+ifneq ($(NOFORTRAN), $(filter $(NOFORTRAN), 1 2))
 	if [ ! -a $< ]; then
 	-wget http://www.netlib.org/lapack/timing/timing.tgz;
 	fi
 endif
 
 lapack-timing : large.tgz timing.tgz
-ifndef NOFORTRAN
+ifneq ($(NOFORTRAN), $(filter $(NOFORTRAN), 1 2))
 	(cd $(NETLIB_LAPACK_DIR); $(TAR) zxf ../timing.tgz TIMING)
 	(cd $(NETLIB_LAPACK_DIR)/TIMING; $(TAR) zxf ../../large.tgz )
 	$(MAKE) -C $(NETLIB_LAPACK_DIR)/TIMING

--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ endif
 endif
 
 	@echo "  C compiler       ... $(C_COMPILER)  (command line : $(CC))"
-ifneq ($(NOFORTRAN), $(filter $(NOFORTRAN), 1 2))
+ifneq ($(NOFORTRAN), $(filter-out $(NOFORTRAN), 1 2))
 	@echo "  Fortran compiler ... $(F_COMPILER)  (command line : $(FC))"
 endif
 ifneq ($(OSNAME), AIX)
@@ -119,7 +119,7 @@ endif
 endif
 
 tests :
-ifneq ($(NOFORTRAN), $(filter $(NOFORTRAN), 1 2))
+ifneq ($(NOFORTRAN), $(filter-out $(NOFORTRAN), 1 2))
 	touch $(LIBNAME)
 ifndef NO_FBLAS
 	$(MAKE) -C test all
@@ -221,7 +221,7 @@ netlib :
 
 else
 netlib : lapack_prebuild
-ifneq ($(NOFORTRAN), $(filter $(NOFORTRAN), 1 2))
+ifneq ($(NOFORTRAN), $(filter-out $(NOFORTRAN), 1 2))
 	@$(MAKE) -C $(NETLIB_LAPACK_DIR) lapacklib
 	@$(MAKE) -C $(NETLIB_LAPACK_DIR) tmglib
 endif
@@ -242,7 +242,10 @@ prof_lapack : lapack_prebuild
 	@$(MAKE) -C $(NETLIB_LAPACK_DIR) lapack_prof
 
 lapack_prebuild :
-ifneq ($(NOFORTRAN), $(filter $(NOFORTRAN), 1 2))
+	$(info filter value of NOFORTRAN is:)
+	$(info x$(filter-out $(NOFORTRAN), 1 2)x)
+
+ifneq ($(NOFORTRAN), $(filter-out $(NOFORTRAN), 1 2))
 	-@echo "FORTRAN     = $(FC)" > $(NETLIB_LAPACK_DIR)/make.inc
 	-@echo "OPTS        = $(LAPACK_FFLAGS)" >> $(NETLIB_LAPACK_DIR)/make.inc
 	-@echo "POPTS       = $(LAPACK_FPFLAGS)" >> $(NETLIB_LAPACK_DIR)/make.inc

--- a/ctest/Makefile
+++ b/ctest/Makefile
@@ -102,7 +102,13 @@ clean ::
 	rm -f x*
 
 FLDFLAGS = $(FFLAGS:-fPIC=) $(LDFLAGS)
-CEXTRALIB =
+ifeq ($(USE_OPENMP), 1)
+ifeq ($(F_COMPILER), GFORTRAN)
+ifeq ($(C_COMPILER), CLANG)
+CEXTRALIB = -lomp
+endif
+endif
+endif
 
 # Single real
 xscblat1: $(stestl1o) c_sblat1.o $(TOPDIR)/$(LIBNAME)

--- a/test/Makefile
+++ b/test/Makefile
@@ -122,8 +122,13 @@ endif
 
 
 FLDFLAGS = $(FFLAGS:-fPIC=) $(LDFLAGS)
-CEXTRALIB =
-
+ifeq ($(USE_OPENMP), 1)
+ifeq ($(F_COMPILER), GFORTRAN)
+ifeq ($(C_COMPILER), CLANG)
+CEXTRALIB = -lomp
+endif
+endif
+endif
 
 sblat1 : sblat1.$(SUFFIX) ../$(LIBNAME)
 	$(FC) $(FLDFLAGS) -o sblat1 sblat1.$(SUFFIX) ../$(LIBNAME) $(EXTRALIB) $(CEXTRALIB)


### PR DESCRIPTION
Fixes #1628. The NOFORTRAN issue is also relevant to #1422