### PR TITLE
replace several assembly implementations with an intrinsics based implementation and add AVX512

### DIFF
--- a/kernel/x86_64/ddot_microk_haswell-2.c
+++ b/kernel/x86_64/ddot_microk_haswell-2.c
@@ -43,18 +43,18 @@ static void ddot_kernel_8( BLASLONG n, FLOAT *x, FLOAT *y, FLOAT *dot)
 
 	".p2align 4				             \n\t"
 	"1:				             \n\t"
-        "vmovups                  (%2,%0,8), %%ymm12         \n\t"  // 2 * x
-        "vmovups                32(%2,%0,8), %%ymm13         \n\t"  // 2 * x
-        "vmovups                64(%2,%0,8), %%ymm14         \n\t"  // 2 * x
-        "vmovups                96(%2,%0,8), %%ymm15         \n\t"  // 2 * x
+        "vmovups                  (%[x],%[i],8), %%ymm12         \n\t"  // 2 * x
+        "vmovups                32(%[x],%[i],8), %%ymm13         \n\t"  // 2 * x
+        "vmovups                64(%[x],%[i],8), %%ymm14         \n\t"  // 2 * x
+        "vmovups                96(%[x],%[i],8), %%ymm15         \n\t"  // 2 * x
 
-	"vfmadd231pd      (%3,%0,8), %%ymm12, %%ymm4 \n\t"  // 2 * y
-	"vfmadd231pd    32(%3,%0,8), %%ymm13, %%ymm5 \n\t"  // 2 * y
-	"vfmadd231pd    64(%3,%0,8), %%ymm14, %%ymm6 \n\t"  // 2 * y
-	"vfmadd231pd    96(%3,%0,8), %%ymm15, %%ymm7 \n\t"  // 2 * y
+	"vfmadd231pd      (%[y],%[i],8), %%ymm12, %%ymm4 \n\t"  // 2 * y
+	"vfmadd231pd    32(%[y],%[i],8), %%ymm13, %%ymm5 \n\t"  // 2 * y
+	"vfmadd231pd    64(%[y],%[i],8), %%ymm14, %%ymm6 \n\t"  // 2 * y
+	"vfmadd231pd    96(%[y],%[i],8), %%ymm15, %%ymm7 \n\t"  // 2 * y
 
-	"addq		$16 , %0	  	     \n\t"
-	"subq	        $16 , %1		     \n\t"		
+	"addq		$16 , %[i]	  	     \n\t"
+	"subq	        $16 , %[n]		     \n\t"		
 	"jnz		1b		             \n\t"
 
 	"vextractf128	$1 , %%ymm4 , %%xmm12	     \n\t"
@@ -73,16 +73,16 @@ static void ddot_kernel_8( BLASLONG n, FLOAT *x, FLOAT *y, FLOAT *dot)
 
 	"vhaddpd        %%xmm4, %%xmm4, %%xmm4	\n\t"
 
-	"vmovsd		%%xmm4,    (%4)		\n\t"
+	"vmovsd		%%xmm4,    (%[dot])		\n\t"
 	"vzeroupper				\n\t"
 
 	:
         : 
-          "r" (i),	// 0	
-	  "r" (n),  	// 1
-          "r" (x),      // 2
-          "r" (y),      // 3
-          "r" (dot)     // 4
+          [i] "r" (i),	// 0	
+	  [n] "r" (n),  	// 1
+          [x] "r" (x),      // 2
+          [y] "r" (y),      // 3
+          [dot] "r" (dot)     // 4
 	: "cc", 
 	  "%xmm4", "%xmm5", 
 	  "%xmm6", "%xmm7", 

--- a/kernel/x86_64/ddot_microk_haswell-2.c
+++ b/kernel/x86_64/ddot_microk_haswell-2.c
@@ -25,71 +25,48 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *****************************************************************************/
 
+/* Ensure that the compiler knows how to generate AVX2 instructions if it doesn't already */
+#ifndef __AVX512CD_
+#pragma GCC target("avx2,fma")
+#endif
+
+#ifdef __AVX2__
+
 #define HAVE_KERNEL_8 1
