### PR TITLE
Ensure that the gotoblas lookup table is always initialized.

### DIFF
--- a/common.h
+++ b/common.h
@@ -641,6 +641,18 @@ void gotoblas_dynamic_quit(void);
 void gotoblas_profile_init(void);
 void gotoblas_profile_quit(void);
 
+#ifdef DYNAMIC_ARCH
+/* Do not reference gotoblas directly, instead use get_gotoblas(), below. This
+is to prevent initialization order issues where an initializer attempts to call
+into OpenBLAS before gotoblas_dynamic_init has been called. */
+extern gotoblas_t *gotoblas;
+static __inline__ gotoblas_t *get_gotoblas() {
+  if (gotoblas) return gotoblas;
+  gotoblas_dynamic_init();
+  return gotoblas;
+}
+#endif
+
 #ifdef USE_OPENMP
 
 #ifndef C_MSVC
@@ -652,7 +664,7 @@ __declspec(dllimport) int __cdecl omp_get_num_procs(void);
 #endif
 
 #if (__STDC_VERSION__ >= 201112L)
-#if defined(C_GCC) && ( __GNUC__ < 7) 
+#if defined(C_GCC) && ( __GNUC__ < 7)
 // workaround for GCC bug 65467
 #ifndef _Atomic
 #define _Atomic volatile

--- a/common_c.h
+++ b/common_c.h
@@ -229,49 +229,49 @@
 #define CIMATCOPY_K_CTC         cimatcopy_k_ctc
 #define CIMATCOPY_K_RTC         cimatcopy_k_rtc
 
-#define CGEADD_K                cgeadd_k 
+#define CGEADD_K                cgeadd_k
 
 #else
 
-#define	CAMAX_K			gotoblas -> camax_k
-#define	CAMIN_K			gotoblas -> camin_k
-#define	CMAX_K			gotoblas -> cmax_k
-#define	CMIN_K			gotoblas -> cmin_k
-#define	ICAMAX_K		gotoblas -> icamax_k
-#define	ICAMIN_K		gotoblas -> icamin_k
-#define	ICMAX_K			gotoblas -> icmax_k
-#define	ICMIN_K			gotoblas -> icmin_k
-#define	CASUM_K			gotoblas -> casum_k
-#define	CAXPYU_K		gotoblas -> caxpy_k
-#define	CAXPYC_K		gotoblas -> caxpyc_k
-#define	CCOPY_K			gotoblas -> ccopy_k
-#define	CDOTU_K			gotoblas -> cdotu_k
-#define	CDOTC_K			gotoblas -> cdotc_k
-#define	CNRM2_K			gotoblas -> cnrm2_k
-#define	CSCAL_K			gotoblas -> cscal_k
-#define	CSWAP_K			gotoblas -> cswap_k
-#define	CROT_K			gotoblas -> csrot_k
+#define	CAMAX_K			get_gotoblas() -> camax_k
+#define	CAMIN_K			get_gotoblas() -> camin_k
+#define	CMAX_K			get_gotoblas() -> cmax_k
+#define	CMIN_K			get_gotoblas() -> cmin_k
+#define	ICAMAX_K		get_gotoblas() -> icamax_k
+#define	ICAMIN_K		get_gotoblas() -> icamin_k
+#define	ICMAX_K			get_gotoblas() -> icmax_k
+#define	ICMIN_K			get_gotoblas() -> icmin_k
+#define	CASUM_K			get_gotoblas() -> casum_k
+#define	CAXPYU_K		get_gotoblas() -> caxpy_k
+#define	CAXPYC_K		get_gotoblas() -> caxpyc_k
+#define	CCOPY_K			get_gotoblas() -> ccopy_k
+#define	CDOTU_K			get_gotoblas() -> cdotu_k
+#define	CDOTC_K			get_gotoblas() -> cdotc_k
+#define	CNRM2_K			get_gotoblas() -> cnrm2_k
+#define	CSCAL_K			get_gotoblas() -> cscal_k
+#define	CSWAP_K			get_gotoblas() -> cswap_k
+#define	CROT_K			get_gotoblas() -> csrot_k
 
-#define	CGEMV_N			gotoblas -> cgemv_n
-#define	CGEMV_T			gotoblas -> cgemv_t
-#define	CGEMV_R			gotoblas -> cgemv_r
-#define	CGEMV_C			gotoblas -> cgemv_c
-#define	CGEMV_O			gotoblas -> cgemv_o
-#define	CGEMV_U			gotoblas -> cgemv_u
-#define	CGEMV_S			gotoblas -> cgemv_s
-#define	CGEMV_D			gotoblas -> cgemv_d
+#define	CGEMV_N			get_gotoblas() -> cgemv_n
+#define	CGEMV_T			get_gotoblas() -> cgemv_t
+#define	CGEMV_R			get_gotoblas() -> cgemv_r
+#define	CGEMV_C			get_gotoblas() -> cgemv_c
+#define	CGEMV_O			get_gotoblas() -> cgemv_o
+#define	CGEMV_U			get_gotoblas() -> cgemv_u
+#define	CGEMV_S			get_gotoblas() -> cgemv_s
+#define	CGEMV_D			get_gotoblas() -> cgemv_d
 
-#define	CGERU_K			gotoblas -> cgeru_k
-#define	CGERC_K			gotoblas -> cgerc_k
-#define	CGERV_K			gotoblas -> cgerv_k
-#define	CGERD_K			gotoblas -> cgerd_k
+#define	CGERU_K			get_gotoblas() -> cgeru_k
+#define	CGERC_K			get_gotoblas() -> cgerc_k
+#define	CGERV_K			get_gotoblas() -> cgerv_k
+#define	CGERD_K			get_gotoblas() -> cgerd_k
 
-#define CSYMV_U			gotoblas -> csymv_U
-#define CSYMV_L			gotoblas -> csymv_L
-#define CHEMV_U			gotoblas -> chemv_U
-#define CHEMV_L			gotoblas -> chemv_L
-#define CHEMV_V			gotoblas -> chemv_V
-#define CHEMV_M			gotoblas -> chemv_M
+#define CSYMV_U			get_gotoblas() -> csymv_U
+#define CSYMV_L			get_gotoblas() -> csymv_L
+#define CHEMV_U			get_gotoblas() -> chemv_U
+#define CHEMV_L			get_gotoblas() -> chemv_L
+#define CHEMV_V			get_gotoblas() -> chemv_V
+#define CHEMV_M			get_gotoblas() -> chemv_M
 
 #define CSYMV_THREAD_U		csymv_thread_U
 #define CSYMV_THREAD_L		csymv_thread_L
@@ -280,149 +280,149 @@
 #define CHEMV_THREAD_V		chemv_thread_V
 #define CHEMV_THREAD_M		chemv_thread_M
 
-#define	CGEMM_ONCOPY		gotoblas -> cgemm_oncopy
-#define	CGEMM_OTCOPY		gotoblas -> cgemm_otcopy
-#define	CGEMM_INCOPY		gotoblas -> cgemm_incopy
-#define	CGEMM_ITCOPY		gotoblas -> cgemm_itcopy
+#define	CGEMM_ONCOPY		get_gotoblas() -> cgemm_oncopy
+#define	CGEMM_OTCOPY		get_gotoblas() -> cgemm_otcopy
+#define	CGEMM_INCOPY		get_gotoblas() -> cgemm_incopy
+#define	CGEMM_ITCOPY		get_gotoblas() -> cgemm_itcopy
 
-#define	CTRMM_OUNUCOPY		gotoblas -> ctrmm_ounucopy
-#define	CTRMM_OUTUCOPY		gotoblas -> ctrmm_outucopy
-#define	CTRMM_OLNUCOPY		gotoblas -> ctrmm_olnucopy
-#define	CTRMM_OLTUCOPY		gotoblas -> ctrmm_oltucopy
-#define	CTRSM_OUNUCOPY		gotoblas -> ctrsm_ounucopy
-#define	CTRSM_OUTUCOPY		gotoblas -> ctrsm_outucopy
-#define	CTRSM_OLNUCOPY		gotoblas -> ctrsm_olnucopy
-#define	CTRSM_OLTUCOPY		gotoblas -> ctrsm_oltucopy
+#define	CTRMM_OUNUCOPY		get_gotoblas() -> ctrmm_ounucopy
+#define	CTRMM_OUTUCOPY		get_gotoblas() -> ctrmm_outucopy
+#define	CTRMM_OLNUCOPY		get_gotoblas() -> ctrmm_olnucopy
+#define	CTRMM_OLTUCOPY		get_gotoblas() -> ctrmm_oltucopy
+#define	CTRSM_OUNUCOPY		get_gotoblas() -> ctrsm_ounucopy
+#define	CTRSM_OUTUCOPY		get_gotoblas() -> ctrsm_outucopy
+#define	CTRSM_OLNUCOPY		get_gotoblas() -> ctrsm_olnucopy
+#define	CTRSM_OLTUCOPY		get_gotoblas() -> ctrsm_oltucopy
 
-#define	CTRMM_IUNUCOPY		gotoblas -> ctrmm_iunucopy
-#define	CTRMM_IUTUCOPY		gotoblas -> ctrmm_iutucopy
-#define	CTRMM_ILNUCOPY		gotoblas -> ctrmm_ilnucopy
-#define	CTRMM_ILTUCOPY		gotoblas -> ctrmm_iltucopy
-#define	CTRSM_IUNUCOPY		gotoblas -> ctrsm_iunucopy
-#define	CTRSM_IUTUCOPY		gotoblas -> ctrsm_iutucopy
-#define	CTRSM_ILNUCOPY		gotoblas -> ctrsm_ilnucopy
-#define	CTRSM_ILTUCOPY		gotoblas -> ctrsm_iltucopy
+#define	CTRMM_IUNUCOPY		get_gotoblas() -> ctrmm_iunucopy
+#define	CTRMM_IUTUCOPY		get_gotoblas() -> ctrmm_iutucopy
+#define	CTRMM_ILNUCOPY		get_gotoblas() -> ctrmm_ilnucopy
+#define	CTRMM_ILTUCOPY		get_gotoblas() -> ctrmm_iltucopy
+#define	CTRSM_IUNUCOPY		get_gotoblas() -> ctrsm_iunucopy
+#define	CTRSM_IUTUCOPY		get_gotoblas() -> ctrsm_iutucopy
+#define	CTRSM_ILNUCOPY		get_gotoblas() -> ctrsm_ilnucopy
+#define	CTRSM_ILTUCOPY		get_gotoblas() -> ctrsm_iltucopy
 
-#define	CTRMM_OUNNCOPY		gotoblas -> ctrmm_ounncopy
-#define	CTRMM_OUTNCOPY		gotoblas -> ctrmm_outncopy
-#define	CTRMM_OLNNCOPY		gotoblas -> ctrmm_olnncopy
-#define	CTRMM_OLTNCOPY		gotoblas -> ctrmm_oltncopy
-#define	CTRSM_OUNNCOPY		gotoblas -> ctrsm_ounncopy
-#define	CTRSM_OUTNCOPY		gotoblas -> ctrsm_outncopy
-#define	CTRSM_OLNNCOPY		gotoblas -> ctrsm_olnncopy
-#define	CTRSM_OLTNCOPY		gotoblas -> ctrsm_oltncopy
+#define	CTRMM_OUNNCOPY		get_gotoblas() -> ctrmm_ounncopy
+#define	CTRMM_OUTNCOPY		get_gotoblas() -> ctrmm_outncopy
+#define	CTRMM_OLNNCOPY		get_gotoblas() -> ctrmm_olnncopy
+#define	CTRMM_OLTNCOPY		get_gotoblas() -> ctrmm_oltncopy
+#define	CTRSM_OUNNCOPY		get_gotoblas() -> ctrsm_ounncopy
+#define	CTRSM_OUTNCOPY		get_gotoblas() -> ctrsm_outncopy
+#define	CTRSM_OLNNCOPY		get_gotoblas() -> ctrsm_olnncopy
+#define	CTRSM_OLTNCOPY		get_gotoblas() -> ctrsm_oltncopy
 
-#define	CTRMM_IUNNCOPY		gotoblas -> ctrmm_iunncopy
-#define	CTRMM_IUTNCOPY		gotoblas -> ctrmm_iutncopy
-#define	CTRMM_ILNNCOPY		gotoblas -> ctrmm_ilnncopy
-#define	CTRMM_ILTNCOPY		gotoblas -> ctrmm_iltncopy
-#define	CTRSM_IUNNCOPY		gotoblas -> ctrsm_iunncopy
-#define	CTRSM_IUTNCOPY		gotoblas -> ctrsm_iutncopy
-#define	CTRSM_ILNNCOPY		gotoblas -> ctrsm_ilnncopy
-#define	CTRSM_ILTNCOPY		gotoblas -> ctrsm_iltncopy
+#define	CTRMM_IUNNCOPY		get_gotoblas() -> ctrmm_iunncopy
+#define	CTRMM_IUTNCOPY		get_gotoblas() -> ctrmm_iutncopy
+#define	CTRMM_ILNNCOPY		get_gotoblas() -> ctrmm_ilnncopy
+#define	CTRMM_ILTNCOPY		get_gotoblas() -> ctrmm_iltncopy
+#define	CTRSM_IUNNCOPY		get_gotoblas() -> ctrsm_iunncopy
+#define	CTRSM_IUTNCOPY		get_gotoblas() -> ctrsm_iutncopy
+#define	CTRSM_ILNNCOPY		get_gotoblas() -> ctrsm_ilnncopy
+#define	CTRSM_ILTNCOPY		get_gotoblas() -> ctrsm_iltncopy
 
-#define	CGEMM_BETA		gotoblas -> cgemm_beta
-#define	CGEMM_KERNEL_N		gotoblas -> cgemm_kernel_n
-#define	CGEMM_KERNEL_L		gotoblas -> cgemm_kernel_l
-#define	CGEMM_KERNEL_R		gotoblas -> cgemm_kernel_r
-#define	CGEMM_KERNEL_B		gotoblas -> cgemm_kernel_b
+#define	CGEMM_BETA		get_gotoblas() -> cgemm_beta
+#define	CGEMM_KERNEL_N		get_gotoblas() -> cgemm_kernel_n
+#define	CGEMM_KERNEL_L		get_gotoblas() -> cgemm_kernel_l
+#define	CGEMM_KERNEL_R		get_gotoblas() -> cgemm_kernel_r
+#define	CGEMM_KERNEL_B		get_gotoblas() -> cgemm_kernel_b
 
-#define	CTRMM_KERNEL_LN		gotoblas -> ctrmm_kernel_LN
-#define	CTRMM_KERNEL_LT		gotoblas -> ctrmm_kernel_LT
-#define	CTRMM_KERNEL_LR		gotoblas -> ctrmm_kernel_LR
-#define	CTRMM_KERNEL_LC		gotoblas -> ctrmm_kernel_LC
-#define	CTRMM_KERNEL_RN		gotoblas -> ctrmm_kernel_RN
-#define	CTRMM_KERNEL_RT		gotoblas -> ctrmm_kernel_RT
-#define	CTRMM_KERNEL_RR		gotoblas -> ctrmm_kernel_RR
-#define	CTRMM_KERNEL_RC		gotoblas -> ctrmm_kernel_RC
+#define	CTRMM_KERNEL_LN		get_gotoblas() -> ctrmm_kernel_LN
+#define	CTRMM_KERNEL_LT		get_gotoblas() -> ctrmm_kernel_LT
+#define	CTRMM_KERNEL_LR		get_gotoblas() -> ctrmm_kernel_LR
+#define	CTRMM_KERNEL_LC		get_gotoblas() -> ctrmm_kernel_LC
+#define	CTRMM_KERNEL_RN		get_gotoblas() -> ctrmm_kernel_RN
+#define	CTRMM_KERNEL_RT		get_gotoblas() -> ctrmm_kernel_RT
+#define	CTRMM_KERNEL_RR		get_gotoblas() -> ctrmm_kernel_RR
+#define	CTRMM_KERNEL_RC		get_gotoblas() -> ctrmm_kernel_RC
 
-#define	CTRSM_KERNEL_LN		gotoblas -> ctrsm_kernel_LN
-#define	CTRSM_KERNEL_LT		gotoblas -> ctrsm_kernel_LT
-#define	CTRSM_KERNEL_LR		gotoblas -> ctrsm_kernel_LR
-#define	CTRSM_KERNEL_LC		gotoblas -> ctrsm_kernel_LC
-#define	CTRSM_KERNEL_RN		gotoblas -> ctrsm_kernel_RN
-#define	CTRSM_KERNEL_RT		gotoblas -> ctrsm_kernel_RT
-#define	CTRSM_KERNEL_RR		gotoblas -> ctrsm_kernel_RR
-#define	CTRSM_KERNEL_RC		gotoblas -> ctrsm_kernel_RC
+#define	CTRSM_KERNEL_LN		get_gotoblas() -> ctrsm_kernel_LN
+#define	CTRSM_KERNEL_LT		get_gotoblas() -> ctrsm_kernel_LT
+#define	CTRSM_KERNEL_LR		get_gotoblas() -> ctrsm_kernel_LR
+#define	CTRSM_KERNEL_LC		get_gotoblas() -> ctrsm_kernel_LC
+#define	CTRSM_KERNEL_RN		get_gotoblas() -> ctrsm_kernel_RN
+#define	CTRSM_KERNEL_RT		get_gotoblas() -> ctrsm_kernel_RT
+#define	CTRSM_KERNEL_RR		get_gotoblas() -> ctrsm_kernel_RR
+#define	CTRSM_KERNEL_RC		get_gotoblas() -> ctrsm_kernel_RC
 
-#define	CSYMM_IUTCOPY		gotoblas -> csymm_iutcopy
-#define	CSYMM_ILTCOPY		gotoblas -> csymm_iltcopy
-#define	CSYMM_OUTCOPY		gotoblas -> csymm_outcopy
-#define	CSYMM_OLTCOPY		gotoblas -> csymm_oltcopy
+#define	CSYMM_IUTCOPY		get_gotoblas() -> csymm_iutcopy
+#define	CSYMM_ILTCOPY		get_gotoblas() -> csymm_iltcopy
+#define	CSYMM_OUTCOPY		get_gotoblas() -> csymm_outcopy
+#define	CSYMM_OLTCOPY		get_gotoblas() -> csymm_oltcopy
 
-#define	CHEMM_OUTCOPY		gotoblas -> chemm_outcopy
-#define	CHEMM_OLTCOPY		gotoblas -> chemm_oltcopy
-#define	CHEMM_IUTCOPY		gotoblas -> chemm_iutcopy
-#define	CHEMM_ILTCOPY		gotoblas -> chemm_iltcopy
+#define	CHEMM_OUTCOPY		get_gotoblas() -> chemm_outcopy
+#define	CHEMM_OLTCOPY		get_gotoblas() -> chemm_oltcopy
+#define	CHEMM_IUTCOPY		get_gotoblas() -> chemm_iutcopy
+#define	CHEMM_ILTCOPY		get_gotoblas() -> chemm_iltcopy
 
