### PR TITLE
Set USE_TRMM for all ZARCH variants to fix TRMM faults with zarch-gen…

### DIFF
--- a/kernel/Makefile.L3
+++ b/kernel/Makefile.L3
@@ -44,7 +44,7 @@ ifeq ($(CORE), POWER8)
 USE_TRMM = 1
 endif
 
-ifeq ($(CORE), Z13)
+ifeq ($(ARCH), zarch)
 USE_TRMM = 1
 endif
 


### PR DESCRIPTION
…eric

fixes #1743