+
+#include <immintrin.h>
 static void ddot_kernel_8( BLASLONG n, FLOAT *x, FLOAT *y , FLOAT *dot) __attribute__ ((noinline));
 
 static void ddot_kernel_8( BLASLONG n, FLOAT *x, FLOAT *y, FLOAT *dot)
 {
+	int i = 0;
+	__m256d accum_0, accum_1, accum_2, accum_3;
+	
+	accum_0 = _mm256_setzero_pd();
+	accum_1 = _mm256_setzero_pd();
+	accum_2 = _mm256_setzero_pd();
+	accum_3 = _mm256_setzero_pd();
 
+	for (; i < n; i += 16) {
+		accum_0 += _mm256_loadu_pd(&x[i+ 0]) * _mm256_loadu_pd(&y[i+0]);
+		accum_1 += _mm256_loadu_pd(&x[i+ 4]) * _mm256_loadu_pd(&y[i+4]);
+		accum_2 += _mm256_loadu_pd(&x[i+ 8]) * _mm256_loadu_pd(&y[i+8]);
+		accum_3 += _mm256_loadu_pd(&x[i+12]) * _mm256_loadu_pd(&y[i+12]);
+	}
 
-	BLASLONG register i = 0;
+	/* we now have the partial sums of the dot product in the 4 accumulation vectors, time to consolidate */
 
-	__asm__  __volatile__
-	(
-	"vxorpd		%%ymm4, %%ymm4, %%ymm4	             \n\t"
-	"vxorpd		%%ymm5, %%ymm5, %%ymm5	             \n\t"
-	"vxorpd		%%ymm6, %%ymm6, %%ymm6	             \n\t"
-	"vxorpd		%%ymm7, %%ymm7, %%ymm7	             \n\t"
+	accum_0 = accum_0 + accum_1 + accum_2 + accum_3;
 
-	".p2align 4				             \n\t"
-	"1:				             \n\t"
-        "vmovups                  (%[x],%[i],8), %%ymm12         \n\t"  // 2 * x
-        "vmovups                32(%[x],%[i],8), %%ymm13         \n\t"  // 2 * x
-        "vmovups                64(%[x],%[i],8), %%ymm14         \n\t"  // 2 * x
-        "vmovups                96(%[x],%[i],8), %%ymm15         \n\t"  // 2 * x
+	__m128d half_accum0;
 
-	"vfmadd231pd      (%[y],%[i],8), %%ymm12, %%ymm4 \n\t"  // 2 * y
-	"vfmadd231pd    32(%[y],%[i],8), %%ymm13, %%ymm5 \n\t"  // 2 * y
-	"vfmadd231pd    64(%[y],%[i],8), %%ymm14, %%ymm6 \n\t"  // 2 * y
-	"vfmadd231pd    96(%[y],%[i],8), %%ymm15, %%ymm7 \n\t"  // 2 * y
+	/* Add upper half to lower half of each of the 256 bit vector to get a 128 bit vector */
+	half_accum0 = _mm_add_pd(_mm256_extractf128_pd(accum_0, 0), _mm256_extractf128_pd(accum_0, 1));
 
-	"addq		$16 , %[i]	  	     \n\t"
-	"subq	        $16 , %[n]		     \n\t"		
-	"jnz		1b		             \n\t"
+	/* in 128 bit land there is a hadd operation to do the rest of the element-wise sum in one go */
+	half_accum0 = _mm_hadd_pd(half_accum0, half_accum0);
 
-	"vextractf128	$1 , %%ymm4 , %%xmm12	     \n\t"
-	"vextractf128	$1 , %%ymm5 , %%xmm13	     \n\t"
-	"vextractf128	$1 , %%ymm6 , %%xmm14	     \n\t"
-	"vextractf128	$1 , %%ymm7 , %%xmm15	     \n\t"
+	*dot = half_accum0[0];
+}
 
-	"vaddpd        %%xmm4, %%xmm12, %%xmm4	\n\t"
-	"vaddpd        %%xmm5, %%xmm13, %%xmm5	\n\t"
-	"vaddpd        %%xmm6, %%xmm14, %%xmm6	\n\t"
-	"vaddpd        %%xmm7, %%xmm15, %%xmm7	\n\t"
-
-	"vaddpd        %%xmm4, %%xmm5, %%xmm4	\n\t"
-	"vaddpd        %%xmm6, %%xmm7, %%xmm6	\n\t"
-	"vaddpd        %%xmm4, %%xmm6, %%xmm4	\n\t"
-
-	"vhaddpd        %%xmm4, %%xmm4, %%xmm4	\n\t"
-
-	"vmovsd		%%xmm4,    (%[dot])		\n\t"
-	"vzeroupper				\n\t"
-
-	:
-        : 
-          [i] "r" (i),	// 0	
-	  [n] "r" (n),  	// 1
-          [x] "r" (x),      // 2
-          [y] "r" (y),      // 3
-          [dot] "r" (dot)     // 4
-	: "cc", 
-	  "%xmm4", "%xmm5", 
-	  "%xmm6", "%xmm7", 
-	  "%xmm12", "%xmm13", "%xmm14", "%xmm15",
-	  "memory"
-	);
-
-} 
-
-
+#endif