-#define	CGEMM3M_ONCOPYB		gotoblas -> cgemm3m_oncopyb
-#define	CGEMM3M_ONCOPYR		gotoblas -> cgemm3m_oncopyr
-#define	CGEMM3M_ONCOPYI		gotoblas -> cgemm3m_oncopyi
-#define	CGEMM3M_OTCOPYB		gotoblas -> cgemm3m_otcopyb
-#define	CGEMM3M_OTCOPYR		gotoblas -> cgemm3m_otcopyr
-#define	CGEMM3M_OTCOPYI		gotoblas -> cgemm3m_otcopyi
+#define	CGEMM3M_ONCOPYB		get_gotoblas() -> cgemm3m_oncopyb
+#define	CGEMM3M_ONCOPYR		get_gotoblas() -> cgemm3m_oncopyr
+#define	CGEMM3M_ONCOPYI		get_gotoblas() -> cgemm3m_oncopyi
+#define	CGEMM3M_OTCOPYB		get_gotoblas() -> cgemm3m_otcopyb
+#define	CGEMM3M_OTCOPYR		get_gotoblas() -> cgemm3m_otcopyr
+#define	CGEMM3M_OTCOPYI		get_gotoblas() -> cgemm3m_otcopyi
 
-#define	CGEMM3M_INCOPYB		gotoblas -> cgemm3m_incopyb
-#define	CGEMM3M_INCOPYR		gotoblas -> cgemm3m_incopyr
-#define	CGEMM3M_INCOPYI		gotoblas -> cgemm3m_incopyi
-#define	CGEMM3M_ITCOPYB		gotoblas -> cgemm3m_itcopyb
-#define	CGEMM3M_ITCOPYR		gotoblas -> cgemm3m_itcopyr
-#define	CGEMM3M_ITCOPYI		gotoblas -> cgemm3m_itcopyi
+#define	CGEMM3M_INCOPYB		get_gotoblas() -> cgemm3m_incopyb
+#define	CGEMM3M_INCOPYR		get_gotoblas() -> cgemm3m_incopyr
+#define	CGEMM3M_INCOPYI		get_gotoblas() -> cgemm3m_incopyi
+#define	CGEMM3M_ITCOPYB		get_gotoblas() -> cgemm3m_itcopyb
+#define	CGEMM3M_ITCOPYR		get_gotoblas() -> cgemm3m_itcopyr
+#define	CGEMM3M_ITCOPYI		get_gotoblas() -> cgemm3m_itcopyi
 
-#define	CSYMM3M_ILCOPYB		gotoblas -> csymm3m_ilcopyb
-#define	CSYMM3M_IUCOPYB		gotoblas -> csymm3m_iucopyb
-#define	CSYMM3M_ILCOPYR		gotoblas -> csymm3m_ilcopyr
-#define	CSYMM3M_IUCOPYR		gotoblas -> csymm3m_iucopyr
-#define	CSYMM3M_ILCOPYI		gotoblas -> csymm3m_ilcopyi
-#define	CSYMM3M_IUCOPYI		gotoblas -> csymm3m_iucopyi
+#define	CSYMM3M_ILCOPYB		get_gotoblas() -> csymm3m_ilcopyb
+#define	CSYMM3M_IUCOPYB		get_gotoblas() -> csymm3m_iucopyb
+#define	CSYMM3M_ILCOPYR		get_gotoblas() -> csymm3m_ilcopyr
+#define	CSYMM3M_IUCOPYR		get_gotoblas() -> csymm3m_iucopyr
+#define	CSYMM3M_ILCOPYI		get_gotoblas() -> csymm3m_ilcopyi
+#define	CSYMM3M_IUCOPYI		get_gotoblas() -> csymm3m_iucopyi
 
-#define	CSYMM3M_OLCOPYB		gotoblas -> csymm3m_olcopyb
-#define	CSYMM3M_OUCOPYB		gotoblas -> csymm3m_oucopyb
-#define	CSYMM3M_OLCOPYR		gotoblas -> csymm3m_olcopyr
-#define	CSYMM3M_OUCOPYR		gotoblas -> csymm3m_oucopyr
-#define	CSYMM3M_OLCOPYI		gotoblas -> csymm3m_olcopyi
-#define	CSYMM3M_OUCOPYI		gotoblas -> csymm3m_oucopyi
+#define	CSYMM3M_OLCOPYB		get_gotoblas() -> csymm3m_olcopyb
+#define	CSYMM3M_OUCOPYB		get_gotoblas() -> csymm3m_oucopyb
+#define	CSYMM3M_OLCOPYR		get_gotoblas() -> csymm3m_olcopyr
+#define	CSYMM3M_OUCOPYR		get_gotoblas() -> csymm3m_oucopyr
+#define	CSYMM3M_OLCOPYI		get_gotoblas() -> csymm3m_olcopyi
+#define	CSYMM3M_OUCOPYI		get_gotoblas() -> csymm3m_oucopyi
 
-#define	CHEMM3M_ILCOPYB		gotoblas -> chemm3m_ilcopyb
-#define	CHEMM3M_IUCOPYB		gotoblas -> chemm3m_iucopyb
-#define	CHEMM3M_ILCOPYR		gotoblas -> chemm3m_ilcopyr
-#define	CHEMM3M_IUCOPYR		gotoblas -> chemm3m_iucopyr
-#define	CHEMM3M_ILCOPYI		gotoblas -> chemm3m_ilcopyi
-#define	CHEMM3M_IUCOPYI		gotoblas -> chemm3m_iucopyi
+#define	CHEMM3M_ILCOPYB		get_gotoblas() -> chemm3m_ilcopyb
+#define	CHEMM3M_IUCOPYB		get_gotoblas() -> chemm3m_iucopyb
+#define	CHEMM3M_ILCOPYR		get_gotoblas() -> chemm3m_ilcopyr
+#define	CHEMM3M_IUCOPYR		get_gotoblas() -> chemm3m_iucopyr
+#define	CHEMM3M_ILCOPYI		get_gotoblas() -> chemm3m_ilcopyi
+#define	CHEMM3M_IUCOPYI		get_gotoblas() -> chemm3m_iucopyi
 
-#define	CHEMM3M_OLCOPYB		gotoblas -> chemm3m_olcopyb
-#define	CHEMM3M_OUCOPYB		gotoblas -> chemm3m_oucopyb
-#define	CHEMM3M_OLCOPYR		gotoblas -> chemm3m_olcopyr
-#define	CHEMM3M_OUCOPYR		gotoblas -> chemm3m_oucopyr
-#define	CHEMM3M_OLCOPYI		gotoblas -> chemm3m_olcopyi
-#define	CHEMM3M_OUCOPYI		gotoblas -> chemm3m_oucopyi
+#define	CHEMM3M_OLCOPYB		get_gotoblas() -> chemm3m_olcopyb
+#define	CHEMM3M_OUCOPYB		get_gotoblas() -> chemm3m_oucopyb
+#define	CHEMM3M_OLCOPYR		get_gotoblas() -> chemm3m_olcopyr
+#define	CHEMM3M_OUCOPYR		get_gotoblas() -> chemm3m_oucopyr
+#define	CHEMM3M_OLCOPYI		get_gotoblas() -> chemm3m_olcopyi
+#define	CHEMM3M_OUCOPYI		get_gotoblas() -> chemm3m_oucopyi
 
-#define	CGEMM3M_KERNEL		gotoblas -> cgemm3m_kernel
+#define	CGEMM3M_KERNEL		get_gotoblas() -> cgemm3m_kernel
 
-#define CNEG_TCOPY		gotoblas -> cneg_tcopy
-#define CLASWP_NCOPY		gotoblas -> claswp_ncopy
+#define CNEG_TCOPY		get_gotoblas() -> cneg_tcopy
+#define CLASWP_NCOPY		get_gotoblas() -> claswp_ncopy
 
-#define CAXPBY_K                gotoblas -> caxpby_k
+#define CAXPBY_K                get_gotoblas() -> caxpby_k
 
-#define COMATCOPY_K_CN          gotoblas -> comatcopy_k_cn
-#define COMATCOPY_K_RN          gotoblas -> comatcopy_k_rn
-#define COMATCOPY_K_CT          gotoblas -> comatcopy_k_ct
-#define COMATCOPY_K_RT          gotoblas -> comatcopy_k_rt
-#define COMATCOPY_K_CNC         gotoblas -> comatcopy_k_cnc
-#define COMATCOPY_K_RNC         gotoblas -> comatcopy_k_rnc
-#define COMATCOPY_K_CTC         gotoblas -> comatcopy_k_ctc
-#define COMATCOPY_K_RTC         gotoblas -> comatcopy_k_rtc
+#define COMATCOPY_K_CN          get_gotoblas() -> comatcopy_k_cn
+#define COMATCOPY_K_RN          get_gotoblas() -> comatcopy_k_rn
+#define COMATCOPY_K_CT          get_gotoblas() -> comatcopy_k_ct
+#define COMATCOPY_K_RT          get_gotoblas() -> comatcopy_k_rt
+#define COMATCOPY_K_CNC         get_gotoblas() -> comatcopy_k_cnc
+#define COMATCOPY_K_RNC         get_gotoblas() -> comatcopy_k_rnc
+#define COMATCOPY_K_CTC         get_gotoblas() -> comatcopy_k_ctc
+#define COMATCOPY_K_RTC         get_gotoblas() -> comatcopy_k_rtc
 
-#define CIMATCOPY_K_CN          gotoblas -> cimatcopy_k_cn
-#define CIMATCOPY_K_RN          gotoblas -> cimatcopy_k_rn
-#define CIMATCOPY_K_CT          gotoblas -> cimatcopy_k_ct
-#define CIMATCOPY_K_RT          gotoblas -> cimatcopy_k_rt
-#define CIMATCOPY_K_CNC         gotoblas -> cimatcopy_k_cnc
-#define CIMATCOPY_K_RNC         gotoblas -> cimatcopy_k_rnc
-#define CIMATCOPY_K_CTC         gotoblas -> cimatcopy_k_ctc
-#define CIMATCOPY_K_RTC         gotoblas -> cimatcopy_k_rtc
+#define CIMATCOPY_K_CN          get_gotoblas() -> cimatcopy_k_cn
+#define CIMATCOPY_K_RN          get_gotoblas() -> cimatcopy_k_rn
+#define CIMATCOPY_K_CT          get_gotoblas() -> cimatcopy_k_ct
+#define CIMATCOPY_K_RT          get_gotoblas() -> cimatcopy_k_rt
+#define CIMATCOPY_K_CNC         get_gotoblas() -> cimatcopy_k_cnc
+#define CIMATCOPY_K_RNC         get_gotoblas() -> cimatcopy_k_rnc
+#define CIMATCOPY_K_CTC         get_gotoblas() -> cimatcopy_k_ctc
+#define CIMATCOPY_K_RTC         get_gotoblas() -> cimatcopy_k_rtc
 
-#define CGEADD_K                gotoblas -> cgeadd_k 
+#define CGEADD_K                get_gotoblas() -> cgeadd_k
 
 #endif
 

--- a/common_d.h
+++ b/common_d.h
@@ -154,130 +154,130 @@
 #define DIMATCOPY_K_RN		dimatcopy_k_rn
 #define DIMATCOPY_K_CT      dimatcopy_k_ct
 #define DIMATCOPY_K_RT      dimatcopy_k_rt
-#define DGEADD_K                dgeadd_k 
+#define DGEADD_K                dgeadd_k
 
 #else
 
-#define	DAMAX_K			gotoblas -> damax_k
-#define	DAMIN_K			gotoblas -> damin_k
-#define	DMAX_K			gotoblas -> dmax_k
-#define	DMIN_K			gotoblas -> dmin_k
-#define	IDAMAX_K		gotoblas -> idamax_k
-#define	IDAMIN_K		gotoblas -> idamin_k
-#define	IDMAX_K			gotoblas -> idmax_k
-#define	IDMIN_K			gotoblas -> idmin_k
-#define	DASUM_K			gotoblas -> dasum_k
-#define	DAXPYU_K		gotoblas -> daxpy_k
-#define	DAXPYC_K		gotoblas -> daxpy_k
-#define	DCOPY_K			gotoblas -> dcopy_k
-#define	DDOTU_K			gotoblas -> ddot_k
-#define	DDOTC_K			gotoblas -> ddot_k
-#define	DNRM2_K			gotoblas -> dnrm2_k
-#define	DSCAL_K			gotoblas -> dscal_k
-#define	DSWAP_K			gotoblas -> dswap_k
-#define	DROT_K			gotoblas -> drot_k
+#define	DAMAX_K			get_gotoblas() -> damax_k
+#define	DAMIN_K			get_gotoblas() -> damin_k
+#define	DMAX_K			get_gotoblas() -> dmax_k
+#define	DMIN_K			get_gotoblas() -> dmin_k
+#define	IDAMAX_K		get_gotoblas() -> idamax_k
+#define	IDAMIN_K		get_gotoblas() -> idamin_k
+#define	IDMAX_K			get_gotoblas() -> idmax_k
+#define	IDMIN_K			get_gotoblas() -> idmin_k
+#define	DASUM_K			get_gotoblas() -> dasum_k
+#define	DAXPYU_K		get_gotoblas() -> daxpy_k
+#define	DAXPYC_K		get_gotoblas() -> daxpy_k
+#define	DCOPY_K			get_gotoblas() -> dcopy_k
+#define	DDOTU_K			get_gotoblas() -> ddot_k
+#define	DDOTC_K			get_gotoblas() -> ddot_k
+#define	DNRM2_K			get_gotoblas() -> dnrm2_k
+#define	DSCAL_K			get_gotoblas() -> dscal_k
+#define	DSWAP_K			get_gotoblas() -> dswap_k
+#define	DROT_K			get_gotoblas() -> drot_k
 
-#define	DGEMV_N			gotoblas -> dgemv_n
-#define	DGEMV_T			gotoblas -> dgemv_t
-#define	DGEMV_R			gotoblas -> dgemv_n
-#define	DGEMV_C			gotoblas -> dgemv_t
-#define	DGEMV_O			gotoblas -> dgemv_n
-#define	DGEMV_U			gotoblas -> dgemv_t
-#define	DGEMV_S			gotoblas -> dgemv_n
-#define	DGEMV_D			gotoblas -> dgemv_t
+#define	DGEMV_N			get_gotoblas() -> dgemv_n
+#define	DGEMV_T			get_gotoblas() -> dgemv_t
+#define	DGEMV_R			get_gotoblas() -> dgemv_n
+#define	DGEMV_C			get_gotoblas() -> dgemv_t
+#define	DGEMV_O			get_gotoblas() -> dgemv_n
+#define	DGEMV_U			get_gotoblas() -> dgemv_t
+#define	DGEMV_S			get_gotoblas() -> dgemv_n
+#define	DGEMV_D			get_gotoblas() -> dgemv_t
 
-#define	DGERU_K			gotoblas -> dger_k
-#define	DGERC_K			gotoblas -> dger_k
-#define	DGERV_K			gotoblas -> dger_k
-#define	DGERD_K			gotoblas -> dger_k
+#define	DGERU_K			get_gotoblas() -> dger_k
+#define	DGERC_K			get_gotoblas() -> dger_k
+#define	DGERV_K			get_gotoblas() -> dger_k
+#define	DGERD_K			get_gotoblas() -> dger_k
 
-#define DSYMV_U			gotoblas -> dsymv_U
-#define DSYMV_L			gotoblas -> dsymv_L
+#define DSYMV_U			get_gotoblas() -> dsymv_U
+#define DSYMV_L			get_gotoblas() -> dsymv_L
 
 #define DSYMV_THREAD_U		dsymv_thread_U
 #define DSYMV_THREAD_L		dsymv_thread_L
 
-#define	DGEMM_ONCOPY		gotoblas -> dgemm_oncopy
-#define	DGEMM_OTCOPY		gotoblas -> dgemm_otcopy
-#define	DGEMM_INCOPY		gotoblas -> dgemm_incopy
-#define	DGEMM_ITCOPY		gotoblas -> dgemm_itcopy
+#define	DGEMM_ONCOPY		get_gotoblas() -> dgemm_oncopy
+#define	DGEMM_OTCOPY		get_gotoblas() -> dgemm_otcopy
+#define	DGEMM_INCOPY		get_gotoblas() -> dgemm_incopy
+#define	DGEMM_ITCOPY		get_gotoblas() -> dgemm_itcopy
 
-#define	DTRMM_OUNUCOPY		gotoblas -> dtrmm_ounucopy
-#define	DTRMM_OUTUCOPY		gotoblas -> dtrmm_outucopy
-#define	DTRMM_OLNUCOPY		gotoblas -> dtrmm_olnucopy
-#define	DTRMM_OLTUCOPY		gotoblas -> dtrmm_oltucopy
-#define	DTRSM_OUNUCOPY		gotoblas -> dtrsm_ounucopy
-#define	DTRSM_OUTUCOPY		gotoblas -> dtrsm_outucopy
-#define	DTRSM_OLNUCOPY		gotoblas -> dtrsm_olnucopy
-#define	DTRSM_OLTUCOPY		gotoblas -> dtrsm_oltucopy
+#define	DTRMM_OUNUCOPY		get_gotoblas() -> dtrmm_ounucopy
+#define	DTRMM_OUTUCOPY		get_gotoblas() -> dtrmm_outucopy
+#define	DTRMM_OLNUCOPY		get_gotoblas() -> dtrmm_olnucopy
+#define	DTRMM_OLTUCOPY		get_gotoblas() -> dtrmm_oltucopy
+#define	DTRSM_OUNUCOPY		get_gotoblas() -> dtrsm_ounucopy
+#define	DTRSM_OUTUCOPY		get_gotoblas() -> dtrsm_outucopy
+#define	DTRSM_OLNUCOPY		get_gotoblas() -> dtrsm_olnucopy
+#define	DTRSM_OLTUCOPY		get_gotoblas() -> dtrsm_oltucopy
 
-#define	DTRMM_IUNUCOPY		gotoblas -> dtrmm_iunucopy
-#define	DTRMM_IUTUCOPY		gotoblas -> dtrmm_iutucopy
-#define	DTRMM_ILNUCOPY		gotoblas -> dtrmm_ilnucopy
-#define	DTRMM_ILTUCOPY		gotoblas -> dtrmm_iltucopy
-#define	DTRSM_IUNUCOPY		gotoblas -> dtrsm_iunucopy
-#define	DTRSM_IUTUCOPY		gotoblas -> dtrsm_iutucopy
-#define	DTRSM_ILNUCOPY		gotoblas -> dtrsm_ilnucopy
-#define	DTRSM_ILTUCOPY		gotoblas -> dtrsm_iltucopy
+#define	DTRMM_IUNUCOPY		get_gotoblas() -> dtrmm_iunucopy
+#define	DTRMM_IUTUCOPY		get_gotoblas() -> dtrmm_iutucopy
+#define	DTRMM_ILNUCOPY		get_gotoblas() -> dtrmm_ilnucopy
+#define	DTRMM_ILTUCOPY		get_gotoblas() -> dtrmm_iltucopy
+#define	DTRSM_IUNUCOPY		get_gotoblas() -> dtrsm_iunucopy
+#define	DTRSM_IUTUCOPY		get_gotoblas() -> dtrsm_iutucopy
+#define	DTRSM_ILNUCOPY		get_gotoblas() -> dtrsm_ilnucopy
+#define	DTRSM_ILTUCOPY		get_gotoblas() -> dtrsm_iltucopy
 
