### PR TITLE
Add workaround for avx512 compilations on Cygwin

### DIFF
--- a/Makefile.x86_64
+++ b/Makefile.x86_64
@@ -12,6 +12,9 @@ ifeq ($(CORE), SKYLAKEX)
 ifndef NO_AVX512
 CCOMMON_OPT += -march=skylake-avx512
 FCOMMON_OPT += -march=skylake-avx512
+ifeq ($(OSNAME), CYGWIN_NT)
+CCOMMON_OPT += -fno-asynchronous-unwind-tables
+endif
 endif
 endif
 


### PR DESCRIPTION
fixes #1708