### PR TITLE
Fix utest failures with the default MIPS64 target

### DIFF
--- a/KERNEL
+++ b/KERNEL
@@ -1,0 +1,168 @@
+CAXPYKERNEL = ../mips/zaxpy.c
+ZAXPYKERNEL = ../mips/zaxpy.c
+SROTKERNEL = ../mips/rot.c
+DROTKERNEL = ../mips/rot.c
+CROTKERNEL = ../mips/zrot.c
+ZROTKERNEL = ../mips/zrot.c
+CSWAPKERNEL = ../mips/zswap.c
+ZSWAPKERNEL = ../mips/zwap.c
+
+ifndef SNRM2KERNEL
+SNRM2KERNEL = snrm2.S
+endif
+
+ifndef DNRM2KERNEL
+DNRM2KERNEL = dnrm2.S
+endif
+
+ifndef CNRM2KERNEL
+CNRM2KERNEL = cnrm2.S
+endif
+
+ifndef ZNRM2KERNEL
+ZNRM2KERNEL = znrm2.S
+endif
+
+ifndef SCABS_KERNEL
+SCABS_KERNEL	= ../generic/cabs.c
+endif
+
+ifndef DCABS_KERNEL
+DCABS_KERNEL	= ../generic/cabs.c
+endif
+
+ifndef QCABS_KERNEL
+QCABS_KERNEL	= ../generic/cabs.c
+endif
+
+ifndef LSAME_KERNEL
+LSAME_KERNEL	= ../generic/lsame.c
+endif
+
+ifndef SGEMMKERNEL
+SGEMMKERNEL    =  gemm_kernel.S
+SGEMMINCOPY    = ../generic/gemm_ncopy_2.c
+SGEMMITCOPY    = ../generic/gemm_tcopy_2.c
+SGEMMONCOPY    = ../generic/gemm_ncopy_8.c
+SGEMMOTCOPY    = ../generic/gemm_tcopy_8.c
+SGEMMINCOPYOBJ =  sgemm_incopy.o
+SGEMMITCOPYOBJ =  sgemm_itcopy.o
+SGEMMONCOPYOBJ =  sgemm_oncopy.o
+SGEMMOTCOPYOBJ =  sgemm_otcopy.o
+endif
+
+ifndef DGEMMKERNEL
+DGEMMKERNEL    =  gemm_kernel.S
+DGEMMINCOPY    = ../generic/gemm_ncopy_2.c
+DGEMMITCOPY    = ../generic/gemm_tcopy_2.c
+DGEMMONCOPY    = ../generic/gemm_ncopy_8.c
+DGEMMOTCOPY    = ../generic/gemm_tcopy_8.c
+DGEMMINCOPYOBJ =  dgemm_incopy.o
+DGEMMITCOPYOBJ =  dgemm_itcopy.o
+DGEMMONCOPYOBJ =  dgemm_oncopy.o
+DGEMMOTCOPYOBJ =  dgemm_otcopy.o
+endif
+
+ifndef CGEMMKERNEL
+CGEMMKERNEL    =  zgemm_kernel.S
+CGEMMINCOPY    = ../generic/zgemm_ncopy_1.c
+CGEMMITCOPY    = ../generic/zgemm_tcopy_1.c
+CGEMMONCOPY    = ../generic/zgemm_ncopy_4.c
+CGEMMOTCOPY    = ../generic/zgemm_tcopy_4.c
+CGEMMINCOPYOBJ =  cgemm_incopy.o
+CGEMMITCOPYOBJ =  cgemm_itcopy.o
+CGEMMONCOPYOBJ =  cgemm_oncopy.o
+CGEMMOTCOPYOBJ =  cgemm_otcopy.o
+endif
+
+ifndef ZGEMMKERNEL
+ZGEMMKERNEL    =  zgemm_kernel.S
+ZGEMMINCOPY    = ../generic/zgemm_ncopy_1.c
+ZGEMMITCOPY    = ../generic/zgemm_tcopy_1.c
+ZGEMMONCOPY    = ../generic/zgemm_ncopy_4.c
+ZGEMMOTCOPY    = ../generic/zgemm_tcopy_4.c
+ZGEMMINCOPYOBJ =  zgemm_incopy.o
+ZGEMMITCOPYOBJ =  zgemm_itcopy.o
+ZGEMMONCOPYOBJ =  zgemm_oncopy.o
+ZGEMMOTCOPYOBJ =  zgemm_otcopy.o
+endif
+
+ifndef SGEMM_BETA
+SGEMM_BETA = ../generic/gemm_beta.c
+endif
+ifndef DGEMM_BETA
+DGEMM_BETA = ../generic/gemm_beta.c
+endif
+ifndef CGEMM_BETA
+CGEMM_BETA = ../generic/zgemm_beta.c
+endif
+ifndef ZGEMM_BETA
+ZGEMM_BETA = ../generic/zgemm_beta.c
+endif
+
+ifndef	STRSMKERNEL_LN
+STRSMKERNEL_LN	=  trsm_kernel_LN.S
+endif
+
+ifndef	STRSMKERNEL_LT
+STRSMKERNEL_LT	=  trsm_kernel_LT.S
+endif
+
+ifndef	STRSMKERNEL_RN
+STRSMKERNEL_RN	=  trsm_kernel_LT.S
+endif
+
+ifndef	STRSMKERNEL_RT
+STRSMKERNEL_RT	=  trsm_kernel_RT.S
+endif
+
+ifndef DTRSMKERNEL_LN
+DTRSMKERNEL_LN	=  trsm_kernel_LN.S
+endif
+
+ifndef DTRSMKERNEL_LT
+DTRSMKERNEL_LT	=  trsm_kernel_LT.S
+endif
+
+ifndef DTRSMKERNEL_RN
+DTRSMKERNEL_RN	=  trsm_kernel_LT.S
+endif
+
+ifndef DTRSMKERNEL_RT
+DTRSMKERNEL_RT	=  trsm_kernel_RT.S
+endif
+
+ifndef	CTRSMKERNEL_LN
+CTRSMKERNEL_LN	=  ztrsm_kernel_LT.S
+endif
+
+ifndef	CTRSMKERNEL_LT
+CTRSMKERNEL_LT	=  ztrsm_kernel_LT.S
+endif
+
+ifndef	CTRSMKERNEL_RN
+CTRSMKERNEL_RN	=  ztrsm_kernel_LT.S
+endif
+
+ifndef	CTRSMKERNEL_RT
+CTRSMKERNEL_RT	=  ztrsm_kernel_RT.S
+endif
+
+ifndef	ZTRSMKERNEL_LN
+ZTRSMKERNEL_LN	=  ztrsm_kernel_LT.S
+endif
+
+ifndef	ZTRSMKERNEL_LT
+ZTRSMKERNEL_LT	=  ztrsm_kernel_LT.S
+endif
+
+ifndef	ZTRSMKERNEL_RN
+ZTRSMKERNEL_RN	=  ztrsm_kernel_LT.S
+endif
+
+ifndef	ZTRSMKERNEL_RT
+ZTRSMKERNEL_RT	=  ztrsm_kernel_RT.S
+endif
+
+CGEMM3MKERNEL    =  zgemm3m_kernel.S
+ZGEMM3MKERNEL    =  zgemm3m_kernel.S