-#define	DTRMM_OUNNCOPY		gotoblas -> dtrmm_ounncopy
-#define	DTRMM_OUTNCOPY		gotoblas -> dtrmm_outncopy
-#define	DTRMM_OLNNCOPY		gotoblas -> dtrmm_olnncopy
-#define	DTRMM_OLTNCOPY		gotoblas -> dtrmm_oltncopy
-#define	DTRSM_OUNNCOPY		gotoblas -> dtrsm_ounncopy
-#define	DTRSM_OUTNCOPY		gotoblas -> dtrsm_outncopy
-#define	DTRSM_OLNNCOPY		gotoblas -> dtrsm_olnncopy
-#define	DTRSM_OLTNCOPY		gotoblas -> dtrsm_oltncopy
+#define	DTRMM_OUNNCOPY		get_gotoblas() -> dtrmm_ounncopy
+#define	DTRMM_OUTNCOPY		get_gotoblas() -> dtrmm_outncopy
+#define	DTRMM_OLNNCOPY		get_gotoblas() -> dtrmm_olnncopy
+#define	DTRMM_OLTNCOPY		get_gotoblas() -> dtrmm_oltncopy
+#define	DTRSM_OUNNCOPY		get_gotoblas() -> dtrsm_ounncopy
+#define	DTRSM_OUTNCOPY		get_gotoblas() -> dtrsm_outncopy
+#define	DTRSM_OLNNCOPY		get_gotoblas() -> dtrsm_olnncopy
+#define	DTRSM_OLTNCOPY		get_gotoblas() -> dtrsm_oltncopy
 
-#define	DTRMM_IUNNCOPY		gotoblas -> dtrmm_iunncopy
-#define	DTRMM_IUTNCOPY		gotoblas -> dtrmm_iutncopy
-#define	DTRMM_ILNNCOPY		gotoblas -> dtrmm_ilnncopy
-#define	DTRMM_ILTNCOPY		gotoblas -> dtrmm_iltncopy
-#define	DTRSM_IUNNCOPY		gotoblas -> dtrsm_iunncopy
-#define	DTRSM_IUTNCOPY		gotoblas -> dtrsm_iutncopy
-#define	DTRSM_ILNNCOPY		gotoblas -> dtrsm_ilnncopy
-#define	DTRSM_ILTNCOPY		gotoblas -> dtrsm_iltncopy
+#define	DTRMM_IUNNCOPY		get_gotoblas() -> dtrmm_iunncopy
+#define	DTRMM_IUTNCOPY		get_gotoblas() -> dtrmm_iutncopy
+#define	DTRMM_ILNNCOPY		get_gotoblas() -> dtrmm_ilnncopy
+#define	DTRMM_ILTNCOPY		get_gotoblas() -> dtrmm_iltncopy
+#define	DTRSM_IUNNCOPY		get_gotoblas() -> dtrsm_iunncopy
+#define	DTRSM_IUTNCOPY		get_gotoblas() -> dtrsm_iutncopy
+#define	DTRSM_ILNNCOPY		get_gotoblas() -> dtrsm_ilnncopy
+#define	DTRSM_ILTNCOPY		get_gotoblas() -> dtrsm_iltncopy
 
-#define	DGEMM_BETA		gotoblas -> dgemm_beta
-#define	DGEMM_KERNEL		gotoblas -> dgemm_kernel
+#define	DGEMM_BETA		get_gotoblas() -> dgemm_beta
+#define	DGEMM_KERNEL		get_gotoblas() -> dgemm_kernel
 
-#define	DTRMM_KERNEL_LN		gotoblas -> dtrmm_kernel_LN
-#define	DTRMM_KERNEL_LT		gotoblas -> dtrmm_kernel_LT
-#define	DTRMM_KERNEL_LR		gotoblas -> dtrmm_kernel_LN
-#define	DTRMM_KERNEL_LC		gotoblas -> dtrmm_kernel_LT
-#define	DTRMM_KERNEL_RN		gotoblas -> dtrmm_kernel_RN
-#define	DTRMM_KERNEL_RT		gotoblas -> dtrmm_kernel_RT
-#define	DTRMM_KERNEL_RR		gotoblas -> dtrmm_kernel_RN
-#define	DTRMM_KERNEL_RC		gotoblas -> dtrmm_kernel_RT
+#define	DTRMM_KERNEL_LN		get_gotoblas() -> dtrmm_kernel_LN
+#define	DTRMM_KERNEL_LT		get_gotoblas() -> dtrmm_kernel_LT
+#define	DTRMM_KERNEL_LR		get_gotoblas() -> dtrmm_kernel_LN
+#define	DTRMM_KERNEL_LC		get_gotoblas() -> dtrmm_kernel_LT
+#define	DTRMM_KERNEL_RN		get_gotoblas() -> dtrmm_kernel_RN
+#define	DTRMM_KERNEL_RT		get_gotoblas() -> dtrmm_kernel_RT
+#define	DTRMM_KERNEL_RR		get_gotoblas() -> dtrmm_kernel_RN
+#define	DTRMM_KERNEL_RC		get_gotoblas() -> dtrmm_kernel_RT
 
-#define	DTRSM_KERNEL_LN		gotoblas -> dtrsm_kernel_LN
-#define	DTRSM_KERNEL_LT		gotoblas -> dtrsm_kernel_LT
-#define	DTRSM_KERNEL_LR		gotoblas -> dtrsm_kernel_LN
-#define	DTRSM_KERNEL_LC		gotoblas -> dtrsm_kernel_LT
-#define	DTRSM_KERNEL_RN		gotoblas -> dtrsm_kernel_RN
-#define	DTRSM_KERNEL_RT		gotoblas -> dtrsm_kernel_RT
-#define	DTRSM_KERNEL_RR		gotoblas -> dtrsm_kernel_RN
-#define	DTRSM_KERNEL_RC		gotoblas -> dtrsm_kernel_RT
+#define	DTRSM_KERNEL_LN		get_gotoblas() -> dtrsm_kernel_LN
+#define	DTRSM_KERNEL_LT		get_gotoblas() -> dtrsm_kernel_LT
+#define	DTRSM_KERNEL_LR		get_gotoblas() -> dtrsm_kernel_LN
+#define	DTRSM_KERNEL_LC		get_gotoblas() -> dtrsm_kernel_LT
+#define	DTRSM_KERNEL_RN		get_gotoblas() -> dtrsm_kernel_RN
+#define	DTRSM_KERNEL_RT		get_gotoblas() -> dtrsm_kernel_RT
+#define	DTRSM_KERNEL_RR		get_gotoblas() -> dtrsm_kernel_RN
+#define	DTRSM_KERNEL_RC		get_gotoblas() -> dtrsm_kernel_RT
 
-#define	DSYMM_IUTCOPY		gotoblas -> dsymm_iutcopy
-#define	DSYMM_ILTCOPY		gotoblas -> dsymm_iltcopy
-#define	DSYMM_OUTCOPY		gotoblas -> dsymm_outcopy
-#define	DSYMM_OLTCOPY		gotoblas -> dsymm_oltcopy
+#define	DSYMM_IUTCOPY		get_gotoblas() -> dsymm_iutcopy
+#define	DSYMM_ILTCOPY		get_gotoblas() -> dsymm_iltcopy
+#define	DSYMM_OUTCOPY		get_gotoblas() -> dsymm_outcopy
+#define	DSYMM_OLTCOPY		get_gotoblas() -> dsymm_oltcopy
 
-#define DNEG_TCOPY		gotoblas -> dneg_tcopy
-#define DLASWP_NCOPY		gotoblas -> dlaswp_ncopy
+#define DNEG_TCOPY		get_gotoblas() -> dneg_tcopy
+#define DLASWP_NCOPY		get_gotoblas() -> dlaswp_ncopy
 
-#define	DAXPBY_K		gotoblas -> daxpby_k
-#define DOMATCOPY_K_CN		gotoblas -> domatcopy_k_cn
-#define DOMATCOPY_K_RN		gotoblas -> domatcopy_k_rn
-#define DOMATCOPY_K_CT		gotoblas -> domatcopy_k_ct
-#define DOMATCOPY_K_RT		gotoblas -> domatcopy_k_rt
-#define DIMATCOPY_K_CN		gotoblas -> dimatcopy_k_cn
-#define DIMATCOPY_K_RN		gotoblas -> dimatcopy_k_rn
-#define DIMATCOPY_K_CT		gotoblas -> dimatcopy_k_ct
-#define DIMATCOPY_K_RT		gotoblas -> dimatcopy_k_rt
+#define	DAXPBY_K		get_gotoblas() -> daxpby_k
+#define DOMATCOPY_K_CN		get_gotoblas() -> domatcopy_k_cn
+#define DOMATCOPY_K_RN		get_gotoblas() -> domatcopy_k_rn
+#define DOMATCOPY_K_CT		get_gotoblas() -> domatcopy_k_ct
+#define DOMATCOPY_K_RT		get_gotoblas() -> domatcopy_k_rt
+#define DIMATCOPY_K_CN		get_gotoblas() -> dimatcopy_k_cn
+#define DIMATCOPY_K_RN		get_gotoblas() -> dimatcopy_k_rn
+#define DIMATCOPY_K_CT		get_gotoblas() -> dimatcopy_k_ct
+#define DIMATCOPY_K_RT		get_gotoblas() -> dimatcopy_k_rt
 
-#define DGEADD_K                gotoblas -> dgeadd_k 
+#define DGEADD_K                get_gotoblas() -> dgeadd_k
 
 #endif
 

--- a/common_param.h
+++ b/common_param.h
@@ -885,84 +885,83 @@ BLASLONG (*ixamin_k)(BLASLONG, xdouble *, BLASLONG);
   int    (*zimatcopy_k_rnc)	(BLASLONG, BLASLONG, double, double, double*, BLASLONG);
   int    (*zimatcopy_k_rtc)	(BLASLONG, BLASLONG, double, double, double*, BLASLONG);
 
-  int    (*sgeadd_k) (BLASLONG, BLASLONG, float, float *, BLASLONG, float, float *, BLASLONG); 
-  int    (*dgeadd_k) (BLASLONG, BLASLONG, double, double *, BLASLONG, double, double *, BLASLONG); 
-  int    (*cgeadd_k) (BLASLONG, BLASLONG, float, float,  float *,  BLASLONG, float, float, float *, BLASLONG); 
-  int    (*zgeadd_k) (BLASLONG, BLASLONG, double, double, double *, BLASLONG, double, double, double *, BLASLONG); 
+  int    (*sgeadd_k) (BLASLONG, BLASLONG, float, float *, BLASLONG, float, float *, BLASLONG);
+  int    (*dgeadd_k) (BLASLONG, BLASLONG, double, double *, BLASLONG, double, double *, BLASLONG);
+  int    (*cgeadd_k) (BLASLONG, BLASLONG, float, float,  float *,  BLASLONG, float, float, float *, BLASLONG);
+  int    (*zgeadd_k) (BLASLONG, BLASLONG, double, double, double *, BLASLONG, double, double, double *, BLASLONG);
 
 } gotoblas_t;
 
-extern gotoblas_t *gotoblas;
 
-#define DTB_ENTRIES  gotoblas -> dtb_entries
-#define GEMM_OFFSET_A	gotoblas -> offsetA
-#define GEMM_OFFSET_B	gotoblas -> offsetB
-#define GEMM_ALIGN	gotoblas -> align
+#define DTB_ENTRIES  get_gotoblas() -> dtb_entries
+#define GEMM_OFFSET_A	get_gotoblas() -> offsetA
+#define GEMM_OFFSET_B	get_gotoblas() -> offsetB
+#define GEMM_ALIGN	get_gotoblas() -> align
 
-#define HAVE_EX_L2	gotoblas -> exclusive_cache
+#define HAVE_EX_L2	get_gotoblas() -> exclusive_cache
 
-#define	SGEMM_P		gotoblas -> sgemm_p
-#define	SGEMM_Q		gotoblas -> sgemm_q
-#define	SGEMM_R		gotoblas -> sgemm_r
-#define	SGEMM_UNROLL_M	gotoblas -> sgemm_unroll_m
-#define	SGEMM_UNROLL_N	gotoblas -> sgemm_unroll_n
-#define SGEMM_UNROLL_MN	gotoblas -> sgemm_unroll_mn
+#define	SGEMM_P		get_gotoblas() -> sgemm_p
+#define	SGEMM_Q		get_gotoblas() -> sgemm_q
+#define	SGEMM_R		get_gotoblas() -> sgemm_r
+#define	SGEMM_UNROLL_M	get_gotoblas() -> sgemm_unroll_m
+#define	SGEMM_UNROLL_N	get_gotoblas() -> sgemm_unroll_n
+#define SGEMM_UNROLL_MN	get_gotoblas() -> sgemm_unroll_mn
 
-#define	DGEMM_P		gotoblas -> dgemm_p
-#define	DGEMM_Q		gotoblas -> dgemm_q
-#define	DGEMM_R		gotoblas -> dgemm_r
-#define	DGEMM_UNROLL_M	gotoblas -> dgemm_unroll_m
-#define	DGEMM_UNROLL_N	gotoblas -> dgemm_unroll_n
-#define DGEMM_UNROLL_MN	gotoblas -> dgemm_unroll_mn
+#define	DGEMM_P		get_gotoblas() -> dgemm_p
+#define	DGEMM_Q		get_gotoblas() -> dgemm_q
+#define	DGEMM_R		get_gotoblas() -> dgemm_r
+#define	DGEMM_UNROLL_M	get_gotoblas() -> dgemm_unroll_m
+#define	DGEMM_UNROLL_N	get_gotoblas() -> dgemm_unroll_n
+#define DGEMM_UNROLL_MN	get_gotoblas() -> dgemm_unroll_mn
 
-#define	QGEMM_P		gotoblas -> qgemm_p
-#define	QGEMM_Q		gotoblas -> qgemm_q
-#define	QGEMM_R		gotoblas -> qgemm_r
-#define	QGEMM_UNROLL_M	gotoblas -> qgemm_unroll_m
-#define	QGEMM_UNROLL_N	gotoblas -> qgemm_unroll_n
-#define QGEMM_UNROLL_MN	gotoblas -> qgemm_unroll_mn
+#define	QGEMM_P		get_gotoblas() -> qgemm_p
+#define	QGEMM_Q		get_gotoblas() -> qgemm_q
+#define	QGEMM_R		get_gotoblas() -> qgemm_r
+#define	QGEMM_UNROLL_M	get_gotoblas() -> qgemm_unroll_m
+#define	QGEMM_UNROLL_N	get_gotoblas() -> qgemm_unroll_n
+#define QGEMM_UNROLL_MN	get_gotoblas() -> qgemm_unroll_mn
 
-#define	CGEMM_P		gotoblas -> cgemm_p
-#define	CGEMM_Q		gotoblas -> cgemm_q
-#define	CGEMM_R		gotoblas -> cgemm_r
-#define	CGEMM_UNROLL_M	gotoblas -> cgemm_unroll_m
-#define	CGEMM_UNROLL_N	gotoblas -> cgemm_unroll_n
-#define CGEMM_UNROLL_MN	gotoblas -> cgemm_unroll_mn
+#define	CGEMM_P		get_gotoblas() -> cgemm_p
+#define	CGEMM_Q		get_gotoblas() -> cgemm_q
+#define	CGEMM_R		get_gotoblas() -> cgemm_r
+#define	CGEMM_UNROLL_M	get_gotoblas() -> cgemm_unroll_m
+#define	CGEMM_UNROLL_N	get_gotoblas() -> cgemm_unroll_n
+#define CGEMM_UNROLL_MN	get_gotoblas() -> cgemm_unroll_mn
 
-#define	ZGEMM_P		gotoblas -> zgemm_p
-#define	ZGEMM_Q		gotoblas -> zgemm_q
-#define	ZGEMM_R		gotoblas -> zgemm_r
-#define	ZGEMM_UNROLL_M	gotoblas -> zgemm_unroll_m
-#define	ZGEMM_UNROLL_N	gotoblas -> zgemm_unroll_n
-#define ZGEMM_UNROLL_MN	gotoblas -> zgemm_unroll_mn
+#define	ZGEMM_P		get_gotoblas() -> zgemm_p
+#define	ZGEMM_Q		get_gotoblas() -> zgemm_q
+#define	ZGEMM_R		get_gotoblas() -> zgemm_r
+#define	ZGEMM_UNROLL_M	get_gotoblas() -> zgemm_unroll_m
+#define	ZGEMM_UNROLL_N	get_gotoblas() -> zgemm_unroll_n
+#define ZGEMM_UNROLL_MN	get_gotoblas() -> zgemm_unroll_mn
 
-#define	XGEMM_P		gotoblas -> xgemm_p
-#define	XGEMM_Q		gotoblas -> xgemm_q
-#define	XGEMM_R		gotoblas -> xgemm_r
-#define	XGEMM_UNROLL_M	gotoblas -> xgemm_unroll_m
-#define	XGEMM_UNROLL_N	gotoblas -> xgemm_unroll_n
-#define XGEMM_UNROLL_MN	gotoblas -> xgemm_unroll_mn
+#define	XGEMM_P		get_gotoblas() -> xgemm_p
+#define	XGEMM_Q		get_gotoblas() -> xgemm_q
+#define	XGEMM_R		get_gotoblas() -> xgemm_r
+#define	XGEMM_UNROLL_M	get_gotoblas() -> xgemm_unroll_m
+#define	XGEMM_UNROLL_N	get_gotoblas() -> xgemm_unroll_n
+#define XGEMM_UNROLL_MN	get_gotoblas() -> xgemm_unroll_mn
 
-#define	CGEMM3M_P		gotoblas -> cgemm3m_p
-#define	CGEMM3M_Q		gotoblas -> cgemm3m_q
-#define	CGEMM3M_R		gotoblas -> cgemm3m_r
-#define	CGEMM3M_UNROLL_M	gotoblas -> cgemm3m_unroll_m
-#define	CGEMM3M_UNROLL_N	gotoblas -> cgemm3m_unroll_n
-#define CGEMM3M_UNROLL_MN	gotoblas -> cgemm3m_unroll_mn
+#define	CGEMM3M_P		get_gotoblas() -> cgemm3m_p
+#define	CGEMM3M_Q		get_gotoblas() -> cgemm3m_q
+#define	CGEMM3M_R		get_gotoblas() -> cgemm3m_r
+#define	CGEMM3M_UNROLL_M	get_gotoblas() -> cgemm3m_unroll_m
+#define	CGEMM3M_UNROLL_N	get_gotoblas() -> cgemm3m_unroll_n
+#define CGEMM3M_UNROLL_MN	get_gotoblas() -> cgemm3m_unroll_mn
 
