### PR TITLE
fix blasabs for windows

### DIFF
--- a/common.h
+++ b/common.h
@@ -257,7 +257,11 @@ typedef unsigned long BLASULONG;
 
 #ifdef USE64BITINT
 typedef BLASLONG blasint;
+#if defined(OS_WINDOWS) && defined(__64BIT__)
+#define blasabs(x) llabs(x)
+#else
 #define blasabs(x) labs(x)
+#endif
 #else
 typedef int blasint;
 #define blasabs(x) abs(x)


### PR DESCRIPTION
Bugfix in #1713 for Windows (LLP64), where `blasabs` needs to be `llabs` rather than `labs` for the 64-bit API.