### PR TITLE
fabs -> fabsl

### DIFF
--- a/interface/rotg.c
+++ b/interface/rotg.c
@@ -22,8 +22,8 @@ void CNAME(FLOAT *DA, FLOAT *DB, FLOAT *C, FLOAT *S){
   long double s;
   long double r, roe, z;
 
-  long double ada = fabs(da);
-  long double adb = fabs(db);
+  long double ada = fabsl(da);
+  long double adb = fabsl(db);
   long double scale = ada + adb;
 
 #ifndef CBLAS

--- a/interface/zrotg.c
+++ b/interface/zrotg.c
@@ -14,7 +14,7 @@ void NAME(FLOAT *DA, FLOAT *DB, FLOAT *C, FLOAT *S){
   long double db_i = *(DB + 1);
   long double r;
 
-  long double ada = fabs(da_r) + fabs(da_i);
+  long double ada = fabsl(da_r) + fabsl(da_i);
 
   PRINT_DEBUG_NAME;
 


### PR DESCRIPTION
Fixes two calls that were using `fabs` on a `long double` argument rather than `fabsl`, which looks like it is doing an unintentional truncation to `double` precision.