-#define	ZGEMM3M_P		gotoblas -> zgemm3m_p
-#define	ZGEMM3M_Q		gotoblas -> zgemm3m_q
-#define	ZGEMM3M_R		gotoblas -> zgemm3m_r
-#define	ZGEMM3M_UNROLL_M	gotoblas -> zgemm3m_unroll_m
-#define	ZGEMM3M_UNROLL_N	gotoblas -> zgemm3m_unroll_n
-#define ZGEMM3M_UNROLL_MN	gotoblas -> zgemm3m_unroll_mn
+#define	ZGEMM3M_P		get_gotoblas() -> zgemm3m_p
+#define	ZGEMM3M_Q		get_gotoblas() -> zgemm3m_q
+#define	ZGEMM3M_R		get_gotoblas() -> zgemm3m_r
+#define	ZGEMM3M_UNROLL_M	get_gotoblas() -> zgemm3m_unroll_m
+#define	ZGEMM3M_UNROLL_N	get_gotoblas() -> zgemm3m_unroll_n
+#define ZGEMM3M_UNROLL_MN	get_gotoblas() -> zgemm3m_unroll_mn
 
-#define	XGEMM3M_P		gotoblas -> xgemm3m_p
-#define	XGEMM3M_Q		gotoblas -> xgemm3m_q
-#define	XGEMM3M_R		gotoblas -> xgemm3m_r
-#define	XGEMM3M_UNROLL_M	gotoblas -> xgemm3m_unroll_m
-#define	XGEMM3M_UNROLL_N	gotoblas -> xgemm3m_unroll_n
-#define XGEMM3M_UNROLL_MN	gotoblas -> xgemm3m_unroll_mn
+#define	XGEMM3M_P		get_gotoblas() -> xgemm3m_p
+#define	XGEMM3M_Q		get_gotoblas() -> xgemm3m_q
+#define	XGEMM3M_R		get_gotoblas() -> xgemm3m_r
+#define	XGEMM3M_UNROLL_M	get_gotoblas() -> xgemm3m_unroll_m
+#define	XGEMM3M_UNROLL_N	get_gotoblas() -> xgemm3m_unroll_n
+#define XGEMM3M_UNROLL_MN	get_gotoblas() -> xgemm3m_unroll_mn
 
 #else
 

--- a/common_q.h
+++ b/common_q.h
@@ -145,114 +145,114 @@
 
 #else
 
-#define	QAMAX_K			gotoblas -> qamax_k
-#define	QAMIN_K			gotoblas -> qamin_k
-#define	QMAX_K			gotoblas -> qmax_k
-#define	QMIN_K			gotoblas -> qmin_k
-#define	IQAMAX_K		gotoblas -> iqamax_k
-#define	IQAMIN_K		gotoblas -> iqamin_k
-#define	IQMAX_K			gotoblas -> iqmax_k
-#define	IQMIN_K			gotoblas -> iqmin_k
-#define	QASUM_K			gotoblas -> qasum_k
-#define	QAXPYU_K		gotoblas -> qaxpy_k
-#define	QAXPYC_K		gotoblas -> qaxpy_k
-#define	QCOPY_K			gotoblas -> qcopy_k
-#define	QDOTU_K			gotoblas -> qdot_k
-#define	QDOTC_K			gotoblas -> qdot_k
-#define	QNRM2_K			gotoblas -> qnrm2_k
-#define	QSCAL_K			gotoblas -> qscal_k
-#define	QSWAP_K			gotoblas -> qswap_k
-#define	QROT_K			gotoblas -> qrot_k
+#define	QAMAX_K			get_gotoblas() -> qamax_k
+#define	QAMIN_K			get_gotoblas() -> qamin_k
+#define	QMAX_K			get_gotoblas() -> qmax_k
+#define	QMIN_K			get_gotoblas() -> qmin_k
+#define	IQAMAX_K		get_gotoblas() -> iqamax_k
+#define	IQAMIN_K		get_gotoblas() -> iqamin_k
+#define	IQMAX_K			get_gotoblas() -> iqmax_k
+#define	IQMIN_K			get_gotoblas() -> iqmin_k
+#define	QASUM_K			get_gotoblas() -> qasum_k
+#define	QAXPYU_K		get_gotoblas() -> qaxpy_k
+#define	QAXPYC_K		get_gotoblas() -> qaxpy_k
+#define	QCOPY_K			get_gotoblas() -> qcopy_k
+#define	QDOTU_K			get_gotoblas() -> qdot_k
+#define	QDOTC_K			get_gotoblas() -> qdot_k
+#define	QNRM2_K			get_gotoblas() -> qnrm2_k
+#define	QSCAL_K			get_gotoblas() -> qscal_k
+#define	QSWAP_K			get_gotoblas() -> qswap_k
+#define	QROT_K			get_gotoblas() -> qrot_k
 
-#define	QGEMV_N			gotoblas -> qgemv_n
-#define	QGEMV_T			gotoblas -> qgemv_t
-#define	QGEMV_R			gotoblas -> qgemv_n
-#define	QGEMV_C			gotoblas -> qgemv_t
-#define	QGEMV_O			gotoblas -> qgemv_n
-#define	QGEMV_U			gotoblas -> qgemv_t
-#define	QGEMV_S			gotoblas -> qgemv_n
-#define	QGEMV_D			gotoblas -> qgemv_t
+#define	QGEMV_N			get_gotoblas() -> qgemv_n
+#define	QGEMV_T			get_gotoblas() -> qgemv_t
+#define	QGEMV_R			get_gotoblas() -> qgemv_n
+#define	QGEMV_C			get_gotoblas() -> qgemv_t
+#define	QGEMV_O			get_gotoblas() -> qgemv_n
+#define	QGEMV_U			get_gotoblas() -> qgemv_t
+#define	QGEMV_S			get_gotoblas() -> qgemv_n
+#define	QGEMV_D			get_gotoblas() -> qgemv_t
 
-#define	QGERU_K			gotoblas -> qger_k
-#define	QGERC_K			gotoblas -> qger_k
-#define	QGERV_K			gotoblas -> qger_k
-#define	QGERD_K			gotoblas -> qger_k
+#define	QGERU_K			get_gotoblas() -> qger_k
+#define	QGERC_K			get_gotoblas() -> qger_k
+#define	QGERV_K			get_gotoblas() -> qger_k
+#define	QGERD_K			get_gotoblas() -> qger_k
 
-#define QSYMV_U			gotoblas -> qsymv_U
-#define QSYMV_L			gotoblas -> qsymv_L
+#define QSYMV_U			get_gotoblas() -> qsymv_U
+#define QSYMV_L			get_gotoblas() -> qsymv_L
 
 #define QSYMV_THREAD_U		qsymv_thread_U
 #define QSYMV_THREAD_L		qsymv_thread_L
 
-#define	QGEMM_ONCOPY		gotoblas -> qgemm_oncopy
-#define	QGEMM_OTCOPY		gotoblas -> qgemm_otcopy
-#define	QGEMM_INCOPY		gotoblas -> qgemm_incopy
-#define	QGEMM_ITCOPY		gotoblas -> qgemm_itcopy
+#define	QGEMM_ONCOPY		get_gotoblas() -> qgemm_oncopy
+#define	QGEMM_OTCOPY		get_gotoblas() -> qgemm_otcopy
+#define	QGEMM_INCOPY		get_gotoblas() -> qgemm_incopy
+#define	QGEMM_ITCOPY		get_gotoblas() -> qgemm_itcopy
 
-#define	QTRMM_OUNUCOPY		gotoblas -> qtrmm_ounucopy
-#define	QTRMM_OUTUCOPY		gotoblas -> qtrmm_outucopy
-#define	QTRMM_OLNUCOPY		gotoblas -> qtrmm_olnucopy
-#define	QTRMM_OLTUCOPY		gotoblas -> qtrmm_oltucopy
-#define	QTRSM_OUNUCOPY		gotoblas -> qtrsm_ounucopy
-#define	QTRSM_OUTUCOPY		gotoblas -> qtrsm_outucopy
-#define	QTRSM_OLNUCOPY		gotoblas -> qtrsm_olnucopy
-#define	QTRSM_OLTUCOPY		gotoblas -> qtrsm_oltucopy
+#define	QTRMM_OUNUCOPY		get_gotoblas() -> qtrmm_ounucopy
+#define	QTRMM_OUTUCOPY		get_gotoblas() -> qtrmm_outucopy
+#define	QTRMM_OLNUCOPY		get_gotoblas() -> qtrmm_olnucopy
+#define	QTRMM_OLTUCOPY		get_gotoblas() -> qtrmm_oltucopy
+#define	QTRSM_OUNUCOPY		get_gotoblas() -> qtrsm_ounucopy
+#define	QTRSM_OUTUCOPY		get_gotoblas() -> qtrsm_outucopy
+#define	QTRSM_OLNUCOPY		get_gotoblas() -> qtrsm_olnucopy
+#define	QTRSM_OLTUCOPY		get_gotoblas() -> qtrsm_oltucopy
 
-#define	QTRMM_IUNUCOPY		gotoblas -> qtrmm_iunucopy
-#define	QTRMM_IUTUCOPY		gotoblas -> qtrmm_iutucopy
-#define	QTRMM_ILNUCOPY		gotoblas -> qtrmm_ilnucopy
-#define	QTRMM_ILTUCOPY		gotoblas -> qtrmm_iltucopy
-#define	QTRSM_IUNUCOPY		gotoblas -> qtrsm_iunucopy
-#define	QTRSM_IUTUCOPY		gotoblas -> qtrsm_iutucopy
-#define	QTRSM_ILNUCOPY		gotoblas -> qtrsm_ilnucopy
-#define	QTRSM_ILTUCOPY		gotoblas -> qtrsm_iltucopy
+#define	QTRMM_IUNUCOPY		get_gotoblas() -> qtrmm_iunucopy
+#define	QTRMM_IUTUCOPY		get_gotoblas() -> qtrmm_iutucopy
+#define	QTRMM_ILNUCOPY		get_gotoblas() -> qtrmm_ilnucopy
+#define	QTRMM_ILTUCOPY		get_gotoblas() -> qtrmm_iltucopy
+#define	QTRSM_IUNUCOPY		get_gotoblas() -> qtrsm_iunucopy
+#define	QTRSM_IUTUCOPY		get_gotoblas() -> qtrsm_iutucopy
+#define	QTRSM_ILNUCOPY		get_gotoblas() -> qtrsm_ilnucopy
+#define	QTRSM_ILTUCOPY		get_gotoblas() -> qtrsm_iltucopy
 
-#define	QTRMM_OUNNCOPY		gotoblas -> qtrmm_ounncopy
-#define	QTRMM_OUTNCOPY		gotoblas -> qtrmm_outncopy
-#define	QTRMM_OLNNCOPY		gotoblas -> qtrmm_olnncopy
-#define	QTRMM_OLTNCOPY		gotoblas -> qtrmm_oltncopy
-#define	QTRSM_OUNNCOPY		gotoblas -> qtrsm_ounncopy
-#define	QTRSM_OUTNCOPY		gotoblas -> qtrsm_outncopy
-#define	QTRSM_OLNNCOPY		gotoblas -> qtrsm_olnncopy
-#define	QTRSM_OLTNCOPY		gotoblas -> qtrsm_oltncopy
+#define	QTRMM_OUNNCOPY		get_gotoblas() -> qtrmm_ounncopy
+#define	QTRMM_OUTNCOPY		get_gotoblas() -> qtrmm_outncopy
+#define	QTRMM_OLNNCOPY		get_gotoblas() -> qtrmm_olnncopy
+#define	QTRMM_OLTNCOPY		get_gotoblas() -> qtrmm_oltncopy
+#define	QTRSM_OUNNCOPY		get_gotoblas() -> qtrsm_ounncopy
+#define	QTRSM_OUTNCOPY		get_gotoblas() -> qtrsm_outncopy
+#define	QTRSM_OLNNCOPY		get_gotoblas() -> qtrsm_olnncopy
+#define	QTRSM_OLTNCOPY		get_gotoblas() -> qtrsm_oltncopy
 
-#define	QTRMM_IUNNCOPY		gotoblas -> qtrmm_iunncopy
-#define	QTRMM_IUTNCOPY		gotoblas -> qtrmm_iutncopy
-#define	QTRMM_ILNNCOPY		gotoblas -> qtrmm_ilnncopy
-#define	QTRMM_ILTNCOPY		gotoblas -> qtrmm_iltncopy
-#define	QTRSM_IUNNCOPY		gotoblas -> qtrsm_iunncopy
-#define	QTRSM_IUTNCOPY		gotoblas -> qtrsm_iutncopy
-#define	QTRSM_ILNNCOPY		gotoblas -> qtrsm_ilnncopy
-#define	QTRSM_ILTNCOPY		gotoblas -> qtrsm_iltncopy
+#define	QTRMM_IUNNCOPY		get_gotoblas() -> qtrmm_iunncopy
+#define	QTRMM_IUTNCOPY		get_gotoblas() -> qtrmm_iutncopy
+#define	QTRMM_ILNNCOPY		get_gotoblas() -> qtrmm_ilnncopy
+#define	QTRMM_ILTNCOPY		get_gotoblas() -> qtrmm_iltncopy
+#define	QTRSM_IUNNCOPY		get_gotoblas() -> qtrsm_iunncopy
+#define	QTRSM_IUTNCOPY		get_gotoblas() -> qtrsm_iutncopy
+#define	QTRSM_ILNNCOPY		get_gotoblas() -> qtrsm_ilnncopy
+#define	QTRSM_ILTNCOPY		get_gotoblas() -> qtrsm_iltncopy
 
-#define	QGEMM_BETA		gotoblas -> qgemm_beta
-#define	QGEMM_KERNEL		gotoblas -> qgemm_kernel
+#define	QGEMM_BETA		get_gotoblas() -> qgemm_beta
+#define	QGEMM_KERNEL		get_gotoblas() -> qgemm_kernel
 
-#define	QTRMM_KERNEL_LN		gotoblas -> qtrmm_kernel_LN
-#define	QTRMM_KERNEL_LT		gotoblas -> qtrmm_kernel_LT
-#define	QTRMM_KERNEL_LR		gotoblas -> qtrmm_kernel_LN
-#define	QTRMM_KERNEL_LC		gotoblas -> qtrmm_kernel_LT
-#define	QTRMM_KERNEL_RN		gotoblas -> qtrmm_kernel_RN
-#define	QTRMM_KERNEL_RT		gotoblas -> qtrmm_kernel_RT
-#define	QTRMM_KERNEL_RR		gotoblas -> qtrmm_kernel_RN
-#define	QTRMM_KERNEL_RC		gotoblas -> qtrmm_kernel_RT
+#define	QTRMM_KERNEL_LN		get_gotoblas() -> qtrmm_kernel_LN
+#define	QTRMM_KERNEL_LT		get_gotoblas() -> qtrmm_kernel_LT
+#define	QTRMM_KERNEL_LR		get_gotoblas() -> qtrmm_kernel_LN
+#define	QTRMM_KERNEL_LC		get_gotoblas() -> qtrmm_kernel_LT
+#define	QTRMM_KERNEL_RN		get_gotoblas() -> qtrmm_kernel_RN
+#define	QTRMM_KERNEL_RT		get_gotoblas() -> qtrmm_kernel_RT
+#define	QTRMM_KERNEL_RR		get_gotoblas() -> qtrmm_kernel_RN
+#define	QTRMM_KERNEL_RC		get_gotoblas() -> qtrmm_kernel_RT
 
-#define	QTRSM_KERNEL_LN		gotoblas -> qtrsm_kernel_LN
-#define	QTRSM_KERNEL_LT		gotoblas -> qtrsm_kernel_LT
-#define	QTRSM_KERNEL_LR		gotoblas -> qtrsm_kernel_LN
-#define	QTRSM_KERNEL_LC		gotoblas -> qtrsm_kernel_LT
-#define	QTRSM_KERNEL_RN		gotoblas -> qtrsm_kernel_RN
-#define	QTRSM_KERNEL_RT		gotoblas -> qtrsm_kernel_RT
-#define	QTRSM_KERNEL_RR		gotoblas -> qtrsm_kernel_RN
-#define	QTRSM_KERNEL_RC		gotoblas -> qtrsm_kernel_RT
+#define	QTRSM_KERNEL_LN		get_gotoblas() -> qtrsm_kernel_LN
+#define	QTRSM_KERNEL_LT		get_gotoblas() -> qtrsm_kernel_LT
+#define	QTRSM_KERNEL_LR		get_gotoblas() -> qtrsm_kernel_LN
+#define	QTRSM_KERNEL_LC		get_gotoblas() -> qtrsm_kernel_LT
+#define	QTRSM_KERNEL_RN		get_gotoblas() -> qtrsm_kernel_RN
+#define	QTRSM_KERNEL_RT		get_gotoblas() -> qtrsm_kernel_RT
+#define	QTRSM_KERNEL_RR		get_gotoblas() -> qtrsm_kernel_RN
+#define	QTRSM_KERNEL_RC		get_gotoblas() -> qtrsm_kernel_RT
 
-#define	QSYMM_IUTCOPY		gotoblas -> qsymm_iutcopy
-#define	QSYMM_ILTCOPY		gotoblas -> qsymm_iltcopy
-#define	QSYMM_OUTCOPY		gotoblas -> qsymm_outcopy
-#define	QSYMM_OLTCOPY		gotoblas -> qsymm_oltcopy
+#define	QSYMM_IUTCOPY		get_gotoblas() -> qsymm_iutcopy
+#define	QSYMM_ILTCOPY		get_gotoblas() -> qsymm_iltcopy
+#define	QSYMM_OUTCOPY		get_gotoblas() -> qsymm_outcopy
+#define	QSYMM_OLTCOPY		get_gotoblas() -> qsymm_oltcopy
 
-#define QNEG_TCOPY		gotoblas -> qneg_tcopy
-#define QLASWP_NCOPY		gotoblas -> qlaswp_ncopy
+#define QNEG_TCOPY		get_gotoblas() -> qneg_tcopy
+#define QLASWP_NCOPY		get_gotoblas() -> qlaswp_ncopy
 
 #endif
 

--- a/common_s.h
+++ b/common_s.h
@@ -157,133 +157,133 @@
 #define SIMATCOPY_K_CT          simatcopy_k_ct
 #define SIMATCOPY_K_RT          simatcopy_k_rt
 
-#define SGEADD_K                sgeadd_k 
+#define SGEADD_K                sgeadd_k
 
 #else
 
