### PR TITLE
fix small typo in strmm_ LN

### DIFF
--- a/kernel/generic/trmm_lncopy_16.c
+++ b/kernel/generic/trmm_lncopy_16.c
@@ -661,7 +661,7 @@ int CNAME(BLASLONG m, BLASLONG n, FLOAT *a, BLASLONG lda, BLASLONG posX, BLASLON
 	      b[  9] = ZERO;
 	      b[ 10] = ZERO;
 	      b[ 11] = ZERO;
-	      b[ 11] = ZERO;
+	      b[ 12] = ZERO;
 	      b[ 13] = ZERO;
 	      b[ 14] = ZERO;
 	      b[ 15] = ZERO;


### PR DESCRIPTION
Fix small old typo that affects SANDYBRIDGE BULLDOZER PILEDRIVER STREAMROLLER EXCAVATOR HASWELL ZEN SKYLAKEX strmm_ and via this [some lapack](http://www.netlib.org/lapack/explore-html/db/dc9/group__single__blas__level3_ga5a8ec25aba550c224cf6941fca7a2c98_ga5a8ec25aba550c224cf6941fca7a2c98_icgraph.svg)