--- a/kernel/mips64/dot.S
+++ b/kernel/mips64/dot.S
@@ -103,35 +103,83 @@
 	.align 3
 
 .L12:
+#ifdef DSDOT
+cvt.d.s  a1, a1
+cvt.d.s  b1, b1  
+madd.d s1, s1, a1, b1
+#else
 	MADD	s1, s1, a1, b1
+#endif
 	LD	a1,  4 * SIZE(X)
 	LD	b1,  4 * SIZE(Y)
 
+#ifdef DSDOT
+cvt.d.s  a2, a2
+cvt.d.s  b2, b2
+madd.d s2, s2, a2, b2
+#else
 	MADD	s2, s2, a2, b2
+#endif
 	LD	a2,  5 * SIZE(X)
 	LD	b2,  5 * SIZE(Y)
 
+#ifdef DSDOT
+cvt.d.s  a3, a3
+cvt.d.s  b3, b3
+madd.d s1, s1, a3, b3
+#else
 	MADD	s1, s1, a3, b3
+#endif
 	LD	a3,  6 * SIZE(X)
 	LD	b3,  6 * SIZE(Y)
 
+#ifdef DSDOT
+cvt.d.s  a4, a4
+cvt.d.s  b4, b4
+madd.d s2, s2, a4, b4
+#else
 	MADD	s2, s2, a4, b4