-#define	SAMAX_K			gotoblas -> samax_k
-#define	SAMIN_K			gotoblas -> samin_k
-#define	SMAX_K			gotoblas -> smax_k
-#define	SMIN_K			gotoblas -> smin_k
-#define	ISAMAX_K		gotoblas -> isamax_k
-#define	ISAMIN_K		gotoblas -> isamin_k
-#define	ISMAX_K			gotoblas -> ismax_k
-#define	ISMIN_K			gotoblas -> ismin_k
-#define	SASUM_K			gotoblas -> sasum_k
-#define	SAXPYU_K		gotoblas -> saxpy_k
-#define	SAXPYC_K		gotoblas -> saxpy_k
-#define	SCOPY_K			gotoblas -> scopy_k
-#define	SDOTU_K			gotoblas -> sdot_k
-#define	SDOTC_K			gotoblas -> sdot_k
-#define	SDSDOT_K		gotoblas -> dsdot_k
-#define	DSDOT_K			gotoblas -> dsdot_k
-#define	SNRM2_K			gotoblas -> snrm2_k
-#define	SSCAL_K			gotoblas -> sscal_k
-#define	SSWAP_K			gotoblas -> sswap_k
-#define	SROT_K			gotoblas -> srot_k
+#define	SAMAX_K			get_gotoblas() -> samax_k
+#define	SAMIN_K			get_gotoblas() -> samin_k
+#define	SMAX_K			get_gotoblas() -> smax_k
+#define	SMIN_K			get_gotoblas() -> smin_k
+#define	ISAMAX_K		get_gotoblas() -> isamax_k
+#define	ISAMIN_K		get_gotoblas() -> isamin_k
+#define	ISMAX_K			get_gotoblas() -> ismax_k
+#define	ISMIN_K			get_gotoblas() -> ismin_k
+#define	SASUM_K			get_gotoblas() -> sasum_k
+#define	SAXPYU_K		get_gotoblas() -> saxpy_k
+#define	SAXPYC_K		get_gotoblas() -> saxpy_k
+#define	SCOPY_K			get_gotoblas() -> scopy_k
+#define	SDOTU_K			get_gotoblas() -> sdot_k
+#define	SDOTC_K			get_gotoblas() -> sdot_k
+#define	SDSDOT_K		get_gotoblas() -> dsdot_k
+#define	DSDOT_K			get_gotoblas() -> dsdot_k
+#define	SNRM2_K			get_gotoblas() -> snrm2_k
+#define	SSCAL_K			get_gotoblas() -> sscal_k
+#define	SSWAP_K			get_gotoblas() -> sswap_k
+#define	SROT_K			get_gotoblas() -> srot_k
 
-#define	SGEMV_N			gotoblas -> sgemv_n
-#define	SGEMV_T			gotoblas -> sgemv_t
-#define	SGEMV_R			gotoblas -> sgemv_n
-#define	SGEMV_C			gotoblas -> sgemv_t
-#define	SGEMV_O			gotoblas -> sgemv_n
-#define	SGEMV_U			gotoblas -> sgemv_t
-#define	SGEMV_S			gotoblas -> sgemv_n
-#define	SGEMV_D			gotoblas -> sgemv_t
+#define	SGEMV_N			get_gotoblas() -> sgemv_n
+#define	SGEMV_T			get_gotoblas() -> sgemv_t
+#define	SGEMV_R			get_gotoblas() -> sgemv_n
+#define	SGEMV_C			get_gotoblas() -> sgemv_t
+#define	SGEMV_O			get_gotoblas() -> sgemv_n
+#define	SGEMV_U			get_gotoblas() -> sgemv_t
+#define	SGEMV_S			get_gotoblas() -> sgemv_n
+#define	SGEMV_D			get_gotoblas() -> sgemv_t
 
-#define	SGERU_K			gotoblas -> sger_k
-#define	SGERC_K			gotoblas -> sger_k
-#define	SGERV_K			gotoblas -> sger_k
-#define	SGERD_K			gotoblas -> sger_k
+#define	SGERU_K			get_gotoblas() -> sger_k
+#define	SGERC_K			get_gotoblas() -> sger_k
+#define	SGERV_K			get_gotoblas() -> sger_k
+#define	SGERD_K			get_gotoblas() -> sger_k
 
-#define SSYMV_U			gotoblas -> ssymv_U
-#define SSYMV_L			gotoblas -> ssymv_L
+#define SSYMV_U			get_gotoblas() -> ssymv_U
+#define SSYMV_L			get_gotoblas() -> ssymv_L
 
 #define SSYMV_THREAD_U		ssymv_thread_U
 #define SSYMV_THREAD_L		ssymv_thread_L
 
-#define	SGEMM_ONCOPY		gotoblas -> sgemm_oncopy
-#define	SGEMM_OTCOPY		gotoblas -> sgemm_otcopy
-#define	SGEMM_INCOPY		gotoblas -> sgemm_incopy
-#define	SGEMM_ITCOPY		gotoblas -> sgemm_itcopy
+#define	SGEMM_ONCOPY		get_gotoblas() -> sgemm_oncopy
+#define	SGEMM_OTCOPY		get_gotoblas() -> sgemm_otcopy
+#define	SGEMM_INCOPY		get_gotoblas() -> sgemm_incopy
+#define	SGEMM_ITCOPY		get_gotoblas() -> sgemm_itcopy
 
-#define	STRMM_OUNUCOPY		gotoblas -> strmm_ounucopy
-#define	STRMM_OUTUCOPY		gotoblas -> strmm_outucopy
-#define	STRMM_OLNUCOPY		gotoblas -> strmm_olnucopy
-#define	STRMM_OLTUCOPY		gotoblas -> strmm_oltucopy
-#define	STRSM_OUNUCOPY		gotoblas -> strsm_ounucopy
-#define	STRSM_OUTUCOPY		gotoblas -> strsm_outucopy
-#define	STRSM_OLNUCOPY		gotoblas -> strsm_olnucopy
-#define	STRSM_OLTUCOPY		gotoblas -> strsm_oltucopy
+#define	STRMM_OUNUCOPY		get_gotoblas() -> strmm_ounucopy
+#define	STRMM_OUTUCOPY		get_gotoblas() -> strmm_outucopy
+#define	STRMM_OLNUCOPY		get_gotoblas() -> strmm_olnucopy
+#define	STRMM_OLTUCOPY		get_gotoblas() -> strmm_oltucopy
+#define	STRSM_OUNUCOPY		get_gotoblas() -> strsm_ounucopy
+#define	STRSM_OUTUCOPY		get_gotoblas() -> strsm_outucopy
+#define	STRSM_OLNUCOPY		get_gotoblas() -> strsm_olnucopy
+#define	STRSM_OLTUCOPY		get_gotoblas() -> strsm_oltucopy
 
-#define	STRMM_IUNUCOPY		gotoblas -> strmm_iunucopy
-#define	STRMM_IUTUCOPY		gotoblas -> strmm_iutucopy
-#define	STRMM_ILNUCOPY		gotoblas -> strmm_ilnucopy
-#define	STRMM_ILTUCOPY		gotoblas -> strmm_iltucopy
-#define	STRSM_IUNUCOPY		gotoblas -> strsm_iunucopy
-#define	STRSM_IUTUCOPY		gotoblas -> strsm_iutucopy
-#define	STRSM_ILNUCOPY		gotoblas -> strsm_ilnucopy
-#define	STRSM_ILTUCOPY		gotoblas -> strsm_iltucopy
+#define	STRMM_IUNUCOPY		get_gotoblas() -> strmm_iunucopy
+#define	STRMM_IUTUCOPY		get_gotoblas() -> strmm_iutucopy
+#define	STRMM_ILNUCOPY		get_gotoblas() -> strmm_ilnucopy
+#define	STRMM_ILTUCOPY		get_gotoblas() -> strmm_iltucopy
+#define	STRSM_IUNUCOPY		get_gotoblas() -> strsm_iunucopy
+#define	STRSM_IUTUCOPY		get_gotoblas() -> strsm_iutucopy
+#define	STRSM_ILNUCOPY		get_gotoblas() -> strsm_ilnucopy
+#define	STRSM_ILTUCOPY		get_gotoblas() -> strsm_iltucopy
 
-#define	STRMM_OUNNCOPY		gotoblas -> strmm_ounncopy
-#define	STRMM_OUTNCOPY		gotoblas -> strmm_outncopy
-#define	STRMM_OLNNCOPY		gotoblas -> strmm_olnncopy
-#define	STRMM_OLTNCOPY		gotoblas -> strmm_oltncopy
-#define	STRSM_OUNNCOPY		gotoblas -> strsm_ounncopy
-#define	STRSM_OUTNCOPY		gotoblas -> strsm_outncopy
-#define	STRSM_OLNNCOPY		gotoblas -> strsm_olnncopy
-#define	STRSM_OLTNCOPY		gotoblas -> strsm_oltncopy
+#define	STRMM_OUNNCOPY		get_gotoblas() -> strmm_ounncopy
+#define	STRMM_OUTNCOPY		get_gotoblas() -> strmm_outncopy
+#define	STRMM_OLNNCOPY		get_gotoblas() -> strmm_olnncopy
+#define	STRMM_OLTNCOPY		get_gotoblas() -> strmm_oltncopy
+#define	STRSM_OUNNCOPY		get_gotoblas() -> strsm_ounncopy
+#define	STRSM_OUTNCOPY		get_gotoblas() -> strsm_outncopy
+#define	STRSM_OLNNCOPY		get_gotoblas() -> strsm_olnncopy
+#define	STRSM_OLTNCOPY		get_gotoblas() -> strsm_oltncopy
 
-#define	STRMM_IUNNCOPY		gotoblas -> strmm_iunncopy
-#define	STRMM_IUTNCOPY		gotoblas -> strmm_iutncopy
-#define	STRMM_ILNNCOPY		gotoblas -> strmm_ilnncopy
-#define	STRMM_ILTNCOPY		gotoblas -> strmm_iltncopy
-#define	STRSM_IUNNCOPY		gotoblas -> strsm_iunncopy
-#define	STRSM_IUTNCOPY		gotoblas -> strsm_iutncopy
-#define	STRSM_ILNNCOPY		gotoblas -> strsm_ilnncopy
-#define	STRSM_ILTNCOPY		gotoblas -> strsm_iltncopy
+#define	STRMM_IUNNCOPY		get_gotoblas() -> strmm_iunncopy
+#define	STRMM_IUTNCOPY		get_gotoblas() -> strmm_iutncopy
+#define	STRMM_ILNNCOPY		get_gotoblas() -> strmm_ilnncopy
+#define	STRMM_ILTNCOPY		get_gotoblas() -> strmm_iltncopy
+#define	STRSM_IUNNCOPY		get_gotoblas() -> strsm_iunncopy
+#define	STRSM_IUTNCOPY		get_gotoblas() -> strsm_iutncopy
+#define	STRSM_ILNNCOPY		get_gotoblas() -> strsm_ilnncopy
+#define	STRSM_ILTNCOPY		get_gotoblas() -> strsm_iltncopy
 
-#define	SGEMM_BETA		gotoblas -> sgemm_beta
-#define	SGEMM_KERNEL		gotoblas -> sgemm_kernel
+#define	SGEMM_BETA		get_gotoblas() -> sgemm_beta
+#define	SGEMM_KERNEL		get_gotoblas() -> sgemm_kernel
 
-#define	STRMM_KERNEL_LN		gotoblas -> strmm_kernel_LN
-#define	STRMM_KERNEL_LT		gotoblas -> strmm_kernel_LT
-#define	STRMM_KERNEL_LR		gotoblas -> strmm_kernel_LN
-#define	STRMM_KERNEL_LC		gotoblas -> strmm_kernel_LT
-#define	STRMM_KERNEL_RN		gotoblas -> strmm_kernel_RN
-#define	STRMM_KERNEL_RT		gotoblas -> strmm_kernel_RT
-#define	STRMM_KERNEL_RR		gotoblas -> strmm_kernel_RN
-#define	STRMM_KERNEL_RC		gotoblas -> strmm_kernel_RT
+#define	STRMM_KERNEL_LN		get_gotoblas() -> strmm_kernel_LN
+#define	STRMM_KERNEL_LT		get_gotoblas() -> strmm_kernel_LT
+#define	STRMM_KERNEL_LR		get_gotoblas() -> strmm_kernel_LN
+#define	STRMM_KERNEL_LC		get_gotoblas() -> strmm_kernel_LT
+#define	STRMM_KERNEL_RN		get_gotoblas() -> strmm_kernel_RN
+#define	STRMM_KERNEL_RT		get_gotoblas() -> strmm_kernel_RT
+#define	STRMM_KERNEL_RR		get_gotoblas() -> strmm_kernel_RN
+#define	STRMM_KERNEL_RC		get_gotoblas() -> strmm_kernel_RT
 
-#define	STRSM_KERNEL_LN		gotoblas -> strsm_kernel_LN
-#define	STRSM_KERNEL_LT		gotoblas -> strsm_kernel_LT
-#define	STRSM_KERNEL_LR		gotoblas -> strsm_kernel_LN
-#define	STRSM_KERNEL_LC		gotoblas -> strsm_kernel_LT
-#define	STRSM_KERNEL_RN		gotoblas -> strsm_kernel_RN
-#define	STRSM_KERNEL_RT		gotoblas -> strsm_kernel_RT
-#define	STRSM_KERNEL_RR		gotoblas -> strsm_kernel_RN
-#define	STRSM_KERNEL_RC		gotoblas -> strsm_kernel_RT
+#define	STRSM_KERNEL_LN		get_gotoblas() -> strsm_kernel_LN
+#define	STRSM_KERNEL_LT		get_gotoblas() -> strsm_kernel_LT
+#define	STRSM_KERNEL_LR		get_gotoblas() -> strsm_kernel_LN
+#define	STRSM_KERNEL_LC		get_gotoblas() -> strsm_kernel_LT
+#define	STRSM_KERNEL_RN		get_gotoblas() -> strsm_kernel_RN
+#define	STRSM_KERNEL_RT		get_gotoblas() -> strsm_kernel_RT
+#define	STRSM_KERNEL_RR		get_gotoblas() -> strsm_kernel_RN
+#define	STRSM_KERNEL_RC		get_gotoblas() -> strsm_kernel_RT
 
-#define	SSYMM_IUTCOPY		gotoblas -> ssymm_iutcopy
-#define	SSYMM_ILTCOPY		gotoblas -> ssymm_iltcopy
-#define	SSYMM_OUTCOPY		gotoblas -> ssymm_outcopy
-#define	SSYMM_OLTCOPY		gotoblas -> ssymm_oltcopy
+#define	SSYMM_IUTCOPY		get_gotoblas() -> ssymm_iutcopy
+#define	SSYMM_ILTCOPY		get_gotoblas() -> ssymm_iltcopy
+#define	SSYMM_OUTCOPY		get_gotoblas() -> ssymm_outcopy
+#define	SSYMM_OLTCOPY		get_gotoblas() -> ssymm_oltcopy
 
-#define SNEG_TCOPY		gotoblas -> sneg_tcopy
-#define SLASWP_NCOPY		gotoblas -> slaswp_ncopy
+#define SNEG_TCOPY		get_gotoblas() -> sneg_tcopy
+#define SLASWP_NCOPY		get_gotoblas() -> slaswp_ncopy
 
-#define SAXPBY_K                gotoblas -> saxpby_k
+#define SAXPBY_K                get_gotoblas() -> saxpby_k
 
-#define SOMATCOPY_K_CN          gotoblas -> somatcopy_k_cn
-#define SOMATCOPY_K_RN          gotoblas -> somatcopy_k_rn
-#define SOMATCOPY_K_CT          gotoblas -> somatcopy_k_ct
-#define SOMATCOPY_K_RT          gotoblas -> somatcopy_k_rt
-#define SIMATCOPY_K_CN          gotoblas -> simatcopy_k_cn
-#define SIMATCOPY_K_RN          gotoblas -> simatcopy_k_rn
-#define SIMATCOPY_K_CT          gotoblas -> simatcopy_k_ct
-#define SIMATCOPY_K_RT          gotoblas -> simatcopy_k_rt
+#define SOMATCOPY_K_CN          get_gotoblas() -> somatcopy_k_cn
+#define SOMATCOPY_K_RN          get_gotoblas() -> somatcopy_k_rn
+#define SOMATCOPY_K_CT          get_gotoblas() -> somatcopy_k_ct
+#define SOMATCOPY_K_RT          get_gotoblas() -> somatcopy_k_rt
+#define SIMATCOPY_K_CN          get_gotoblas() -> simatcopy_k_cn
+#define SIMATCOPY_K_RN          get_gotoblas() -> simatcopy_k_rn
+#define SIMATCOPY_K_CT          get_gotoblas() -> simatcopy_k_ct
+#define SIMATCOPY_K_RT          get_gotoblas() -> simatcopy_k_rt
 
-#define SGEADD_K                gotoblas -> sgeadd_k 
+#define SGEADD_K                get_gotoblas() -> sgeadd_k
 
 #endif
 

--- a/common_x.h
+++ b/common_x.h
@@ -211,45 +211,45 @@
 
 #else
 
-#define	XAMAX_K			gotoblas -> xamax_k
-#define	XAMIN_K			gotoblas -> xamin_k
-#define	XMAX_K			gotoblas -> xmax_k
-#define	XMIN_K			gotoblas -> xmin_k
-#define	IXAMAX_K		gotoblas -> ixamax_k
-#define	IXAMIN_K		gotoblas -> ixamin_k
-#define	IXMAX_K			gotoblas -> ixmax_k
-#define	IXMIN_K			gotoblas -> ixmin_k
-#define	XASUM_K			gotoblas -> xasum_k
-#define	XAXPYU_K		gotoblas -> xaxpy_k
-#define	XAXPYC_K		gotoblas -> xaxpyc_k
-#define	XCOPY_K			gotoblas -> xcopy_k
-#define	XDOTU_K			gotoblas -> xdotu_k
-#define	XDOTC_K			gotoblas -> xdotc_k
-#define	XNRM2_K			gotoblas -> xnrm2_k
-#define	XSCAL_K			gotoblas -> xscal_k
-#define	XSWAP_K			gotoblas -> xswap_k
-#define	XROT_K			gotoblas -> xqrot_k
+#define	XAMAX_K			get_gotoblas() -> xamax_k
+#define	XAMIN_K			get_gotoblas() -> xamin_k
+#define	XMAX_K			get_gotoblas() -> xmax_k
+#define	XMIN_K			get_gotoblas() -> xmin_k
+#define	IXAMAX_K		get_gotoblas() -> ixamax_k
+#define	IXAMIN_K		get_gotoblas() -> ixamin_k
+#define	IXMAX_K			get_gotoblas() -> ixmax_k
+#define	IXMIN_K			get_gotoblas() -> ixmin_k
+#define	XASUM_K			get_gotoblas() -> xasum_k
+#define	XAXPYU_K		get_gotoblas() -> xaxpy_k
+#define	XAXPYC_K		get_gotoblas() -> xaxpyc_k
+#define	XCOPY_K			get_gotoblas() -> xcopy_k
+#define	XDOTU_K			get_gotoblas() -> xdotu_k
+#define	XDOTC_K			get_gotoblas() -> xdotc_k
+#define	XNRM2_K			get_gotoblas() -> xnrm2_k
+#define	XSCAL_K			get_gotoblas() -> xscal_k
+#define	XSWAP_K			get_gotoblas() -> xswap_k
+#define	XROT_K			get_gotoblas() -> xqrot_k
 
-#define	XGEMV_N			gotoblas -> xgemv_n
-#define	XGEMV_T			gotoblas -> xgemv_t
-#define	XGEMV_R			gotoblas -> xgemv_r
-#define	XGEMV_C			gotoblas -> xgemv_c
-#define	XGEMV_O			gotoblas -> xgemv_o
-#define	XGEMV_U			gotoblas -> xgemv_u
-#define	XGEMV_S			gotoblas -> xgemv_s
-#define	XGEMV_D			gotoblas -> xgemv_d
+#define	XGEMV_N			get_gotoblas() -> xgemv_n
+#define	XGEMV_T			get_gotoblas() -> xgemv_t
+#define	XGEMV_R			get_gotoblas() -> xgemv_r
+#define	XGEMV_C			get_gotoblas() -> xgemv_c
+#define	XGEMV_O			get_gotoblas() -> xgemv_o
+#define	XGEMV_U			get_gotoblas() -> xgemv_u
+#define	XGEMV_S			get_gotoblas() -> xgemv_s
+#define	XGEMV_D			get_gotoblas() -> xgemv_d
 