--- a/kernel/x86_64/dgemv_n_microk_haswell-4.c
+++ b/kernel/x86_64/dgemv_n_microk_haswell-4.c
@@ -25,7 +25,7 @@ OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *****************************************************************************/
 
-/* Ensure that the compiler knows how to generate AVX2 instructions if it doesn't already*/
+/* Ensure that the compiler knows how to generate AVX2 instructions if it doesn't already */
 #ifndef __AVX512CD_
 #pragma GCC target("avx2,fma")
 #endif
@@ -68,17 +68,13 @@ static void dgemv_kernel_4x4( BLASLONG n, FLOAT **ap, FLOAT *x, FLOAT *y, FLOAT 
 		__m512d tempY;
 		__m512d sum;
 
-		sum = _mm512_add_pd(
-				_mm512_add_pd(
-					_mm512_mul_pd(_mm512_loadu_pd(&ap[0][i]), x05),
-					_mm512_mul_pd(_mm512_loadu_pd(&ap[1][i]), x15)),
-				_mm512_add_pd(
-					_mm512_mul_pd(_mm512_loadu_pd(&ap[2][i]), x25),
-					_mm512_mul_pd(_mm512_loadu_pd(&ap[3][i]), x35))
-			);
+		sum = _mm512_loadu_pd(&ap[0][i]) * x05 +
+		      _mm512_loadu_pd(&ap[1][i]) * x15 +
+		      _mm512_loadu_pd(&ap[2][i]) * x25 +
+		      _mm512_loadu_pd(&ap[3][i]) * x35;
 
 		tempY = _mm512_loadu_pd(&y[i]);
-		tempY = _mm512_add_pd(tempY, _mm512_mul_pd(sum, __alpha5));
+		tempY += sum *  __alpha5;
 		_mm512_storeu_pd(&y[i], tempY);
 	}
 #endif
@@ -87,17 +83,13 @@ static void dgemv_kernel_4x4( BLASLONG n, FLOAT **ap, FLOAT *x, FLOAT *y, FLOAT 
 		__m256d tempY;
 		__m256d sum;
 
-		sum = _mm256_add_pd(
-				_mm256_add_pd(
-					_mm256_mul_pd(_mm256_loadu_pd(&ap[0][i]), x0),
-					_mm256_mul_pd(_mm256_loadu_pd(&ap[1][i]), x1)),
-				_mm256_add_pd(
-					_mm256_mul_pd(_mm256_loadu_pd(&ap[2][i]), x2),
-					_mm256_mul_pd(_mm256_loadu_pd(&ap[3][i]), x3))
-			);
+		sum = _mm256_loadu_pd(&ap[0][i]) * x0 +
+		      _mm256_loadu_pd(&ap[1][i]) * x1 +
+		      _mm256_loadu_pd(&ap[2][i]) * x2 +
+		      _mm256_loadu_pd(&ap[3][i]) * x3;
 
 		tempY = _mm256_loadu_pd(&y[i]);
-		tempY = _mm256_add_pd(tempY, _mm256_mul_pd(sum, __alpha));
+		tempY += sum *  __alpha;
 		_mm256_storeu_pd(&y[i], tempY);
 	}
 
