### PR TITLE
Fix wrong redefinitions of snprintf for older MSVC

### DIFF
--- a/driver/others/openblas_get_config.c
+++ b/driver/others/openblas_get_config.c
@@ -37,7 +37,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #if defined(_WIN32) && defined(_MSC_VER)
 #if _MSC_VER < 1900
-#define snprintf _snprintf_s
+#define snprintf _snprintf
 #endif
 #endif
 

--- a/utest/ctest.h
+++ b/utest/ctest.h
@@ -84,7 +84,7 @@ struct ctest {
 #endif
 
 #if _MSC_VER < 1900
-#define snprintf _snprintf_s
+#define snprintf _snprintf
 #endif
 
 #ifndef __cplusplus


### PR DESCRIPTION
_snprintf_s takes an additional argument as noted in #1677. I had blindly copied this from utest/ctest.h in #1678 but that (wrong) code never got compiled for MSVC due to various ifdefs.