-#define	XGERU_K			gotoblas -> xgeru_k
-#define	XGERC_K			gotoblas -> xgerc_k
-#define	XGERV_K			gotoblas -> xgerv_k
-#define	XGERD_K			gotoblas -> xgerd_k
+#define	XGERU_K			get_gotoblas() -> xgeru_k
+#define	XGERC_K			get_gotoblas() -> xgerc_k
+#define	XGERV_K			get_gotoblas() -> xgerv_k
+#define	XGERD_K			get_gotoblas() -> xgerd_k
 
-#define XSYMV_U			gotoblas -> xsymv_U
-#define XSYMV_L			gotoblas -> xsymv_L
-#define XHEMV_U			gotoblas -> xhemv_U
-#define XHEMV_L			gotoblas -> xhemv_L
-#define XHEMV_V			gotoblas -> xhemv_V
-#define XHEMV_M			gotoblas -> xhemv_M
+#define XSYMV_U			get_gotoblas() -> xsymv_U
+#define XSYMV_L			get_gotoblas() -> xsymv_L
+#define XHEMV_U			get_gotoblas() -> xhemv_U
+#define XHEMV_L			get_gotoblas() -> xhemv_L
+#define XHEMV_V			get_gotoblas() -> xhemv_V
+#define XHEMV_M			get_gotoblas() -> xhemv_M
 
 #define XSYMV_THREAD_U		xsymv_thread_U
 #define XSYMV_THREAD_L		xsymv_thread_L
@@ -258,127 +258,127 @@
 #define XHEMV_THREAD_V		xhemv_thread_V
 #define XHEMV_THREAD_M		xhemv_thread_M
 
-#define	XGEMM_ONCOPY		gotoblas -> xgemm_oncopy
-#define	XGEMM_OTCOPY		gotoblas -> xgemm_otcopy
-#define	XGEMM_INCOPY		gotoblas -> xgemm_incopy
-#define	XGEMM_ITCOPY		gotoblas -> xgemm_itcopy
+#define	XGEMM_ONCOPY		get_gotoblas() -> xgemm_oncopy
+#define	XGEMM_OTCOPY		get_gotoblas() -> xgemm_otcopy
+#define	XGEMM_INCOPY		get_gotoblas() -> xgemm_incopy
+#define	XGEMM_ITCOPY		get_gotoblas() -> xgemm_itcopy
 
-#define	XTRMM_OUNUCOPY		gotoblas -> xtrmm_ounucopy
-#define	XTRMM_OUTUCOPY		gotoblas -> xtrmm_outucopy
-#define	XTRMM_OLNUCOPY		gotoblas -> xtrmm_olnucopy
-#define	XTRMM_OLTUCOPY		gotoblas -> xtrmm_oltucopy
-#define	XTRSM_OUNUCOPY		gotoblas -> xtrsm_ounucopy
-#define	XTRSM_OUTUCOPY		gotoblas -> xtrsm_outucopy
-#define	XTRSM_OLNUCOPY		gotoblas -> xtrsm_olnucopy
-#define	XTRSM_OLTUCOPY		gotoblas -> xtrsm_oltucopy
+#define	XTRMM_OUNUCOPY		get_gotoblas() -> xtrmm_ounucopy
+#define	XTRMM_OUTUCOPY		get_gotoblas() -> xtrmm_outucopy
+#define	XTRMM_OLNUCOPY		get_gotoblas() -> xtrmm_olnucopy
+#define	XTRMM_OLTUCOPY		get_gotoblas() -> xtrmm_oltucopy
+#define	XTRSM_OUNUCOPY		get_gotoblas() -> xtrsm_ounucopy
+#define	XTRSM_OUTUCOPY		get_gotoblas() -> xtrsm_outucopy
+#define	XTRSM_OLNUCOPY		get_gotoblas() -> xtrsm_olnucopy
+#define	XTRSM_OLTUCOPY		get_gotoblas() -> xtrsm_oltucopy
 
-#define	XTRMM_IUNUCOPY		gotoblas -> xtrmm_iunucopy
-#define	XTRMM_IUTUCOPY		gotoblas -> xtrmm_iutucopy
-#define	XTRMM_ILNUCOPY		gotoblas -> xtrmm_ilnucopy
-#define	XTRMM_ILTUCOPY		gotoblas -> xtrmm_iltucopy
-#define	XTRSM_IUNUCOPY		gotoblas -> xtrsm_iunucopy
-#define	XTRSM_IUTUCOPY		gotoblas -> xtrsm_iutucopy
-#define	XTRSM_ILNUCOPY		gotoblas -> xtrsm_ilnucopy
-#define	XTRSM_ILTUCOPY		gotoblas -> xtrsm_iltucopy
+#define	XTRMM_IUNUCOPY		get_gotoblas() -> xtrmm_iunucopy
+#define	XTRMM_IUTUCOPY		get_gotoblas() -> xtrmm_iutucopy
+#define	XTRMM_ILNUCOPY		get_gotoblas() -> xtrmm_ilnucopy
+#define	XTRMM_ILTUCOPY		get_gotoblas() -> xtrmm_iltucopy
+#define	XTRSM_IUNUCOPY		get_gotoblas() -> xtrsm_iunucopy
+#define	XTRSM_IUTUCOPY		get_gotoblas() -> xtrsm_iutucopy
+#define	XTRSM_ILNUCOPY		get_gotoblas() -> xtrsm_ilnucopy
+#define	XTRSM_ILTUCOPY		get_gotoblas() -> xtrsm_iltucopy
 
-#define	XTRMM_OUNNCOPY		gotoblas -> xtrmm_ounncopy
-#define	XTRMM_OUTNCOPY		gotoblas -> xtrmm_outncopy
-#define	XTRMM_OLNNCOPY		gotoblas -> xtrmm_olnncopy
-#define	XTRMM_OLTNCOPY		gotoblas -> xtrmm_oltncopy
-#define	XTRSM_OUNNCOPY		gotoblas -> xtrsm_ounncopy
-#define	XTRSM_OUTNCOPY		gotoblas -> xtrsm_outncopy
-#define	XTRSM_OLNNCOPY		gotoblas -> xtrsm_olnncopy
-#define	XTRSM_OLTNCOPY		gotoblas -> xtrsm_oltncopy
+#define	XTRMM_OUNNCOPY		get_gotoblas() -> xtrmm_ounncopy
+#define	XTRMM_OUTNCOPY		get_gotoblas() -> xtrmm_outncopy
+#define	XTRMM_OLNNCOPY		get_gotoblas() -> xtrmm_olnncopy
+#define	XTRMM_OLTNCOPY		get_gotoblas() -> xtrmm_oltncopy
+#define	XTRSM_OUNNCOPY		get_gotoblas() -> xtrsm_ounncopy
+#define	XTRSM_OUTNCOPY		get_gotoblas() -> xtrsm_outncopy
+#define	XTRSM_OLNNCOPY		get_gotoblas() -> xtrsm_olnncopy
+#define	XTRSM_OLTNCOPY		get_gotoblas() -> xtrsm_oltncopy
 
-#define	XTRMM_IUNNCOPY		gotoblas -> xtrmm_iunncopy
-#define	XTRMM_IUTNCOPY		gotoblas -> xtrmm_iutncopy
-#define	XTRMM_ILNNCOPY		gotoblas -> xtrmm_ilnncopy
-#define	XTRMM_ILTNCOPY		gotoblas -> xtrmm_iltncopy
-#define	XTRSM_IUNNCOPY		gotoblas -> xtrsm_iunncopy
-#define	XTRSM_IUTNCOPY		gotoblas -> xtrsm_iutncopy
-#define	XTRSM_ILNNCOPY		gotoblas -> xtrsm_ilnncopy
-#define	XTRSM_ILTNCOPY		gotoblas -> xtrsm_iltncopy
+#define	XTRMM_IUNNCOPY		get_gotoblas() -> xtrmm_iunncopy
+#define	XTRMM_IUTNCOPY		get_gotoblas() -> xtrmm_iutncopy
+#define	XTRMM_ILNNCOPY		get_gotoblas() -> xtrmm_ilnncopy
+#define	XTRMM_ILTNCOPY		get_gotoblas() -> xtrmm_iltncopy
+#define	XTRSM_IUNNCOPY		get_gotoblas() -> xtrsm_iunncopy
+#define	XTRSM_IUTNCOPY		get_gotoblas() -> xtrsm_iutncopy
+#define	XTRSM_ILNNCOPY		get_gotoblas() -> xtrsm_ilnncopy
+#define	XTRSM_ILTNCOPY		get_gotoblas() -> xtrsm_iltncopy
 
-#define	XGEMM_BETA		gotoblas -> xgemm_beta
-#define	XGEMM_KERNEL_N		gotoblas -> xgemm_kernel_n
-#define	XGEMM_KERNEL_L		gotoblas -> xgemm_kernel_l
-#define	XGEMM_KERNEL_R		gotoblas -> xgemm_kernel_r
-#define	XGEMM_KERNEL_B		gotoblas -> xgemm_kernel_b
+#define	XGEMM_BETA		get_gotoblas() -> xgemm_beta
+#define	XGEMM_KERNEL_N		get_gotoblas() -> xgemm_kernel_n
+#define	XGEMM_KERNEL_L		get_gotoblas() -> xgemm_kernel_l
+#define	XGEMM_KERNEL_R		get_gotoblas() -> xgemm_kernel_r
+#define	XGEMM_KERNEL_B		get_gotoblas() -> xgemm_kernel_b
 
-#define	XTRMM_KERNEL_LN		gotoblas -> xtrmm_kernel_LN
-#define	XTRMM_KERNEL_LT		gotoblas -> xtrmm_kernel_LT
-#define	XTRMM_KERNEL_LR		gotoblas -> xtrmm_kernel_LR
-#define	XTRMM_KERNEL_LC		gotoblas -> xtrmm_kernel_LC
-#define	XTRMM_KERNEL_RN		gotoblas -> xtrmm_kernel_RN
-#define	XTRMM_KERNEL_RT		gotoblas -> xtrmm_kernel_RT
-#define	XTRMM_KERNEL_RR		gotoblas -> xtrmm_kernel_RR
-#define	XTRMM_KERNEL_RC		gotoblas -> xtrmm_kernel_RC
+#define	XTRMM_KERNEL_LN		get_gotoblas() -> xtrmm_kernel_LN
+#define	XTRMM_KERNEL_LT		get_gotoblas() -> xtrmm_kernel_LT
+#define	XTRMM_KERNEL_LR		get_gotoblas() -> xtrmm_kernel_LR
+#define	XTRMM_KERNEL_LC		get_gotoblas() -> xtrmm_kernel_LC
+#define	XTRMM_KERNEL_RN		get_gotoblas() -> xtrmm_kernel_RN
+#define	XTRMM_KERNEL_RT		get_gotoblas() -> xtrmm_kernel_RT
+#define	XTRMM_KERNEL_RR		get_gotoblas() -> xtrmm_kernel_RR
+#define	XTRMM_KERNEL_RC		get_gotoblas() -> xtrmm_kernel_RC
 
-#define	XTRSM_KERNEL_LN		gotoblas -> xtrsm_kernel_LN
-#define	XTRSM_KERNEL_LT		gotoblas -> xtrsm_kernel_LT
-#define	XTRSM_KERNEL_LR		gotoblas -> xtrsm_kernel_LR
-#define	XTRSM_KERNEL_LC		gotoblas -> xtrsm_kernel_LC
-#define	XTRSM_KERNEL_RN		gotoblas -> xtrsm_kernel_RN
-#define	XTRSM_KERNEL_RT		gotoblas -> xtrsm_kernel_RT
-#define	XTRSM_KERNEL_RR		gotoblas -> xtrsm_kernel_RR
-#define	XTRSM_KERNEL_RC		gotoblas -> xtrsm_kernel_RC
+#define	XTRSM_KERNEL_LN		get_gotoblas() -> xtrsm_kernel_LN
+#define	XTRSM_KERNEL_LT		get_gotoblas() -> xtrsm_kernel_LT
+#define	XTRSM_KERNEL_LR		get_gotoblas() -> xtrsm_kernel_LR
+#define	XTRSM_KERNEL_LC		get_gotoblas() -> xtrsm_kernel_LC
+#define	XTRSM_KERNEL_RN		get_gotoblas() -> xtrsm_kernel_RN
+#define	XTRSM_KERNEL_RT		get_gotoblas() -> xtrsm_kernel_RT
+#define	XTRSM_KERNEL_RR		get_gotoblas() -> xtrsm_kernel_RR
+#define	XTRSM_KERNEL_RC		get_gotoblas() -> xtrsm_kernel_RC
 
-#define	XSYMM_IUTCOPY		gotoblas -> xsymm_iutcopy
-#define	XSYMM_ILTCOPY		gotoblas -> xsymm_iltcopy
-#define	XSYMM_OUTCOPY		gotoblas -> xsymm_outcopy
-#define	XSYMM_OLTCOPY		gotoblas -> xsymm_oltcopy
+#define	XSYMM_IUTCOPY		get_gotoblas() -> xsymm_iutcopy
+#define	XSYMM_ILTCOPY		get_gotoblas() -> xsymm_iltcopy
+#define	XSYMM_OUTCOPY		get_gotoblas() -> xsymm_outcopy
+#define	XSYMM_OLTCOPY		get_gotoblas() -> xsymm_oltcopy
 
-#define	XHEMM_OUTCOPY		gotoblas -> xhemm_outcopy
-#define	XHEMM_OLTCOPY		gotoblas -> xhemm_oltcopy
-#define	XHEMM_IUTCOPY		gotoblas -> xhemm_iutcopy
-#define	XHEMM_ILTCOPY		gotoblas -> xhemm_iltcopy
+#define	XHEMM_OUTCOPY		get_gotoblas() -> xhemm_outcopy
+#define	XHEMM_OLTCOPY		get_gotoblas() -> xhemm_oltcopy
+#define	XHEMM_IUTCOPY		get_gotoblas() -> xhemm_iutcopy
+#define	XHEMM_ILTCOPY		get_gotoblas() -> xhemm_iltcopy
 
-#define	XGEMM3M_ONCOPYB		gotoblas -> xgemm3m_oncopyb
-#define	XGEMM3M_ONCOPYR		gotoblas -> xgemm3m_oncopyr
-#define	XGEMM3M_ONCOPYI		gotoblas -> xgemm3m_oncopyi
-#define	XGEMM3M_OTCOPYB		gotoblas -> xgemm3m_otcopyb
-#define	XGEMM3M_OTCOPYR		gotoblas -> xgemm3m_otcopyr
-#define	XGEMM3M_OTCOPYI		gotoblas -> xgemm3m_otcopyi
+#define	XGEMM3M_ONCOPYB		get_gotoblas() -> xgemm3m_oncopyb
+#define	XGEMM3M_ONCOPYR		get_gotoblas() -> xgemm3m_oncopyr
+#define	XGEMM3M_ONCOPYI		get_gotoblas() -> xgemm3m_oncopyi
+#define	XGEMM3M_OTCOPYB		get_gotoblas() -> xgemm3m_otcopyb
+#define	XGEMM3M_OTCOPYR		get_gotoblas() -> xgemm3m_otcopyr
+#define	XGEMM3M_OTCOPYI		get_gotoblas() -> xgemm3m_otcopyi
 
-#define	XGEMM3M_INCOPYB		gotoblas -> xgemm3m_incopyb
-#define	XGEMM3M_INCOPYR		gotoblas -> xgemm3m_incopyr
-#define	XGEMM3M_INCOPYI		gotoblas -> xgemm3m_incopyi
-#define	XGEMM3M_ITCOPYB		gotoblas -> xgemm3m_itcopyb
-#define	XGEMM3M_ITCOPYR		gotoblas -> xgemm3m_itcopyr
-#define	XGEMM3M_ITCOPYI		gotoblas -> xgemm3m_itcopyi
+#define	XGEMM3M_INCOPYB		get_gotoblas() -> xgemm3m_incopyb
+#define	XGEMM3M_INCOPYR		get_gotoblas() -> xgemm3m_incopyr
+#define	XGEMM3M_INCOPYI		get_gotoblas() -> xgemm3m_incopyi
+#define	XGEMM3M_ITCOPYB		get_gotoblas() -> xgemm3m_itcopyb
+#define	XGEMM3M_ITCOPYR		get_gotoblas() -> xgemm3m_itcopyr
+#define	XGEMM3M_ITCOPYI		get_gotoblas() -> xgemm3m_itcopyi
 
-#define	XSYMM3M_ILCOPYB		gotoblas -> xsymm3m_ilcopyb
-#define	XSYMM3M_IUCOPYB		gotoblas -> xsymm3m_iucopyb
-#define	XSYMM3M_ILCOPYR		gotoblas -> xsymm3m_ilcopyr
-#define	XSYMM3M_IUCOPYR		gotoblas -> xsymm3m_iucopyr
-#define	XSYMM3M_ILCOPYI		gotoblas -> xsymm3m_ilcopyi
-#define	XSYMM3M_IUCOPYI		gotoblas -> xsymm3m_iucopyi
+#define	XSYMM3M_ILCOPYB		get_gotoblas() -> xsymm3m_ilcopyb
+#define	XSYMM3M_IUCOPYB		get_gotoblas() -> xsymm3m_iucopyb
+#define	XSYMM3M_ILCOPYR		get_gotoblas() -> xsymm3m_ilcopyr
+#define	XSYMM3M_IUCOPYR		get_gotoblas() -> xsymm3m_iucopyr
+#define	XSYMM3M_ILCOPYI		get_gotoblas() -> xsymm3m_ilcopyi
+#define	XSYMM3M_IUCOPYI		get_gotoblas() -> xsymm3m_iucopyi
 
-#define	XSYMM3M_OLCOPYB		gotoblas -> xsymm3m_olcopyb
-#define	XSYMM3M_OUCOPYB		gotoblas -> xsymm3m_oucopyb
-#define	XSYMM3M_OLCOPYR		gotoblas -> xsymm3m_olcopyr
-#define	XSYMM3M_OUCOPYR		gotoblas -> xsymm3m_oucopyr
-#define	XSYMM3M_OLCOPYI		gotoblas -> xsymm3m_olcopyi
-#define	XSYMM3M_OUCOPYI		gotoblas -> xsymm3m_oucopyi
+#define	XSYMM3M_OLCOPYB		get_gotoblas() -> xsymm3m_olcopyb
+#define	XSYMM3M_OUCOPYB		get_gotoblas() -> xsymm3m_oucopyb
+#define	XSYMM3M_OLCOPYR		get_gotoblas() -> xsymm3m_olcopyr
+#define	XSYMM3M_OUCOPYR		get_gotoblas() -> xsymm3m_oucopyr
+#define	XSYMM3M_OLCOPYI		get_gotoblas() -> xsymm3m_olcopyi
+#define	XSYMM3M_OUCOPYI		get_gotoblas() -> xsymm3m_oucopyi
 
