### PR TITLE
Remove premature exits from ARMV7 xdot codes 

### DIFF
--- a/kernel/arm/cdot_vfp.S
+++ b/kernel/arm/cdot_vfp.S
@@ -215,11 +215,11 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	cmp	N, #0
 	ble	cdot_kernel_L999
 
-	cmp	INC_X, #0
-	beq	cdot_kernel_L999
+#	cmp	INC_X, #0
+#	beq	cdot_kernel_L999
 
-	cmp	INC_Y, #0
-	beq	cdot_kernel_L999
+#	cmp	INC_Y, #0
+#	beq	cdot_kernel_L999
 
 	cmp	INC_X, #1
 	bne	cdot_kernel_S_BEGIN

--- a/kernel/arm/ddot_vfp.S
+++ b/kernel/arm/ddot_vfp.S
@@ -164,11 +164,11 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	cmp	N, #0
 	ble	ddot_kernel_L999
 
-	cmp	INC_X, #0
-	beq	ddot_kernel_L999
+#	cmp	INC_X, #0
+#	beq	ddot_kernel_L999
 
-	cmp	INC_Y, #0
-	beq	ddot_kernel_L999
+#	cmp	INC_Y, #0
+#	beq	ddot_kernel_L999
 
 	cmp	INC_X, #1
 	bne	ddot_kernel_S_BEGIN

--- a/kernel/arm/sdot_vfp.S
+++ b/kernel/arm/sdot_vfp.S
@@ -253,11 +253,11 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	cmp	N, #0
 	ble	sdot_kernel_L999
 
-	cmp	INC_X, #0
-	beq	sdot_kernel_L999
+#	cmp	INC_X, #0
+#	beq	sdot_kernel_L999
 
-	cmp	INC_Y, #0
-	beq	sdot_kernel_L999
+#	cmp	INC_Y, #0
+#	beq	sdot_kernel_L999
 
 	cmp	INC_X, #1
 	bne	sdot_kernel_S_BEGIN

--- a/kernel/arm/zdot_vfp.S
+++ b/kernel/arm/zdot_vfp.S
@@ -218,11 +218,11 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	cmp	N, #0
 	ble	zdot_kernel_L999
 
-	cmp	INC_X, #0
-	beq	zdot_kernel_L999
+#	cmp	INC_X, #0
+#	beq	zdot_kernel_L999
 
-	cmp	INC_Y, #0
-	beq	zdot_kernel_L999
+#	cmp	INC_Y, #0
+#	beq	zdot_kernel_L999
 
 	cmp	INC_X, #1
 	bne	zdot_kernel_S_BEGIN


### PR DESCRIPTION
The early exits provided for INC_X==0 or INC_Y==0 are an overoptimization that gives wrong results.
Fixes #1640