### PR TITLE
Fix typo that broke compilation with DYNAMIC_ARCH and NO_AVX2

### DIFF
--- a/driver/others/dynamic.c
+++ b/driver/others/dynamic.c
@@ -510,7 +510,7 @@ static gotoblas_t *get_coretype(void){
 #ifndef NO_AVX2
 	  return &gotoblas_HASWELL;
 #else
-	  return &gotblas_SANDYBRIDGE;
+	  return &gotoblas_SANDYBRIDGE;
 #endif
 	  else
 	  return &gotoblas_NEHALEM;


### PR DESCRIPTION
fixes #1659