### PR TITLE
Unset memory table entry, not just the local pointer to it on shutdown

### DIFF
--- a/driver/others/memory.c
+++ b/driver/others/memory.c
@@ -1279,7 +1279,7 @@ void blas_shutdown(void){
       struct alloc_t *alloc_info = local_memory_table[thread][pos];
       if (alloc_info) {
         alloc_info->release_func(alloc_info);
-        alloc_info = (void *)0;
+        local_memory_table[thread][pos] = (void *)0;
       }
     }
   }


### PR DESCRIPTION
fixes crash with multiple instances of OpenBLAS, patch from changyp6 in issue #1692