+#endif
 	LD	a4,  7 * SIZE(X)
 	LD	b4,  7 * SIZE(Y)
 
+#ifdef DSDOT
+cvt.d.s  a1, a1
+cvt.d.s  b1, b1
+madd.d s1, s1, a1, b1
+#else
 	MADD	s1, s1, a1, b1
+#endif
 	LD	a1,  8 * SIZE(X)
 	LD	b1,  8 * SIZE(Y)
 
+#ifdef DSDOT
+cvt.d.s  a2, a2
+cvt.d.s  b2, b2
+madd.d s2, s2, a2, b2
+#else
 	MADD	s2, s2, a2, b2
+#endif
 	LD	a2,  9 * SIZE(X)
 	LD	b2,  9 * SIZE(Y)
 
+#ifdef DSDOT
+cvt.d.s  a3, a3
+cvt.d.s  b3, b3
+madd.d s1, s1, a3, b3
+#else
 	MADD	s1, s1, a3, b3
+#endif
 	LD	a3, 10 * SIZE(X)
 	LD	b3, 10 * SIZE(Y)
 
+#ifdef DSDOT
+cvt.d.s  a4, a4
+cvt.d.s  b4, b4
+madd.d s2, s2, a4, b4
+#else
 	MADD	s2, s2, a4, b4
+#endif
 	LD	a4, 11 * SIZE(X)
 	LD	b4, 11 * SIZE(Y)
 
@@ -143,29 +191,77 @@
 	.align 3
 
 .L13:
+#ifdef DSDOT
+cvt.d.s  a1, a1
+cvt.d.s  b1, b1
+madd.d s1, s1, a1, b1
+#else
 	MADD	s1, s1, a1, b1
+#endif
 	LD	a1,  4 * SIZE(X)
 	LD	b1,  4 * SIZE(Y)
 
+#ifdef DSDOT
+cvt.d.s a2, a2
+cvt.d.s b2, b2
+madd.d s2, s2, a2, b2
+#else
 	MADD	s2, s2, a2, b2
+#endif
 	LD	a2,  5 * SIZE(X)
 	LD	b2,  5 * SIZE(Y)
 
+#ifdef DSDOT
+cvt.d.s a3, a3 
+cvt.d.s b3, b3
+madd.d s1, s1, a3, b3
+#else
 	MADD	s1, s1, a3, b3
+#endif
 	LD	a3,  6 * SIZE(X)
 	LD	b3,  6 * SIZE(Y)
 
+#ifdef DSDOT
+cvt.d.s a4, a4
+cvt.d.s b4, b4
+madd.d s2, s2, a4, b4
+#else
 	MADD	s2, s2, a4, b4
+#endif
 	LD	a4,  7 * SIZE(X)
 	LD	b4,  7 * SIZE(Y)
 
+#ifdef DSDOT
+cvt.d.s  a1, a1
+cvt.d.s  b1, b1
+madd.d s1, s1, a1, b1
+#else
 	MADD	s1, s1, a1, b1
+#endif
 	daddiu	X, X, 8 * SIZE
+#ifdef DSDOT
+cvt.d.s  a2, a2
+cvt.d.s  b2, b2
+madd.d s2, s2, a2, b2
+#else
 	MADD	s2, s2, a2, b2
+#endif
 	daddiu	Y, Y, 8 * SIZE
 
+#ifdef DSDOT
+cvt.d.s  a3, a3
+cvt.d.s  b3, b3
+madd.d s1, s1, a3, b3
+#else
 	MADD	s1, s1, a3, b3
+#endif
+#ifdef DSDOT
+cvt.d.s  a4, a4
+cvt.d.s  b4, b4
+madd.d s2, s2, a4, b4
+#else
 	MADD	s2, s2, a4, b4
+#endif
 	.align 3
 
 .L15:
@@ -179,8 +275,13 @@
 	LD	a1,  0 * SIZE(X)
 	LD	b1,  0 * SIZE(Y)
 
+#ifdef DSDOT
+cvt.d.s  a1, a1
+cvt.d.s  b1, b1
+madd.d s1, s1, a1, b1
+#else
 	MADD	s1, s1, a1, b1