@@ -124,13 +116,10 @@ static void dgemv_kernel_4x2( BLASLONG n, FLOAT **ap, FLOAT *x, FLOAT *y, FLOAT 
 		__m256d tempY;
 		__m256d sum;
 
-		sum = _mm256_add_pd(
-				_mm256_mul_pd(_mm256_loadu_pd(&ap[0][i]), x0),
-				_mm256_mul_pd(_mm256_loadu_pd(&ap[1][i]), x1)
-			);
+		sum = _mm256_loadu_pd(&ap[0][i]) * x0 + _mm256_loadu_pd(&ap[1][i]) * x1;
 
 		tempY = _mm256_loadu_pd(&y[i]);
-		tempY = _mm256_add_pd(tempY, _mm256_mul_pd(sum, __alpha));
+		tempY +=  sum *  __alpha;
 		_mm256_storeu_pd(&y[i], tempY);
 	}
 

--- a/kernel/x86_64/dsymv_L_microk_haswell-2.c
+++ b/kernel/x86_64/dsymv_L_microk_haswell-2.c
@@ -27,7 +27,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 /* Ensure that the compiler knows how to generate AVX2 instructions if it doesn't already */
-#ifndef __AVX512CD_
+#ifndef __AVX512CD__
 #pragma GCC target("avx2,fma")
 #endif
 

--- a/kernel/x86_64/saxpy_microk_haswell-2.c
+++ b/kernel/x86_64/saxpy_microk_haswell-2.c
@@ -52,43 +52,19 @@ static void saxpy_kernel_16( BLASLONG n, FLOAT *x, FLOAT *y, FLOAT *alpha)
 	n64 = n & ~63;
 
 	for (; i < n64; i+= 64) {
-		__m512 y0, y16, y32, y48;
-
-		y0  = _mm512_loadu_ps(&y[i +  0]);
-		y16 = _mm512_loadu_ps(&y[i + 16]);
-		y32 = _mm512_loadu_ps(&y[i + 32]);
-		y48 = _mm512_loadu_ps(&y[i + 48]);
-
-		y0  += __alpha5 * _mm512_loadu_ps(&x[i +  0]);
-		y16 += __alpha5 * _mm512_loadu_ps(&x[i + 16]);
-		y32 += __alpha5 * _mm512_loadu_ps(&x[i + 32]);
-		y48 += __alpha5 * _mm512_loadu_ps(&x[i + 48]);
-
-		_mm512_storeu_ps(&y[i +  0], y0);
-		_mm512_storeu_ps(&y[i + 16], y16);
-		_mm512_storeu_ps(&y[i + 32], y32);
-		_mm512_storeu_ps(&y[i + 48], y48);
+		_mm512_storeu_ps(&y[i +  0], _mm512_loadu_ps(&y[i +  0]) + __alpha5 * _mm512_loadu_ps(&x[i +  0]));
+		_mm512_storeu_ps(&y[i + 16], _mm512_loadu_ps(&y[i + 16]) + __alpha5 * _mm512_loadu_ps(&x[i + 16]));
+		_mm512_storeu_ps(&y[i + 32], _mm512_loadu_ps(&y[i + 32]) + __alpha5 * _mm512_loadu_ps(&x[i + 32]));
+		_mm512_storeu_ps(&y[i + 48], _mm512_loadu_ps(&y[i + 48]) + __alpha5 * _mm512_loadu_ps(&x[i + 48]));
 	}
 
 #endif
 
 	for (; i < n; i+= 32) {
-		__m256 y0, y8, y16, y24;
-
-		y0  = _mm256_loadu_ps(&y[i +  0]);
-		y8  = _mm256_loadu_ps(&y[i +  8]);
-		y16 = _mm256_loadu_ps(&y[i + 16]);
-		y24 = _mm256_loadu_ps(&y[i + 24]);
-
-		y0  += __alpha * _mm256_loadu_ps(&x[i +  0]);
-		y8  += __alpha * _mm256_loadu_ps(&x[i +  8]);
-		y16 += __alpha * _mm256_loadu_ps(&x[i + 16]);
-		y24 += __alpha * _mm256_loadu_ps(&x[i + 24]);
-
-		_mm256_storeu_ps(&y[i +  0], y0);
-		_mm256_storeu_ps(&y[i +  8], y8);
-		_mm256_storeu_ps(&y[i + 16], y16);
-		_mm256_storeu_ps(&y[i + 24], y24);
+		_mm256_storeu_ps(&y[i +  0], _mm256_loadu_ps(&y[i +  0]) + __alpha * _mm256_loadu_ps(&x[i +  0]));
+		_mm256_storeu_ps(&y[i +  8], _mm256_loadu_ps(&y[i +  8]) + __alpha * _mm256_loadu_ps(&x[i +  8]));
+		_mm256_storeu_ps(&y[i + 16], _mm256_loadu_ps(&y[i + 16]) + __alpha * _mm256_loadu_ps(&x[i + 16]));
+		_mm256_storeu_ps(&y[i + 24], _mm256_loadu_ps(&y[i + 24]) + __alpha * _mm256_loadu_ps(&x[i + 24]));
 	}
 }
 #endif