-#define	XHEMM3M_ILCOPYB		gotoblas -> xhemm3m_ilcopyb
-#define	XHEMM3M_IUCOPYB		gotoblas -> xhemm3m_iucopyb
-#define	XHEMM3M_ILCOPYR		gotoblas -> xhemm3m_ilcopyr
-#define	XHEMM3M_IUCOPYR		gotoblas -> xhemm3m_iucopyr
-#define	XHEMM3M_ILCOPYI		gotoblas -> xhemm3m_ilcopyi
-#define	XHEMM3M_IUCOPYI		gotoblas -> xhemm3m_iucopyi
+#define	XHEMM3M_ILCOPYB		get_gotoblas() -> xhemm3m_ilcopyb
+#define	XHEMM3M_IUCOPYB		get_gotoblas() -> xhemm3m_iucopyb
+#define	XHEMM3M_ILCOPYR		get_gotoblas() -> xhemm3m_ilcopyr
+#define	XHEMM3M_IUCOPYR		get_gotoblas() -> xhemm3m_iucopyr
+#define	XHEMM3M_ILCOPYI		get_gotoblas() -> xhemm3m_ilcopyi
+#define	XHEMM3M_IUCOPYI		get_gotoblas() -> xhemm3m_iucopyi
 
-#define	XHEMM3M_OLCOPYB		gotoblas -> xhemm3m_olcopyb
-#define	XHEMM3M_OUCOPYB		gotoblas -> xhemm3m_oucopyb
-#define	XHEMM3M_OLCOPYR		gotoblas -> xhemm3m_olcopyr
-#define	XHEMM3M_OUCOPYR		gotoblas -> xhemm3m_oucopyr
-#define	XHEMM3M_OLCOPYI		gotoblas -> xhemm3m_olcopyi
-#define	XHEMM3M_OUCOPYI		gotoblas -> xhemm3m_oucopyi
+#define	XHEMM3M_OLCOPYB		get_gotoblas() -> xhemm3m_olcopyb
+#define	XHEMM3M_OUCOPYB		get_gotoblas() -> xhemm3m_oucopyb
+#define	XHEMM3M_OLCOPYR		get_gotoblas() -> xhemm3m_olcopyr
+#define	XHEMM3M_OUCOPYR		get_gotoblas() -> xhemm3m_oucopyr
+#define	XHEMM3M_OLCOPYI		get_gotoblas() -> xhemm3m_olcopyi
+#define	XHEMM3M_OUCOPYI		get_gotoblas() -> xhemm3m_oucopyi
 
-#define	XGEMM3M_KERNEL		gotoblas -> xgemm3m_kernel
+#define	XGEMM3M_KERNEL		get_gotoblas() -> xgemm3m_kernel
 
-#define XNEG_TCOPY		gotoblas -> xneg_tcopy
-#define XLASWP_NCOPY		gotoblas -> xlaswp_ncopy
+#define XNEG_TCOPY		get_gotoblas() -> xneg_tcopy
+#define XLASWP_NCOPY		get_gotoblas() -> xlaswp_ncopy
 
 #endif
 

--- a/common_z.h
+++ b/common_z.h
@@ -229,49 +229,49 @@
 #define ZIMATCOPY_K_CTC         zimatcopy_k_ctc
 #define ZIMATCOPY_K_RTC         zimatcopy_k_rtc
 
-#define ZGEADD_K                zgeadd_k 
+#define ZGEADD_K                zgeadd_k
 
 #else
 
-#define	ZAMAX_K			gotoblas -> zamax_k
-#define	ZAMIN_K			gotoblas -> zamin_k
-#define	ZMAX_K			gotoblas -> zmax_k
-#define	ZMIN_K			gotoblas -> zmin_k
-#define	IZAMAX_K		gotoblas -> izamax_k
-#define	IZAMIN_K		gotoblas -> izamin_k
-#define	IZMAX_K			gotoblas -> izmax_k
-#define	IZMIN_K			gotoblas -> izmin_k
-#define	ZASUM_K			gotoblas -> zasum_k
-#define	ZAXPYU_K		gotoblas -> zaxpy_k
-#define	ZAXPYC_K		gotoblas -> zaxpyc_k
-#define	ZCOPY_K			gotoblas -> zcopy_k
-#define	ZDOTU_K			gotoblas -> zdotu_k
-#define	ZDOTC_K			gotoblas -> zdotc_k
-#define	ZNRM2_K			gotoblas -> znrm2_k
-#define	ZSCAL_K			gotoblas -> zscal_k
-#define	ZSWAP_K			gotoblas -> zswap_k
-#define	ZROT_K			gotoblas -> zdrot_k
+#define	ZAMAX_K			get_gotoblas() -> zamax_k
+#define	ZAMIN_K			get_gotoblas() -> zamin_k
+#define	ZMAX_K			get_gotoblas() -> zmax_k
+#define	ZMIN_K			get_gotoblas() -> zmin_k
+#define	IZAMAX_K		get_gotoblas() -> izamax_k
+#define	IZAMIN_K		get_gotoblas() -> izamin_k
+#define	IZMAX_K			get_gotoblas() -> izmax_k
+#define	IZMIN_K			get_gotoblas() -> izmin_k
+#define	ZASUM_K			get_gotoblas() -> zasum_k
+#define	ZAXPYU_K		get_gotoblas() -> zaxpy_k
+#define	ZAXPYC_K		get_gotoblas() -> zaxpyc_k
+#define	ZCOPY_K			get_gotoblas() -> zcopy_k
+#define	ZDOTU_K			get_gotoblas() -> zdotu_k
+#define	ZDOTC_K			get_gotoblas() -> zdotc_k
+#define	ZNRM2_K			get_gotoblas() -> znrm2_k
+#define	ZSCAL_K			get_gotoblas() -> zscal_k
+#define	ZSWAP_K			get_gotoblas() -> zswap_k
+#define	ZROT_K			get_gotoblas() -> zdrot_k
 
-#define	ZGEMV_N			gotoblas -> zgemv_n
-#define	ZGEMV_T			gotoblas -> zgemv_t
-#define	ZGEMV_R			gotoblas -> zgemv_r
-#define	ZGEMV_C			gotoblas -> zgemv_c
-#define	ZGEMV_O			gotoblas -> zgemv_o
-#define	ZGEMV_U			gotoblas -> zgemv_u
-#define	ZGEMV_S			gotoblas -> zgemv_s
-#define	ZGEMV_D			gotoblas -> zgemv_d
+#define	ZGEMV_N			get_gotoblas() -> zgemv_n
+#define	ZGEMV_T			get_gotoblas() -> zgemv_t
+#define	ZGEMV_R			get_gotoblas() -> zgemv_r
+#define	ZGEMV_C			get_gotoblas() -> zgemv_c
+#define	ZGEMV_O			get_gotoblas() -> zgemv_o
+#define	ZGEMV_U			get_gotoblas() -> zgemv_u
+#define	ZGEMV_S			get_gotoblas() -> zgemv_s
+#define	ZGEMV_D			get_gotoblas() -> zgemv_d
 
-#define	ZGERU_K			gotoblas -> zgeru_k
-#define	ZGERC_K			gotoblas -> zgerc_k
-#define	ZGERV_K			gotoblas -> zgerv_k
-#define	ZGERD_K			gotoblas -> zgerd_k
+#define	ZGERU_K			get_gotoblas() -> zgeru_k
+#define	ZGERC_K			get_gotoblas() -> zgerc_k
+#define	ZGERV_K			get_gotoblas() -> zgerv_k
+#define	ZGERD_K			get_gotoblas() -> zgerd_k
 
-#define ZSYMV_U			gotoblas -> zsymv_U
-#define ZSYMV_L			gotoblas -> zsymv_L
-#define ZHEMV_U			gotoblas -> zhemv_U
-#define ZHEMV_L			gotoblas -> zhemv_L
-#define ZHEMV_V			gotoblas -> zhemv_V
-#define ZHEMV_M			gotoblas -> zhemv_M
+#define ZSYMV_U			get_gotoblas() -> zsymv_U
+#define ZSYMV_L			get_gotoblas() -> zsymv_L
+#define ZHEMV_U			get_gotoblas() -> zhemv_U
+#define ZHEMV_L			get_gotoblas() -> zhemv_L
+#define ZHEMV_V			get_gotoblas() -> zhemv_V
+#define ZHEMV_M			get_gotoblas() -> zhemv_M
 
 #define ZSYMV_THREAD_U		zsymv_thread_U
 #define ZSYMV_THREAD_L		zsymv_thread_L
@@ -280,149 +280,149 @@
 #define ZHEMV_THREAD_V		zhemv_thread_V
 #define ZHEMV_THREAD_M		zhemv_thread_M
 
-#define	ZGEMM_ONCOPY		gotoblas -> zgemm_oncopy
-#define	ZGEMM_OTCOPY		gotoblas -> zgemm_otcopy
-#define	ZGEMM_INCOPY		gotoblas -> zgemm_incopy
-#define	ZGEMM_ITCOPY		gotoblas -> zgemm_itcopy
+#define	ZGEMM_ONCOPY		get_gotoblas() -> zgemm_oncopy
+#define	ZGEMM_OTCOPY		get_gotoblas() -> zgemm_otcopy
+#define	ZGEMM_INCOPY		get_gotoblas() -> zgemm_incopy
+#define	ZGEMM_ITCOPY		get_gotoblas() -> zgemm_itcopy
 
-#define	ZTRMM_OUNUCOPY		gotoblas -> ztrmm_ounucopy
-#define	ZTRMM_OUTUCOPY		gotoblas -> ztrmm_outucopy
-#define	ZTRMM_OLNUCOPY		gotoblas -> ztrmm_olnucopy
-#define	ZTRMM_OLTUCOPY		gotoblas -> ztrmm_oltucopy
-#define	ZTRSM_OUNUCOPY		gotoblas -> ztrsm_ounucopy
-#define	ZTRSM_OUTUCOPY		gotoblas -> ztrsm_outucopy
-#define	ZTRSM_OLNUCOPY		gotoblas -> ztrsm_olnucopy
-#define	ZTRSM_OLTUCOPY		gotoblas -> ztrsm_oltucopy
+#define	ZTRMM_OUNUCOPY		get_gotoblas() -> ztrmm_ounucopy
+#define	ZTRMM_OUTUCOPY		get_gotoblas() -> ztrmm_outucopy
+#define	ZTRMM_OLNUCOPY		get_gotoblas() -> ztrmm_olnucopy
+#define	ZTRMM_OLTUCOPY		get_gotoblas() -> ztrmm_oltucopy
+#define	ZTRSM_OUNUCOPY		get_gotoblas() -> ztrsm_ounucopy
+#define	ZTRSM_OUTUCOPY		get_gotoblas() -> ztrsm_outucopy
+#define	ZTRSM_OLNUCOPY		get_gotoblas() -> ztrsm_olnucopy
+#define	ZTRSM_OLTUCOPY		get_gotoblas() -> ztrsm_oltucopy
 
-#define	ZTRMM_IUNUCOPY		gotoblas -> ztrmm_iunucopy
-#define	ZTRMM_IUTUCOPY		gotoblas -> ztrmm_iutucopy
-#define	ZTRMM_ILNUCOPY		gotoblas -> ztrmm_ilnucopy
-#define	ZTRMM_ILTUCOPY		gotoblas -> ztrmm_iltucopy
-#define	ZTRSM_IUNUCOPY		gotoblas -> ztrsm_iunucopy
-#define	ZTRSM_IUTUCOPY		gotoblas -> ztrsm_iutucopy
-#define	ZTRSM_ILNUCOPY		gotoblas -> ztrsm_ilnucopy
-#define	ZTRSM_ILTUCOPY		gotoblas -> ztrsm_iltucopy
+#define	ZTRMM_IUNUCOPY		get_gotoblas() -> ztrmm_iunucopy
+#define	ZTRMM_IUTUCOPY		get_gotoblas() -> ztrmm_iutucopy
+#define	ZTRMM_ILNUCOPY		get_gotoblas() -> ztrmm_ilnucopy
+#define	ZTRMM_ILTUCOPY		get_gotoblas() -> ztrmm_iltucopy
+#define	ZTRSM_IUNUCOPY		get_gotoblas() -> ztrsm_iunucopy
+#define	ZTRSM_IUTUCOPY		get_gotoblas() -> ztrsm_iutucopy
+#define	ZTRSM_ILNUCOPY		get_gotoblas() -> ztrsm_ilnucopy
+#define	ZTRSM_ILTUCOPY		get_gotoblas() -> ztrsm_iltucopy
 
-#define	ZTRMM_OUNNCOPY		gotoblas -> ztrmm_ounncopy
-#define	ZTRMM_OUTNCOPY		gotoblas -> ztrmm_outncopy
-#define	ZTRMM_OLNNCOPY		gotoblas -> ztrmm_olnncopy
-#define	ZTRMM_OLTNCOPY		gotoblas -> ztrmm_oltncopy
-#define	ZTRSM_OUNNCOPY		gotoblas -> ztrsm_ounncopy
-#define	ZTRSM_OUTNCOPY		gotoblas -> ztrsm_outncopy
-#define	ZTRSM_OLNNCOPY		gotoblas -> ztrsm_olnncopy
-#define	ZTRSM_OLTNCOPY		gotoblas -> ztrsm_oltncopy
+#define	ZTRMM_OUNNCOPY		get_gotoblas() -> ztrmm_ounncopy
+#define	ZTRMM_OUTNCOPY		get_gotoblas() -> ztrmm_outncopy
+#define	ZTRMM_OLNNCOPY		get_gotoblas() -> ztrmm_olnncopy
+#define	ZTRMM_OLTNCOPY		get_gotoblas() -> ztrmm_oltncopy
+#define	ZTRSM_OUNNCOPY		get_gotoblas() -> ztrsm_ounncopy
+#define	ZTRSM_OUTNCOPY		get_gotoblas() -> ztrsm_outncopy
+#define	ZTRSM_OLNNCOPY		get_gotoblas() -> ztrsm_olnncopy
+#define	ZTRSM_OLTNCOPY		get_gotoblas() -> ztrsm_oltncopy
 
-#define	ZTRMM_IUNNCOPY		gotoblas -> ztrmm_iunncopy
-#define	ZTRMM_IUTNCOPY		gotoblas -> ztrmm_iutncopy
-#define	ZTRMM_ILNNCOPY		gotoblas -> ztrmm_ilnncopy
-#define	ZTRMM_ILTNCOPY		gotoblas -> ztrmm_iltncopy
-#define	ZTRSM_IUNNCOPY		gotoblas -> ztrsm_iunncopy
-#define	ZTRSM_IUTNCOPY		gotoblas -> ztrsm_iutncopy
-#define	ZTRSM_ILNNCOPY		gotoblas -> ztrsm_ilnncopy
-#define	ZTRSM_ILTNCOPY		gotoblas -> ztrsm_iltncopy
+#define	ZTRMM_IUNNCOPY		get_gotoblas() -> ztrmm_iunncopy
+#define	ZTRMM_IUTNCOPY		get_gotoblas() -> ztrmm_iutncopy
+#define	ZTRMM_ILNNCOPY		get_gotoblas() -> ztrmm_ilnncopy
+#define	ZTRMM_ILTNCOPY		get_gotoblas() -> ztrmm_iltncopy
+#define	ZTRSM_IUNNCOPY		get_gotoblas() -> ztrsm_iunncopy
+#define	ZTRSM_IUTNCOPY		get_gotoblas() -> ztrsm_iutncopy
+#define	ZTRSM_ILNNCOPY		get_gotoblas() -> ztrsm_ilnncopy
+#define	ZTRSM_ILTNCOPY		get_gotoblas() -> ztrsm_iltncopy
 
-#define	ZGEMM_BETA		gotoblas -> zgemm_beta
-#define	ZGEMM_KERNEL_N		gotoblas -> zgemm_kernel_n
-#define	ZGEMM_KERNEL_L		gotoblas -> zgemm_kernel_l
-#define	ZGEMM_KERNEL_R		gotoblas -> zgemm_kernel_r
-#define	ZGEMM_KERNEL_B		gotoblas -> zgemm_kernel_b
+#define	ZGEMM_BETA		get_gotoblas() -> zgemm_beta
+#define	ZGEMM_KERNEL_N		get_gotoblas() -> zgemm_kernel_n
+#define	ZGEMM_KERNEL_L		get_gotoblas() -> zgemm_kernel_l
+#define	ZGEMM_KERNEL_R		get_gotoblas() -> zgemm_kernel_r
+#define	ZGEMM_KERNEL_B		get_gotoblas() -> zgemm_kernel_b
 
-#define	ZTRMM_KERNEL_LN		gotoblas -> ztrmm_kernel_LN
-#define	ZTRMM_KERNEL_LT		gotoblas -> ztrmm_kernel_LT
-#define	ZTRMM_KERNEL_LR		gotoblas -> ztrmm_kernel_LR
-#define	ZTRMM_KERNEL_LC		gotoblas -> ztrmm_kernel_LC
-#define	ZTRMM_KERNEL_RN		gotoblas -> ztrmm_kernel_RN
-#define	ZTRMM_KERNEL_RT		gotoblas -> ztrmm_kernel_RT
-#define	ZTRMM_KERNEL_RR		gotoblas -> ztrmm_kernel_RR
-#define	ZTRMM_KERNEL_RC		gotoblas -> ztrmm_kernel_RC
+#define	ZTRMM_KERNEL_LN		get_gotoblas() -> ztrmm_kernel_LN
+#define	ZTRMM_KERNEL_LT		get_gotoblas() -> ztrmm_kernel_LT
+#define	ZTRMM_KERNEL_LR		get_gotoblas() -> ztrmm_kernel_LR
+#define	ZTRMM_KERNEL_LC		get_gotoblas() -> ztrmm_kernel_LC
+#define	ZTRMM_KERNEL_RN		get_gotoblas() -> ztrmm_kernel_RN
+#define	ZTRMM_KERNEL_RT		get_gotoblas() -> ztrmm_kernel_RT
+#define	ZTRMM_KERNEL_RR		get_gotoblas() -> ztrmm_kernel_RR
+#define	ZTRMM_KERNEL_RC		get_gotoblas() -> ztrmm_kernel_RC
 