-
+#endif
 	daddiu	I, I, -1
 
 	daddiu	X, X, SIZE
@@ -225,50 +326,85 @@
 	LD	b1,  0 * SIZE(Y)
 	dadd	Y, Y, INCY
 
+#ifdef DSDOT
+cvt.d.s  a1, a1
+cvt.d.s  b1, b1
+madd.d s1, s1, a1, b1
+#else
 	MADD	s1, s1, a1, b1
-
+#endif
 	LD	a1,  0 * SIZE(X)
 	dadd	X, X, INCX
 	LD	b1,  0 * SIZE(Y)
 	dadd	Y, Y, INCY
 
+#ifdef DSDOT
+cvt.d.s  a1, a1
+cvt.d.s  b1, b1
+madd.d s2, s2, a1, b1
+#else
 	MADD	s2, s2, a1, b1
-
+#endif
 	LD	a1,  0 * SIZE(X)
 	dadd	X, X, INCX
 	LD	b1,  0 * SIZE(Y)
 	dadd	Y, Y, INCY
 
+#ifdef DSDOT
+cvt.d.s  a1, a1
+cvt.d.s  b1, b1
+madd.d s1, s1, a1, b1
+#else
 	MADD	s1, s1, a1, b1
-
+#endif
 	LD	a1,  0 * SIZE(X)
 	dadd	X, X, INCX
 	LD	b1,  0 * SIZE(Y)
 	dadd	Y, Y, INCY
 
+#ifdef DSDOT
+cvt.d.s  a1, a1
+cvt.d.s  b1, b1
+madd.d s2, s2, a1, b1
+#else
 	MADD	s2, s2, a1, b1
-
+#endif
 	LD	a1,  0 * SIZE(X)
 	dadd	X, X, INCX
 	LD	b1,  0 * SIZE(Y)
 	dadd	Y, Y, INCY
 
+#ifdef DSDOT
+cvt.d.s  a1, a1
+cvt.d.s  b1, b1
+madd.d s1, s1, a1, b1
+#else
 	MADD	s1, s1, a1, b1
-
+#endif
 	LD	a1,  0 * SIZE(X)
 	dadd	X, X, INCX
 	LD	b1,  0 * SIZE(Y)
 	dadd	Y, Y, INCY
 
+#ifdef DSDOT
+cvt.d.s  a1, a1
+cvt.d.s  b1, b1
+madd.d s2, s2, a1, b1
+#else
 	MADD	s2, s2, a1, b1
-
+#endif
 	LD	a1,  0 * SIZE(X)
 	dadd	X, X, INCX
 	LD	b1,  0 * SIZE(Y)
 	dadd	Y, Y, INCY
 
+#ifdef DSDOT
+cvt.d.s  a1, a1
+cvt.d.s  b1, b1
+madd.d s1, s1, a1, b1
+#else
 	MADD	s1, s1, a1, b1
-
+#endif
 	LD	a1,  0 * SIZE(X)
 	dadd	X, X, INCX
 	LD	b1,  0 * SIZE(Y)
@@ -277,7 +413,13 @@
 	daddiu	I, I, -1
 
 	bgtz	I, .L23
+#ifdef DSDOT
+cvt.d.s  a1, a1
+cvt.d.s  b1, b1
+madd.d s2, s2, a1, b1
+#else
 	MADD	s2, s2, a1, b1
+#endif
 	.align 3
 
 .L25:
@@ -296,13 +438,20 @@
 	daddiu	I, I, -1
 
 	bgtz	I, .L26
+#ifdef DSDOT
+cvt.d.s  a1, a1
+cvt.d.s  b1, b1
+madd.d s1, s1, a1, b1
+#else
 	MADD	s1, s1, a1, b1
+#endif
 	.align 3
 
 .L999:
-	ADD	s1, s1, s2
 #ifdef DSDOT
-	cvt.d.s s1, s1
+	add.d s1, s1, s2
+#else
+	ADD	s1, s1, s2
 #endif
 	j	$31
 	NOP


### PR DESCRIPTION
fixes (or works around) #1672 by retiring most of the affected (original GotoBLAS) kernels in favor of the generic C implementations that are already used by the I6400, I6500 and P6600 targets. Adds argument
promotion to dot.S in DSDOT mode to avoid loss of precision.