--- a/kernel/x86_64/saxpy_microk_haswell-2.c
+++ b/kernel/x86_64/saxpy_microk_haswell-2.c
@@ -44,6 +44,34 @@ static void saxpy_kernel_16( BLASLONG n, FLOAT *x, FLOAT *y, FLOAT *alpha)
 
 	__alpha =  _mm256_broadcastss_ps(_mm_load_ss(alpha));
 
+#ifdef __AVX512CD__
+	BLASLONG n64;
+	__m512 __alpha5;
+	__alpha5 = _mm512_broadcastss_ps(_mm_load_ss(alpha));
+
+	n64 = n & ~63;
+
+	for (; i < n64; i+= 64) {
+		__m512 y0, y16, y32, y48;
+
+		y0  = _mm512_loadu_ps(&y[i +  0]);
+		y16 = _mm512_loadu_ps(&y[i + 16]);
+		y32 = _mm512_loadu_ps(&y[i + 32]);
+		y48 = _mm512_loadu_ps(&y[i + 48]);
+
+		y0  += __alpha5 * _mm512_loadu_ps(&x[i +  0]);
+		y16 += __alpha5 * _mm512_loadu_ps(&x[i + 16]);
+		y32 += __alpha5 * _mm512_loadu_ps(&x[i + 32]);
+		y48 += __alpha5 * _mm512_loadu_ps(&x[i + 48]);
+
+		_mm512_storeu_ps(&y[i +  0], y0);
+		_mm512_storeu_ps(&y[i + 16], y16);
+		_mm512_storeu_ps(&y[i + 32], y32);
+		_mm512_storeu_ps(&y[i + 48], y48);
+	}
+
+#endif
+
 	for (; i < n; i+= 32) {
 		__m256 y0, y8, y16, y24;
 

--- a/kernel/x86_64/saxpy_microk_haswell-2.c
+++ b/kernel/x86_64/saxpy_microk_haswell-2.c
@@ -36,36 +36,36 @@ static void saxpy_kernel_16( BLASLONG n, FLOAT *x, FLOAT *y, FLOAT *alpha)
 
 	__asm__  __volatile__
 	(
-	"vbroadcastss		(%4), %%ymm0		    \n\t"  // alpha	
+	"vbroadcastss		(%[alpha]), %%ymm0		\n\t"  // alpha	
 
-	".p2align 4				            \n\t"
-	"1:				            \n\t"
+	".p2align 4				         	\n\t"
+	"1:				            		\n\t"
 
-        "vmovups                  (%3,%0,4), %%ymm12         \n\t"  // 8 * y
-        "vmovups                32(%3,%0,4), %%ymm13         \n\t"  // 8 * y
-        "vmovups                64(%3,%0,4), %%ymm14         \n\t"  // 8 * y
-        "vmovups                96(%3,%0,4), %%ymm15         \n\t"  // 8 * y
-	"vfmadd231ps       (%2,%0,4), %%ymm0  , %%ymm12  	     \n\t"   // y += alpha * x
-	"vfmadd231ps     32(%2,%0,4), %%ymm0  , %%ymm13  	     \n\t"   // y += alpha * x
-	"vfmadd231ps     64(%2,%0,4), %%ymm0  , %%ymm14  	     \n\t"   // y += alpha * x
-	"vfmadd231ps     96(%2,%0,4), %%ymm0  , %%ymm15  	     \n\t"   // y += alpha * x
-	"vmovups	%%ymm12,   (%3,%0,4)		     \n\t"
-	"vmovups	%%ymm13, 32(%3,%0,4)		     \n\t"
-	"vmovups	%%ymm14, 64(%3,%0,4)		     \n\t"
-	"vmovups	%%ymm15, 96(%3,%0,4)		     \n\t"
+        "vmovups                  (%[y],%[i],4), %%ymm12         \n\t"  // 8 * y
+        "vmovups                32(%[y],%[i],4), %%ymm13         \n\t"  // 8 * y
+        "vmovups                64(%[y],%[i],4), %%ymm14         \n\t"  // 8 * y
+        "vmovups                96(%[y],%[i],4), %%ymm15         \n\t"  // 8 * y
+	"vfmadd231ps       (%[x],%[i],4), %%ymm0  , %%ymm12  	     \n\t"   // y += alpha * x
+	"vfmadd231ps     32(%[x],%[i],4), %%ymm0  , %%ymm13  	     \n\t"   // y += alpha * x
+	"vfmadd231ps     64(%[x],%[i],4), %%ymm0  , %%ymm14  	     \n\t"   // y += alpha * x
+	"vfmadd231ps     96(%[x],%[i],4), %%ymm0  , %%ymm15  	     \n\t"   // y += alpha * x
+	"vmovups	%%ymm12,   (%[y],%[i],4)		     \n\t"
+	"vmovups	%%ymm13, 32(%[y],%[i],4)		     \n\t"
+	"vmovups	%%ymm14, 64(%[y],%[i],4)		     \n\t"
+	"vmovups	%%ymm15, 96(%[y],%[i],4)		     \n\t"
 
-	"addq		$32, %0	  	 	             \n\t"
-	"subq	        $32, %1			             \n\t"		
+	"addq		$32, %[i]  	 	             \n\t"
+	"subq	        $32, %[n]		             \n\t"		
 	"jnz		1b		             \n\t"
 	"vzeroupper				     \n\t"
 
 	:
         : 
-          "r" (i),	// 0	
-	  "r" (n),  	// 1
-          "r" (x),      // 2
-          "r" (y),      // 3
-          "r" (alpha)   // 4
+          [i] "r" (i),	// 0	
+	  [n] "r" (n),  // 1
+          [x] "r" (x),  // 2
+          [y] "r" (y),  // 3
+          [alpha] "r" (alpha)   // 4
 	: "cc", 
 	  "%xmm0", 
 	  "%xmm8", "%xmm9", "%xmm10", "%xmm11", 


### PR DESCRIPTION
This patch series does, for a range of algorithms the following

Step 1: Replace "evil" gcc inline asm syntax with %0/%1 etc with named variables (%[name[) to make the assembly more readable
Step 2: Replace the now-readable assembly construct with the same algorithm written using C intrinsics
Step 3: Add AVX512 support to the now easier-to-change C intrinsics version

C intrinsics compile to pretty much the same code as the assembly version, but it lets the compiler do register allocation, but more importantly, it makes the non-math part of the code much easier to understand in terms of what is going on and is less fragile in general.