### PR TITLE
Remove an unused variable from several LAPACKE 2stage_work functions

### DIFF
--- a/lapack-netlib/LAPACKE/src/lapacke_dsytrf_aa_2stage_work.c
+++ b/lapack-netlib/LAPACKE/src/lapacke_dsytrf_aa_2stage_work.c
@@ -50,7 +50,6 @@ lapack_int LAPACKE_dsytrf_aa_2stage_work( int matrix_layout, char uplo, lapack_i
         }
     } else if( matrix_layout == LAPACK_ROW_MAJOR ) {
         lapack_int lda_t = MAX(1,n);
-        lapack_int ldb_t = MAX(1,n);
         double* a_t = NULL;
         double* tb_t = NULL;
         /* Check leading dimension(s) */

--- a/lapack-netlib/LAPACKE/src/lapacke_zhetrf_aa_2stage_work.c
+++ b/lapack-netlib/LAPACKE/src/lapacke_zhetrf_aa_2stage_work.c
@@ -50,7 +50,6 @@ lapack_int LAPACKE_zhetrf_aa_2stage_work( int matrix_layout, char uplo, lapack_i
         }
     } else if( matrix_layout == LAPACK_ROW_MAJOR ) {
         lapack_int lda_t = MAX(1,n);
-        lapack_int ldb_t = MAX(1,n);
         lapack_complex_double* a_t = NULL;
         lapack_complex_double* tb_t = NULL;
         /* Check leading dimension(s) */

--- a/lapack-netlib/LAPACKE/src/lapacke_zsytrf_aa_2stage_work.c
+++ b/lapack-netlib/LAPACKE/src/lapacke_zsytrf_aa_2stage_work.c
@@ -50,7 +50,6 @@ lapack_int LAPACKE_zsytrf_aa_2stage_work( int matrix_layout, char uplo, lapack_i
         }
     } else if( matrix_layout == LAPACK_ROW_MAJOR ) {
         lapack_int lda_t = MAX(1,n);
-        lapack_int ldb_t = MAX(1,n);
         lapack_complex_double* a_t = NULL;
         lapack_complex_double* tb_t = NULL;
         /* Check leading dimension(s) */


### PR DESCRIPTION
Copied from https://github.com/Reference-LAPACK/lapack/pull/283 to fix a few warnings