-#define	ZTRSM_KERNEL_LN		gotoblas -> ztrsm_kernel_LN
-#define	ZTRSM_KERNEL_LT		gotoblas -> ztrsm_kernel_LT
-#define	ZTRSM_KERNEL_LR		gotoblas -> ztrsm_kernel_LR
-#define	ZTRSM_KERNEL_LC		gotoblas -> ztrsm_kernel_LC
-#define	ZTRSM_KERNEL_RN		gotoblas -> ztrsm_kernel_RN
-#define	ZTRSM_KERNEL_RT		gotoblas -> ztrsm_kernel_RT
-#define	ZTRSM_KERNEL_RR		gotoblas -> ztrsm_kernel_RR
-#define	ZTRSM_KERNEL_RC		gotoblas -> ztrsm_kernel_RC
+#define	ZTRSM_KERNEL_LN		get_gotoblas() -> ztrsm_kernel_LN
+#define	ZTRSM_KERNEL_LT		get_gotoblas() -> ztrsm_kernel_LT
+#define	ZTRSM_KERNEL_LR		get_gotoblas() -> ztrsm_kernel_LR
+#define	ZTRSM_KERNEL_LC		get_gotoblas() -> ztrsm_kernel_LC
+#define	ZTRSM_KERNEL_RN		get_gotoblas() -> ztrsm_kernel_RN
+#define	ZTRSM_KERNEL_RT		get_gotoblas() -> ztrsm_kernel_RT
+#define	ZTRSM_KERNEL_RR		get_gotoblas() -> ztrsm_kernel_RR
+#define	ZTRSM_KERNEL_RC		get_gotoblas() -> ztrsm_kernel_RC
 
-#define	ZSYMM_IUTCOPY		gotoblas -> zsymm_iutcopy
-#define	ZSYMM_ILTCOPY		gotoblas -> zsymm_iltcopy
-#define	ZSYMM_OUTCOPY		gotoblas -> zsymm_outcopy
-#define	ZSYMM_OLTCOPY		gotoblas -> zsymm_oltcopy
+#define	ZSYMM_IUTCOPY		get_gotoblas() -> zsymm_iutcopy
+#define	ZSYMM_ILTCOPY		get_gotoblas() -> zsymm_iltcopy
+#define	ZSYMM_OUTCOPY		get_gotoblas() -> zsymm_outcopy
+#define	ZSYMM_OLTCOPY		get_gotoblas() -> zsymm_oltcopy
 
-#define	ZHEMM_OUTCOPY		gotoblas -> zhemm_outcopy
-#define	ZHEMM_OLTCOPY		gotoblas -> zhemm_oltcopy
-#define	ZHEMM_IUTCOPY		gotoblas -> zhemm_iutcopy
-#define	ZHEMM_ILTCOPY		gotoblas -> zhemm_iltcopy
+#define	ZHEMM_OUTCOPY		get_gotoblas() -> zhemm_outcopy
+#define	ZHEMM_OLTCOPY		get_gotoblas() -> zhemm_oltcopy
+#define	ZHEMM_IUTCOPY		get_gotoblas() -> zhemm_iutcopy
+#define	ZHEMM_ILTCOPY		get_gotoblas() -> zhemm_iltcopy
 
-#define	ZGEMM3M_ONCOPYB		gotoblas -> zgemm3m_oncopyb
-#define	ZGEMM3M_ONCOPYR		gotoblas -> zgemm3m_oncopyr
-#define	ZGEMM3M_ONCOPYI		gotoblas -> zgemm3m_oncopyi
-#define	ZGEMM3M_OTCOPYB		gotoblas -> zgemm3m_otcopyb
-#define	ZGEMM3M_OTCOPYR		gotoblas -> zgemm3m_otcopyr
-#define	ZGEMM3M_OTCOPYI		gotoblas -> zgemm3m_otcopyi
+#define	ZGEMM3M_ONCOPYB		get_gotoblas() -> zgemm3m_oncopyb
+#define	ZGEMM3M_ONCOPYR		get_gotoblas() -> zgemm3m_oncopyr
+#define	ZGEMM3M_ONCOPYI		get_gotoblas() -> zgemm3m_oncopyi
+#define	ZGEMM3M_OTCOPYB		get_gotoblas() -> zgemm3m_otcopyb
+#define	ZGEMM3M_OTCOPYR		get_gotoblas() -> zgemm3m_otcopyr
+#define	ZGEMM3M_OTCOPYI		get_gotoblas() -> zgemm3m_otcopyi
 
-#define	ZGEMM3M_INCOPYB		gotoblas -> zgemm3m_incopyb
-#define	ZGEMM3M_INCOPYR		gotoblas -> zgemm3m_incopyr
-#define	ZGEMM3M_INCOPYI		gotoblas -> zgemm3m_incopyi
-#define	ZGEMM3M_ITCOPYB		gotoblas -> zgemm3m_itcopyb
-#define	ZGEMM3M_ITCOPYR		gotoblas -> zgemm3m_itcopyr
-#define	ZGEMM3M_ITCOPYI		gotoblas -> zgemm3m_itcopyi
+#define	ZGEMM3M_INCOPYB		get_gotoblas() -> zgemm3m_incopyb
+#define	ZGEMM3M_INCOPYR		get_gotoblas() -> zgemm3m_incopyr
+#define	ZGEMM3M_INCOPYI		get_gotoblas() -> zgemm3m_incopyi
+#define	ZGEMM3M_ITCOPYB		get_gotoblas() -> zgemm3m_itcopyb
+#define	ZGEMM3M_ITCOPYR		get_gotoblas() -> zgemm3m_itcopyr
+#define	ZGEMM3M_ITCOPYI		get_gotoblas() -> zgemm3m_itcopyi
 
-#define	ZSYMM3M_ILCOPYB		gotoblas -> zsymm3m_ilcopyb
-#define	ZSYMM3M_IUCOPYB		gotoblas -> zsymm3m_iucopyb
-#define	ZSYMM3M_ILCOPYR		gotoblas -> zsymm3m_ilcopyr
-#define	ZSYMM3M_IUCOPYR		gotoblas -> zsymm3m_iucopyr
-#define	ZSYMM3M_ILCOPYI		gotoblas -> zsymm3m_ilcopyi
-#define	ZSYMM3M_IUCOPYI		gotoblas -> zsymm3m_iucopyi
+#define	ZSYMM3M_ILCOPYB		get_gotoblas() -> zsymm3m_ilcopyb
+#define	ZSYMM3M_IUCOPYB		get_gotoblas() -> zsymm3m_iucopyb
+#define	ZSYMM3M_ILCOPYR		get_gotoblas() -> zsymm3m_ilcopyr
+#define	ZSYMM3M_IUCOPYR		get_gotoblas() -> zsymm3m_iucopyr
+#define	ZSYMM3M_ILCOPYI		get_gotoblas() -> zsymm3m_ilcopyi
+#define	ZSYMM3M_IUCOPYI		get_gotoblas() -> zsymm3m_iucopyi
 
-#define	ZSYMM3M_OLCOPYB		gotoblas -> zsymm3m_olcopyb
-#define	ZSYMM3M_OUCOPYB		gotoblas -> zsymm3m_oucopyb
-#define	ZSYMM3M_OLCOPYR		gotoblas -> zsymm3m_olcopyr
-#define	ZSYMM3M_OUCOPYR		gotoblas -> zsymm3m_oucopyr
-#define	ZSYMM3M_OLCOPYI		gotoblas -> zsymm3m_olcopyi
-#define	ZSYMM3M_OUCOPYI		gotoblas -> zsymm3m_oucopyi
+#define	ZSYMM3M_OLCOPYB		get_gotoblas() -> zsymm3m_olcopyb
+#define	ZSYMM3M_OUCOPYB		get_gotoblas() -> zsymm3m_oucopyb
+#define	ZSYMM3M_OLCOPYR		get_gotoblas() -> zsymm3m_olcopyr
+#define	ZSYMM3M_OUCOPYR		get_gotoblas() -> zsymm3m_oucopyr
+#define	ZSYMM3M_OLCOPYI		get_gotoblas() -> zsymm3m_olcopyi
+#define	ZSYMM3M_OUCOPYI		get_gotoblas() -> zsymm3m_oucopyi
 
-#define	ZHEMM3M_ILCOPYB		gotoblas -> zhemm3m_ilcopyb
-#define	ZHEMM3M_IUCOPYB		gotoblas -> zhemm3m_iucopyb
-#define	ZHEMM3M_ILCOPYR		gotoblas -> zhemm3m_ilcopyr
-#define	ZHEMM3M_IUCOPYR		gotoblas -> zhemm3m_iucopyr
-#define	ZHEMM3M_ILCOPYI		gotoblas -> zhemm3m_ilcopyi
-#define	ZHEMM3M_IUCOPYI		gotoblas -> zhemm3m_iucopyi
+#define	ZHEMM3M_ILCOPYB		get_gotoblas() -> zhemm3m_ilcopyb
+#define	ZHEMM3M_IUCOPYB		get_gotoblas() -> zhemm3m_iucopyb
+#define	ZHEMM3M_ILCOPYR		get_gotoblas() -> zhemm3m_ilcopyr
+#define	ZHEMM3M_IUCOPYR		get_gotoblas() -> zhemm3m_iucopyr
+#define	ZHEMM3M_ILCOPYI		get_gotoblas() -> zhemm3m_ilcopyi
+#define	ZHEMM3M_IUCOPYI		get_gotoblas() -> zhemm3m_iucopyi
 
-#define	ZHEMM3M_OLCOPYB		gotoblas -> zhemm3m_olcopyb
-#define	ZHEMM3M_OUCOPYB		gotoblas -> zhemm3m_oucopyb
-#define	ZHEMM3M_OLCOPYR		gotoblas -> zhemm3m_olcopyr
-#define	ZHEMM3M_OUCOPYR		gotoblas -> zhemm3m_oucopyr
-#define	ZHEMM3M_OLCOPYI		gotoblas -> zhemm3m_olcopyi
-#define	ZHEMM3M_OUCOPYI		gotoblas -> zhemm3m_oucopyi
+#define	ZHEMM3M_OLCOPYB		get_gotoblas() -> zhemm3m_olcopyb
+#define	ZHEMM3M_OUCOPYB		get_gotoblas() -> zhemm3m_oucopyb
+#define	ZHEMM3M_OLCOPYR		get_gotoblas() -> zhemm3m_olcopyr
+#define	ZHEMM3M_OUCOPYR		get_gotoblas() -> zhemm3m_oucopyr
+#define	ZHEMM3M_OLCOPYI		get_gotoblas() -> zhemm3m_olcopyi
+#define	ZHEMM3M_OUCOPYI		get_gotoblas() -> zhemm3m_oucopyi
 
-#define	ZGEMM3M_KERNEL		gotoblas -> zgemm3m_kernel
+#define	ZGEMM3M_KERNEL		get_gotoblas() -> zgemm3m_kernel
 
-#define ZNEG_TCOPY		gotoblas -> zneg_tcopy
-#define ZLASWP_NCOPY		gotoblas -> zlaswp_ncopy
+#define ZNEG_TCOPY		get_gotoblas() -> zneg_tcopy
+#define ZLASWP_NCOPY		get_gotoblas() -> zlaswp_ncopy
 
-#define ZAXPBY_K                gotoblas -> zaxpby_k
+#define ZAXPBY_K                get_gotoblas() -> zaxpby_k
 
-#define ZOMATCOPY_K_CN          gotoblas -> zomatcopy_k_cn
-#define ZOMATCOPY_K_RN          gotoblas -> zomatcopy_k_rn
-#define ZOMATCOPY_K_CT          gotoblas -> zomatcopy_k_ct
-#define ZOMATCOPY_K_RT          gotoblas -> zomatcopy_k_rt
-#define ZOMATCOPY_K_CNC         gotoblas -> zomatcopy_k_cnc
-#define ZOMATCOPY_K_RNC         gotoblas -> zomatcopy_k_rnc
-#define ZOMATCOPY_K_CTC         gotoblas -> zomatcopy_k_ctc
-#define ZOMATCOPY_K_RTC         gotoblas -> zomatcopy_k_rtc
+#define ZOMATCOPY_K_CN          get_gotoblas() -> zomatcopy_k_cn
+#define ZOMATCOPY_K_RN          get_gotoblas() -> zomatcopy_k_rn
+#define ZOMATCOPY_K_CT          get_gotoblas() -> zomatcopy_k_ct
+#define ZOMATCOPY_K_RT          get_gotoblas() -> zomatcopy_k_rt
+#define ZOMATCOPY_K_CNC         get_gotoblas() -> zomatcopy_k_cnc
+#define ZOMATCOPY_K_RNC         get_gotoblas() -> zomatcopy_k_rnc
+#define ZOMATCOPY_K_CTC         get_gotoblas() -> zomatcopy_k_ctc
+#define ZOMATCOPY_K_RTC         get_gotoblas() -> zomatcopy_k_rtc
 
-#define ZIMATCOPY_K_CN          gotoblas -> zimatcopy_k_cn
-#define ZIMATCOPY_K_RN          gotoblas -> zimatcopy_k_rn
-#define ZIMATCOPY_K_CT          gotoblas -> zimatcopy_k_ct
-#define ZIMATCOPY_K_RT          gotoblas -> zimatcopy_k_rt
-#define ZIMATCOPY_K_CNC         gotoblas -> zimatcopy_k_cnc
-#define ZIMATCOPY_K_RNC         gotoblas -> zimatcopy_k_rnc
-#define ZIMATCOPY_K_CTC         gotoblas -> zimatcopy_k_ctc
-#define ZIMATCOPY_K_RTC         gotoblas -> zimatcopy_k_rtc
+#define ZIMATCOPY_K_CN          get_gotoblas() -> zimatcopy_k_cn
+#define ZIMATCOPY_K_RN          get_gotoblas() -> zimatcopy_k_rn
+#define ZIMATCOPY_K_CT          get_gotoblas() -> zimatcopy_k_ct
+#define ZIMATCOPY_K_RT          get_gotoblas() -> zimatcopy_k_rt
+#define ZIMATCOPY_K_CNC         get_gotoblas() -> zimatcopy_k_cnc
+#define ZIMATCOPY_K_RNC         get_gotoblas() -> zimatcopy_k_rnc
+#define ZIMATCOPY_K_CTC         get_gotoblas() -> zimatcopy_k_ctc
+#define ZIMATCOPY_K_RTC         get_gotoblas() -> zimatcopy_k_rtc
 
-#define ZGEADD_K                gotoblas -> zgeadd_k
+#define ZGEADD_K                get_gotoblas() -> zgeadd_k
 
 #endif
 

--- a/driver/others/dynamic.c
+++ b/driver/others/dynamic.c
@@ -278,6 +278,12 @@ extern gotoblas_t  gotoblas_SKYLAKEX;
 
 #define BITMASK(a, b, c) ((((a) >> (b)) & (c)))
 
+/* Do not reference gotoblas directly outside of dynamic.c, to prevent
+initialization order issues where an initializer attempts to call into OpenBLAS
+before gotoblas_dynamic_init has been called. Instead, use get_gotoblas(),
+defined in common.h. */
+gotoblas_t *gotoblas = NULL;
+
 #ifndef NO_AVX
 static inline void xgetbv(int op, int * eax, int * edx){
   //Use binary code for xgetbv
@@ -419,7 +425,7 @@ static gotoblas_t *get_coretype(void){
 	    return &gotoblas_NEHALEM; //OS doesn't support AVX. Use old kernels.
 	  }
 	}
-	if (model == 7) return &gotoblas_ATOM; //Bay Trail	
+	if (model == 7) return &gotoblas_ATOM; //Bay Trail
 	return NULL;
       case 4:
 		//Intel Haswell
@@ -450,9 +456,9 @@ static gotoblas_t *get_coretype(void){
 	  }
 	}
 	//Intel Braswell / Avoton
-	if (model == 12 || model == 13) { 
+	if (model == 12 || model == 13) {
 	  return &gotoblas_NEHALEM;
-	}	
+	}
 	return NULL;
       case 5:
 	//Intel Broadwell
@@ -464,18 +470,18 @@ static gotoblas_t *get_coretype(void){
 	    return &gotoblas_NEHALEM; //OS doesn't support AVX. Use old kernels.
 	  }
 	}
-	if (model == 5) {	
+	if (model == 5) {
 	// Intel Skylake X
 #ifndef NO_AVX512
 	  return &gotoblas_SKYLAKEX;
-#else		
+#else
 	  if(support_avx())
 	    return &gotoblas_HASWELL;
 	  else {
 	    openblas_warning(FALLBACK_VERBOSE, NEHALEM_FALLBACK);
 	    return &gotoblas_NEHALEM;
 	  }
-#endif		
+#endif
 	}
 	//Intel Skylake
 	if (model == 14) {
@@ -496,9 +502,9 @@ static gotoblas_t *get_coretype(void){
 	  }
 	}
 	//Apollo Lake
-	if (model == 12) { 
+	if (model == 12) {
 	  return &gotoblas_NEHALEM;
-	}	
+	}
 	return NULL;
       case 6:
         if (model == 6) {
@@ -514,9 +520,9 @@ static gotoblas_t *get_coretype(void){
 #endif
 	  else
 	  return &gotoblas_NEHALEM;
-#endif			
+#endif
         }
-        return NULL;  
+        return NULL;
       case 9:
       case 8:
 	if (model == 14 ) { // Kaby Lake
@@ -656,7 +662,7 @@ static char *corename[] = {
     "Steamroller",
     "Excavator",
     "Zen",
-    "SkylakeX"	
+    "SkylakeX"
 };
 
 char *gotoblas_corename(void) {
@@ -714,7 +720,7 @@ static gotoblas_t *force_coretype(char *coretype){
 
 	switch (found)
 	{
-		case 24: return (&gotoblas_SKYLAKEX);	
+		case 24: return (&gotoblas_SKYLAKEX);
 		case 23: return (&gotoblas_ZEN);
 		case 22: return (&gotoblas_EXCAVATOR);
 		case 21: return (&gotoblas_STEAMROLLER);

--- a/driver/others/memory.c
+++ b/driver/others/memory.c
@@ -163,9 +163,6 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define DESTRUCTOR	__attribute__ ((destructor))
 #endif
 
-#ifdef DYNAMIC_ARCH
-gotoblas_t *gotoblas = NULL;
-#endif
 extern void openblas_warning(int verbose, const char * msg);
 
 #ifndef SMP
@@ -421,10 +418,8 @@ int hugetlb_allocated = 0;
 
 #if defined(OS_WINDOWS)
 #define THREAD_LOCAL __declspec(thread)
-#define LIKELY_ONE(x) (x)
 #else
 #define THREAD_LOCAL __thread
-#define LIKELY_ONE(x) (__builtin_expect(x, 1))
 #endif
 
 /* Stores information about the allocation and how to release it */
@@ -1105,7 +1100,7 @@ void *blas_memory_alloc(int procpos){
   struct alloc_t * alloc_info;
   struct alloc_t ** alloc_table;
 
-  if (!LIKELY_ONE(memory_initialized)) {
+  if (!memory_initialized) {
 #if defined(SMP) && !defined(USE_OPENMP)
     /* Only allow a single thread to initialize memory system */
     LOCK_COMMAND(&alloc_lock);


### PR DESCRIPTION
It is possible to build a program that calls a non-GEMM OpenBLAS routine from
a static initializer. Since the order of initialization is undefined, and even
less defined when using __attribute__((constructor)) in one TU and a C++ static
initializer in another TU, it can happen (and does, unfortunately) that
gotoblas_init is not called before the first BLAS routine. This results in a
segfault when trying to index into the gotoblas table.

The solution I've put here is indirection: rather than directly using the table
use an inlined function to first check if it's been initialized. Since it will
only not have been done once, the branch prediction should keep things fast.