### PR TITLE
remove unused 'levelness' parameter from num_cpu_avail()

### DIFF
--- a/common_thread.h
+++ b/common_thread.h
@@ -129,7 +129,7 @@ typedef struct blas_queue {
 
 extern int blas_server_avail;
 
-static __inline int num_cpu_avail(int level) {
+static __inline int num_cpu_avail(void) {
 
 #ifdef USE_OPENMP
 	int openmp_nthreads=0;

--- a/interface/axpy.c
+++ b/interface/axpy.c
@@ -91,7 +91,7 @@ void CNAME(blasint n, FLOAT alpha, FLOAT *x, blasint incx, FLOAT *y, blasint inc
   if (incx == 0 || incy == 0 || n <= MULTI_THREAD_MINIMAL)
 	  nthreads = 1;
   else
-	  nthreads = num_cpu_avail(1);
+	  nthreads = num_cpu_avail();
 
   if (nthreads == 1) {
 #endif

--- a/interface/gbmv.c
+++ b/interface/gbmv.c
@@ -227,7 +227,7 @@ void CNAME(enum CBLAS_ORDER order,
   buffer = (FLOAT *)blas_memory_alloc(1);
 
 #ifdef SMP
-  nthreads = num_cpu_avail(2);
+  nthreads = num_cpu_avail();
 
   if (nthreads == 1) {
 #endif

--- a/interface/gemm.c
+++ b/interface/gemm.c
@@ -413,7 +413,7 @@ void CNAME(enum CBLAS_ORDER order, enum CBLAS_TRANSPOSE TransA, enum CBLAS_TRANS
   if ( MNK <= (SMP_THRESHOLD_MIN  * (double) GEMM_MULTITHREAD_THRESHOLD)  )
 	args.nthreads = 1;
   else
-	args.nthreads = num_cpu_avail(3);
+	args.nthreads = num_cpu_avail();
   args.common = NULL;
 
  if (args.nthreads == 1) {

--- a/interface/gemv.c
+++ b/interface/gemv.c
@@ -223,7 +223,7 @@ void CNAME(enum CBLAS_ORDER order,
   if ( 1L * m * n < 2304L * GEMM_MULTITHREAD_THRESHOLD )
     nthreads = 1;
   else
-    nthreads = num_cpu_avail(2);
+    nthreads = num_cpu_avail();
 
   if (nthreads == 1) {
 #endif

--- a/interface/ger.c
+++ b/interface/ger.c
@@ -176,7 +176,7 @@ void CNAME(enum CBLAS_ORDER order,
 #ifdef SMPTEST
   // Threshold chosen so that speed-up is > 1 on a Xeon E5-2630
   if(1L * m * n > 2048L * GEMM_MULTITHREAD_THRESHOLD)
-    nthreads = num_cpu_avail(2);
+    nthreads = num_cpu_avail();
   else
     nthreads = 1;
 

--- a/interface/lapack/gesv.c
+++ b/interface/lapack/gesv.c
@@ -114,7 +114,7 @@ int NAME(blasint *N, blasint *NRHS, FLOAT *a, blasint *ldA, blasint *ipiv,
 
 #ifdef SMP
   args.common = NULL;
-  args.nthreads = num_cpu_avail(4);
+  args.nthreads = num_cpu_avail();
 
   if (args.nthreads == 1) {
 #endif

--- a/interface/lapack/getrf.c
+++ b/interface/lapack/getrf.c
@@ -95,7 +95,7 @@ int NAME(blasint *M, blasint *N, FLOAT *a, blasint *ldA, blasint *ipiv, blasint 
 
 #ifdef SMP
   args.common = NULL;
-  args.nthreads = num_cpu_avail(4);
+  args.nthreads = num_cpu_avail();
 
   if (args.nthreads == 1) {
 #endif

--- a/interface/lapack/getrs.c
+++ b/interface/lapack/getrs.c
@@ -126,7 +126,7 @@ int NAME(char *TRANS, blasint *N, blasint *NRHS, FLOAT *a, blasint *ldA,
 
 #ifdef SMP
   args.common = NULL;
-  args.nthreads = num_cpu_avail(4);
+  args.nthreads = num_cpu_avail();
 
   if (args.nthreads == 1) {
 #endif

--- a/interface/lapack/laswp.c
+++ b/interface/lapack/laswp.c
@@ -77,7 +77,7 @@ int NAME(blasint *N, FLOAT *a, blasint *LDA, blasint *K1, blasint *K2, blasint *
   flag = (incx < 0);
 
 #ifdef SMP
-  nthreads = num_cpu_avail(1);
+  nthreads = num_cpu_avail();
 
   if (nthreads == 1) {
 #endif

--- a/interface/lapack/lauum.c
+++ b/interface/lapack/lauum.c
@@ -112,7 +112,7 @@ int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
 
 #ifdef SMP
   args.common = NULL;
-  args.nthreads = num_cpu_avail(4);
+  args.nthreads = num_cpu_avail();
 
   if (args.nthreads == 1) {
 #endif

--- a/interface/lapack/potrf.c
+++ b/interface/lapack/potrf.c
@@ -112,7 +112,7 @@ int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
 
 #ifdef SMP
   args.common = NULL;
-  args.nthreads = num_cpu_avail(4);
+  args.nthreads = num_cpu_avail();
 
   if (args.nthreads == 1) {
 #endif

--- a/interface/lapack/potri.c
+++ b/interface/lapack/potri.c
@@ -121,7 +121,7 @@ int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
 
 #ifdef SMP
   args.common = NULL;
-  args.nthreads = num_cpu_avail(4);
+  args.nthreads = num_cpu_avail();
 
   if (args.nthreads == 1) {
 #endif

--- a/interface/lapack/trtri.c
+++ b/interface/lapack/trtri.c
@@ -127,7 +127,7 @@ int NAME(char *UPLO, char *DIAG, blasint *N, FLOAT *a, blasint *ldA, blasint *In
 #endif
 
 #ifdef SMP
-  args.nthreads = num_cpu_avail(4);
+  args.nthreads = num_cpu_avail();
 
   if (args.nthreads == 1) {
 #endif

--- a/interface/lapack/zgetrf.c
+++ b/interface/lapack/zgetrf.c
@@ -95,7 +95,7 @@ int NAME(blasint *M, blasint *N, FLOAT *a, blasint *ldA, blasint *ipiv, blasint 
 
 #ifdef SMP
   args.common = NULL;
-  args.nthreads = num_cpu_avail(4);
+  args.nthreads = num_cpu_avail();
 
   if (args.nthreads == 1) {
 #endif

--- a/interface/lapack/zgetrs.c
+++ b/interface/lapack/zgetrs.c
@@ -125,7 +125,7 @@ int NAME(char *TRANS, blasint *N, blasint *NRHS, FLOAT *a, blasint *ldA,
 #endif
 
 #ifdef SMP
-  args.nthreads = num_cpu_avail(4);
+  args.nthreads = num_cpu_avail();
 
   if (args.nthreads == 1) {
 #endif

--- a/interface/lapack/zlaswp.c
+++ b/interface/lapack/zlaswp.c
@@ -78,7 +78,7 @@ int NAME(blasint *N, FLOAT *a, blasint *LDA, blasint *K1, blasint *K2, blasint *
   flag = (incx < 0);
 
 #ifdef SMP
-  nthreads = num_cpu_avail(2);
+  nthreads = num_cpu_avail();
 
   if (nthreads == 1) {
 #endif

--- a/interface/lapack/zlauum.c
+++ b/interface/lapack/zlauum.c
@@ -112,7 +112,7 @@ int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
 
 #ifdef SMP
   args.common = NULL;
-  args.nthreads = num_cpu_avail(4);
+  args.nthreads = num_cpu_avail();
 
   if (args.nthreads == 1) {
 #endif

--- a/interface/lapack/zpotrf.c
+++ b/interface/lapack/zpotrf.c
@@ -112,7 +112,7 @@ int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
 
 #ifdef SMP
   args.common = NULL;
-  args.nthreads = num_cpu_avail(4);
+  args.nthreads = num_cpu_avail();
 
   if (args.nthreads == 1) {
 #endif

--- a/interface/lapack/zpotri.c
+++ b/interface/lapack/zpotri.c
@@ -120,7 +120,7 @@ int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
 #endif
 
 #ifdef SMP
-  args.nthreads = num_cpu_avail(4);
+  args.nthreads = num_cpu_avail();
 
   if (args.nthreads == 1) {
 #endif

--- a/interface/lapack/ztrtri.c
+++ b/interface/lapack/ztrtri.c
@@ -125,7 +125,7 @@ int NAME(char *UPLO, char *DIAG, blasint *N, FLOAT *a, blasint *ldA, blasint *In
 
 #ifdef SMP
   args.common = NULL;
-  args.nthreads = num_cpu_avail(4);
+  args.nthreads = num_cpu_avail();
 
   if (args.nthreads == 1) {
 #endif

--- a/interface/sbmv.c
+++ b/interface/sbmv.c
@@ -198,7 +198,7 @@ void CNAME(enum CBLAS_ORDER order,
   buffer = (FLOAT *)blas_memory_alloc(1);
 
 #ifdef SMPTEST
-  nthreads = num_cpu_avail(2);
+  nthreads = num_cpu_avail();
 
   if (nthreads == 1) {
 #endif

--- a/interface/scal.c
+++ b/interface/scal.c
@@ -79,7 +79,7 @@ void CNAME(blasint n, FLOAT alpha, FLOAT *x, blasint incx){
   if (n <= 1048576 )
 	nthreads = 1;
   else
-	nthreads = num_cpu_avail(1);
+	nthreads = num_cpu_avail();
 
 
   if (nthreads == 1) {

--- a/interface/spmv.c
+++ b/interface/spmv.c
@@ -182,7 +182,7 @@ void CNAME(enum CBLAS_ORDER order,
   buffer = (FLOAT *)blas_memory_alloc(1);
 
 #ifdef SMPTEST
-  nthreads = num_cpu_avail(2);
+  nthreads = num_cpu_avail();
 
   if (nthreads == 1) {
 #endif

--- a/interface/spr.c
+++ b/interface/spr.c
@@ -172,7 +172,7 @@ void CNAME(enum CBLAS_ORDER order,
   buffer = (FLOAT *)blas_memory_alloc(1);
 
 #ifdef SMP
-  nthreads = num_cpu_avail(2);
+  nthreads = num_cpu_avail();
 
   if (nthreads == 1) {
 #endif

--- a/interface/spr2.c
+++ b/interface/spr2.c
@@ -178,7 +178,7 @@ void CNAME(enum CBLAS_ORDER order,
   buffer = (FLOAT *)blas_memory_alloc(1);
 
 #ifdef SMP
-  nthreads = num_cpu_avail(2);
+  nthreads = num_cpu_avail();
 
   if (nthreads == 1) {
 #endif

--- a/interface/symm.c
+++ b/interface/symm.c
@@ -375,7 +375,7 @@ void CNAME(enum CBLAS_ORDER order, enum CBLAS_SIDE Side, enum CBLAS_UPLO Uplo,
 
 #ifdef SMP
   args.common = NULL;
-  args.nthreads = num_cpu_avail(3);
+  args.nthreads = num_cpu_avail();
 
   if (args.nthreads == 1) {
 #endif

--- a/interface/symv.c
+++ b/interface/symv.c
@@ -180,7 +180,7 @@ void CNAME(enum CBLAS_ORDER order, enum CBLAS_UPLO Uplo, blasint n, FLOAT alpha,
   buffer = (FLOAT *)blas_memory_alloc(1);
 
 #ifdef SMP
-  nthreads = num_cpu_avail(2);
+  nthreads = num_cpu_avail();
 
   if (nthreads == 1) {
 #endif

--- a/interface/syr.c
+++ b/interface/syr.c
@@ -174,7 +174,7 @@ void CNAME(enum CBLAS_ORDER order, enum CBLAS_UPLO Uplo, blasint n, FLOAT alpha,
   buffer = (FLOAT *)blas_memory_alloc(1);
 
 #ifdef SMP
-  nthreads = num_cpu_avail(2);
+  nthreads = num_cpu_avail();
 
   if (nthreads == 1) {
 #endif

--- a/interface/syr2.c
+++ b/interface/syr2.c
@@ -178,7 +178,7 @@ void CNAME(enum CBLAS_ORDER order, enum CBLAS_UPLO Uplo, blasint n, FLOAT alpha,
   buffer = (FLOAT *)blas_memory_alloc(1);
 
 #ifdef SMP
-  nthreads = num_cpu_avail(2);
+  nthreads = num_cpu_avail();
 
   if (nthreads == 1) {
 #endif

--- a/interface/syr2k.c
+++ b/interface/syr2k.c
@@ -368,7 +368,7 @@ void CNAME(enum CBLAS_ORDER order, enum CBLAS_UPLO Uplo, enum CBLAS_TRANSPOSE Tr
   mode |= (uplo  << BLAS_UPLO_SHIFT);
 
   args.common = NULL;
-  args.nthreads = num_cpu_avail(3);
+  args.nthreads = num_cpu_avail();
 
   if (args.nthreads == 1) {
 #endif

--- a/interface/syrk.c
+++ b/interface/syrk.c
@@ -354,7 +354,7 @@ void CNAME(enum CBLAS_ORDER order, enum CBLAS_UPLO Uplo, enum CBLAS_TRANSPOSE Tr
 #endif
 
   args.common = NULL;
-  args.nthreads = num_cpu_avail(3);
+  args.nthreads = num_cpu_avail();
 
   if (args.nthreads == 1) {
 #endif

--- a/interface/tbmv.c
+++ b/interface/tbmv.c
@@ -223,7 +223,7 @@ void CNAME(enum CBLAS_ORDER order, enum CBLAS_UPLO Uplo,
   buffer = (FLOAT *)blas_memory_alloc(1);
 
 #ifdef SMP
-  nthreads = num_cpu_avail(2);
+  nthreads = num_cpu_avail();
 
   if (nthreads == 1) {
 #endif

--- a/interface/tpmv.c
+++ b/interface/tpmv.c
@@ -221,7 +221,7 @@ void CNAME(enum CBLAS_ORDER order, enum CBLAS_UPLO Uplo,
   buffer = (FLOAT *)blas_memory_alloc(1);
 
 #ifdef SMP
-  nthreads = num_cpu_avail(2);
+  nthreads = num_cpu_avail();
 
   if (nthreads == 1) {
 #endif

--- a/interface/trmv.c
+++ b/interface/trmv.c
@@ -218,7 +218,7 @@ void CNAME(enum CBLAS_ORDER order, enum CBLAS_UPLO Uplo,
   buffer = (FLOAT *)blas_memory_alloc(1);
 
 #ifdef SMP
-/*  nthreads = num_cpu_avail(2);
+/*  nthreads = num_cpu_avail();
 
 FIXME trmv_thread was found to be broken, see issue 1332 */
   nthreads = 1;

--- a/interface/trsm.c
+++ b/interface/trsm.c
@@ -372,7 +372,7 @@ void CNAME(enum CBLAS_ORDER order,
 	if ( args.n < 2*GEMM_MULTITHREAD_THRESHOLD )
 		args.nthreads = 1;
   else
-	args.nthreads = num_cpu_avail(3);
+	args.nthreads = num_cpu_avail();
 		
 
   if (args.nthreads == 1) {

--- a/interface/zaxpy.c
+++ b/interface/zaxpy.c
@@ -98,7 +98,7 @@ void CNAME(blasint n, FLOAT *ALPHA, FLOAT *x, blasint incx, FLOAT *y, blasint in
   if (incx == 0 || incy == 0 || n <= MULTI_THREAD_MINIMAL)
 	  nthreads = 1;
   else
-	  nthreads = num_cpu_avail(1);
+	  nthreads = num_cpu_avail();
 
   if (nthreads == 1) {
 #endif

--- a/interface/zgbmv.c
+++ b/interface/zgbmv.c
@@ -251,7 +251,7 @@ void CNAME(enum CBLAS_ORDER order,
   buffer = (FLOAT *)blas_memory_alloc(1);
 
 #ifdef SMP
-  nthreads = num_cpu_avail(2);
+  nthreads = num_cpu_avail();
 
   if (nthreads == 1) {
 #endif

--- a/interface/zgemv.c
+++ b/interface/zgemv.c
@@ -255,7 +255,7 @@ void CNAME(enum CBLAS_ORDER order,
   if ( 1L * m * n < 1024L * GEMM_MULTITHREAD_THRESHOLD )
     nthreads = 1;
   else
-    nthreads = num_cpu_avail(2);
+    nthreads = num_cpu_avail();
 
   if (nthreads == 1) {
 #endif

--- a/interface/zger.c
+++ b/interface/zger.c
@@ -220,7 +220,7 @@ void CNAME(enum CBLAS_ORDER order,
 #ifdef SMPTEST
   // Threshold chosen so that speed-up is > 1 on a Xeon E5-2630
   if(1L * m * n > 36L * sizeof(FLOAT) * sizeof(FLOAT) * GEMM_MULTITHREAD_THRESHOLD)
-    nthreads = num_cpu_avail(2);
+    nthreads = num_cpu_avail();
   else
     nthreads = 1;
 

--- a/interface/zhbmv.c
+++ b/interface/zhbmv.c
@@ -204,7 +204,7 @@ void CNAME(enum CBLAS_ORDER order,
   buffer = (FLOAT *)blas_memory_alloc(1);
 
 #ifdef SMPBUG
-  nthreads = num_cpu_avail(2);
+  nthreads = num_cpu_avail();
 
   if (nthreads == 1) {
 #endif

--- a/interface/zhemv.c
+++ b/interface/zhemv.c
@@ -195,7 +195,7 @@ void CNAME(enum CBLAS_ORDER order, enum CBLAS_UPLO Uplo, blasint n, void *VALPHA
   buffer = (FLOAT *)blas_memory_alloc(1);
 
 #ifdef SMP
-  nthreads = num_cpu_avail(2);
+  nthreads = num_cpu_avail();
 
   if (nthreads == 1) {
 #endif

--- a/interface/zher.c
+++ b/interface/zher.c
@@ -177,7 +177,7 @@ void CNAME(enum CBLAS_ORDER order, enum CBLAS_UPLO Uplo, blasint n, FLOAT alpha,
   buffer = (FLOAT *)blas_memory_alloc(1);
 
 #ifdef SMP
-  nthreads = num_cpu_avail(2);
+  nthreads = num_cpu_avail();
 
   if (nthreads == 1) {
 #endif

--- a/interface/zher2.c
+++ b/interface/zher2.c
@@ -186,7 +186,7 @@ void CNAME(enum CBLAS_ORDER order, enum CBLAS_UPLO Uplo, blasint n, void *VALPHA
   buffer = (FLOAT *)blas_memory_alloc(1);
 
 #ifdef SMP
-  nthreads = num_cpu_avail(2);
+  nthreads = num_cpu_avail();
 
   if (nthreads == 1) {
 #endif

--- a/interface/zhpmv.c
+++ b/interface/zhpmv.c
@@ -194,7 +194,7 @@ void CNAME(enum CBLAS_ORDER order,
   buffer = (FLOAT *)blas_memory_alloc(1);
 
 #ifdef SMP
-  nthreads = num_cpu_avail(2);
+  nthreads = num_cpu_avail();
 
   if (nthreads == 1) {
 #endif

--- a/interface/zhpr.c
+++ b/interface/zhpr.c
@@ -175,7 +175,7 @@ void CNAME(enum CBLAS_ORDER order,
   buffer = (FLOAT *)blas_memory_alloc(1);
 
 #ifdef SMP
-  nthreads = num_cpu_avail(2);
+  nthreads = num_cpu_avail();
 
   if (nthreads == 1) {
 #endif

--- a/interface/zhpr2.c
+++ b/interface/zhpr2.c
@@ -187,7 +187,7 @@ void CNAME(enum CBLAS_ORDER order,
   buffer = (FLOAT *)blas_memory_alloc(1);
 
 #ifdef SMP
-  nthreads = num_cpu_avail(2);
+  nthreads = num_cpu_avail();
 
   if (nthreads == 1) {
 #endif

--- a/interface/zsbmv.c
+++ b/interface/zsbmv.c
@@ -140,7 +140,7 @@ void NAME(char *UPLO, blasint *N, blasint *K, FLOAT  *ALPHA, FLOAT *a, blasint *
   buffer = (FLOAT *)blas_memory_alloc(1);
 
 #ifdef SMPTEST
-  nthreads = num_cpu_avail(2);
+  nthreads = num_cpu_avail();
 
   if (nthreads == 1) {
 #endif

--- a/interface/zscal.c
+++ b/interface/zscal.c
@@ -93,7 +93,7 @@ void CNAME(blasint n, FLOAT alpha_r, void *vx, blasint incx){
   if ( n <= 1048576 )
 	nthreads = 1;
   else
-	nthreads = num_cpu_avail(1);
+	nthreads = num_cpu_avail();
 
   if (nthreads == 1) {
 #endif

--- a/interface/zspmv.c
+++ b/interface/zspmv.c
@@ -128,7 +128,7 @@ void NAME(char *UPLO, blasint *N, FLOAT  *ALPHA, FLOAT *a,
   buffer = (FLOAT *)blas_memory_alloc(1);
 
 #ifdef SMPTEST
-  nthreads = num_cpu_avail(2);
+  nthreads = num_cpu_avail();
 
   if (nthreads == 1) {
 #endif

--- a/interface/zspr.c
+++ b/interface/zspr.c
@@ -121,7 +121,7 @@ void NAME(char *UPLO, blasint *N, FLOAT  *ALPHA,
   buffer = (FLOAT *)blas_memory_alloc(1);
 
 #ifdef SMP
-  nthreads = num_cpu_avail(2);
+  nthreads = num_cpu_avail();
 
   if (nthreads == 1) {
 #endif

--- a/interface/zspr2.c
+++ b/interface/zspr2.c
@@ -124,7 +124,7 @@ void NAME(char *UPLO, blasint *N, FLOAT  *ALPHA,
   buffer = (FLOAT *)blas_memory_alloc(1);
 
 #ifdef SMP
-  nthreads = num_cpu_avail(2);
+  nthreads = num_cpu_avail();
 
   if (nthreads == 1) {
 #endif

--- a/interface/zswap.c
+++ b/interface/zswap.c
@@ -84,7 +84,7 @@ FLOAT *y = (FLOAT*)vy;
   if (incx == 0 || incy == 0)
 	  nthreads = 1;
   else
-	  nthreads = num_cpu_avail(1);
+	  nthreads = num_cpu_avail();
 
   if (nthreads == 1) {
 #endif

--- a/interface/zsymv.c
+++ b/interface/zsymv.c
@@ -118,7 +118,7 @@ void NAME(char *UPLO, blasint *N, FLOAT  *ALPHA, FLOAT *a, blasint *LDA,
   buffer = (FLOAT *)blas_memory_alloc(1);
 
 #ifdef SMP
-  nthreads = num_cpu_avail(2);
+  nthreads = num_cpu_avail();
 
   if (nthreads == 1) {
 #endif

--- a/interface/zsyr.c
+++ b/interface/zsyr.c
@@ -181,7 +181,7 @@ void CNAME(enum CBLAS_ORDER order, enum CBLAS_UPLO Uplo, int n, FLOAT alpha, FLO
   buffer = (FLOAT *)blas_memory_alloc(1);
 
 #ifdef SMP
-  nthreads = num_cpu_avail(2);
+  nthreads = num_cpu_avail();
 
   if (nthreads == 1) {
 #endif

--- a/interface/zsyr2.c
+++ b/interface/zsyr2.c
@@ -126,7 +126,7 @@ void NAME(char *UPLO, blasint *N, FLOAT  *ALPHA,
   buffer = (FLOAT *)blas_memory_alloc(1);
 
 #ifdef SMP
-  nthreads = num_cpu_avail(2);
+  nthreads = num_cpu_avail();
 
   if (nthreads == 1) {
 #endif

--- a/interface/ztbmv.c
+++ b/interface/ztbmv.c
@@ -238,7 +238,7 @@ void CNAME(enum CBLAS_ORDER order, enum CBLAS_UPLO Uplo,
   buffer = (FLOAT *)blas_memory_alloc(1);
 
 #ifdef SMP
-  nthreads = num_cpu_avail(2);
+  nthreads = num_cpu_avail();
 
   if (nthreads == 1) {
 #endif

--- a/interface/ztpmv.c
+++ b/interface/ztpmv.c
@@ -229,7 +229,7 @@ void CNAME(enum CBLAS_ORDER order, enum CBLAS_UPLO Uplo,
   buffer = (FLOAT *)blas_memory_alloc(1);
 
 #ifdef SMP
-  nthreads = num_cpu_avail(2);
+  nthreads = num_cpu_avail();
 
   if (nthreads == 1) {
 #endif

--- a/interface/ztrmv.c
+++ b/interface/ztrmv.c
@@ -233,7 +233,7 @@ void CNAME(enum CBLAS_ORDER order, enum CBLAS_UPLO Uplo,
 #ifdef SMP
   // Calibrated on a Xeon E5-2630
   if(1L * n * n > 36L * sizeof(FLOAT) * sizeof(FLOAT) * GEMM_MULTITHREAD_THRESHOLD) {
-    nthreads = num_cpu_avail(2);
+    nthreads = num_cpu_avail();
     if(nthreads > 2 && 1L * n * n < 64L * sizeof(FLOAT) * sizeof(FLOAT) * GEMM_MULTITHREAD_THRESHOLD)
       nthreads = 2;
   } else

--- a/kernel/arm64/casum_thunderx2t99.c
+++ b/kernel/arm64/casum_thunderx2t99.c
@@ -236,7 +236,7 @@ FLOAT CNAME(BLASLONG n, FLOAT *x, BLASLONG inc_x)
 	if (inc_x == 0 || n <= 10000)
 		nthreads = 1;
 	else
-		nthreads = num_cpu_avail(1);
+		nthreads = num_cpu_avail();
 
 	if (nthreads == 1) {
 		asum = casum_compute(n, x, inc_x);

--- a/kernel/arm64/copy_thunderx2t99.c
+++ b/kernel/arm64/copy_thunderx2t99.c
@@ -186,7 +186,7 @@ int CNAME(BLASLONG n, FLOAT *x, BLASLONG inc_x, FLOAT *y, BLASLONG inc_y)
 	if (inc_x == 0 || n <= 10000)
 		nthreads = 1;
 	else
-		nthreads = num_cpu_avail(1);
+		nthreads = num_cpu_avail();
 
 	if (nthreads == 1) {
 		do_copy(n, x, inc_x, y, inc_y);

--- a/kernel/arm64/dasum_thunderx2t99.c
+++ b/kernel/arm64/dasum_thunderx2t99.c
@@ -231,7 +231,7 @@ FLOAT CNAME(BLASLONG n, FLOAT *x, BLASLONG inc_x)
 	if (inc_x == 0 || n <= 10000)
 		nthreads = 1;
 	else
-		nthreads = num_cpu_avail(1);
+		nthreads = num_cpu_avail();
 
 	if (nthreads == 1) {
 		asum = dasum_compute(n, x, inc_x);

--- a/kernel/arm64/dot_thunderx2t99.c
+++ b/kernel/arm64/dot_thunderx2t99.c
@@ -387,7 +387,7 @@ RETURN_TYPE CNAME(BLASLONG n, FLOAT *x, BLASLONG inc_x, FLOAT *y, BLASLONG inc_y
 	if (inc_x == 0 || inc_y == 0 || n <= 10000)
 		nthreads = 1;
 	else
-		nthreads = num_cpu_avail(1);
+		nthreads = num_cpu_avail();
 
 	if (nthreads == 1) {
 		dot = dot_compute(n, x, inc_x, y, inc_y);

--- a/kernel/arm64/dznrm2_thunderx2t99.c
+++ b/kernel/arm64/dznrm2_thunderx2t99.c
@@ -331,7 +331,7 @@ FLOAT CNAME(BLASLONG n, FLOAT *x, BLASLONG inc_x)
 	if (n <= 10000)
 		nthreads = 1;
 	else
-		nthreads = num_cpu_avail(1);
+		nthreads = num_cpu_avail();
 
 	if (nthreads == 1) {
 		nrm2_compute(n, x, inc_x, &ssq, &scale);

--- a/kernel/arm64/dznrm2_thunderx2t99_fast.c
+++ b/kernel/arm64/dznrm2_thunderx2t99_fast.c
@@ -238,7 +238,7 @@ FLOAT CNAME(BLASLONG n, FLOAT *x, BLASLONG inc_x)
 	if (n <= 10000)
 		nthreads = 1;
 	else
-		nthreads = num_cpu_avail(1);
+		nthreads = num_cpu_avail();
 
 	if (nthreads == 1) {
 		nrm2 = nrm2_compute(n, x, inc_x);

--- a/kernel/arm64/iamax_thunderx2t99.c
+++ b/kernel/arm64/iamax_thunderx2t99.c
@@ -324,7 +324,7 @@ BLASLONG CNAME(BLASLONG n, FLOAT *x, BLASLONG inc_x)
 	if (inc_x == 0 || n <= 10000)
 		nthreads = 1;
 	else
-		nthreads = num_cpu_avail(1);
+		nthreads = num_cpu_avail();
 
 	if (nthreads == 1) {
 		max_index = iamax_compute(n, x, inc_x);

--- a/kernel/arm64/izamax_thunderx2t99.c
+++ b/kernel/arm64/izamax_thunderx2t99.c
@@ -333,7 +333,7 @@ BLASLONG CNAME(BLASLONG n, FLOAT *x, BLASLONG inc_x)
 	if (inc_x == 0 || n <= 10000)
 		nthreads = 1;
 	else
-		nthreads = num_cpu_avail(1);
+		nthreads = num_cpu_avail();
 
 	if (nthreads == 1) {
 		max_index = izamax_compute(n, x, inc_x);

--- a/kernel/arm64/sasum_thunderx2t99.c
+++ b/kernel/arm64/sasum_thunderx2t99.c
@@ -233,7 +233,7 @@ FLOAT CNAME(BLASLONG n, FLOAT *x, BLASLONG inc_x)
 	if (inc_x == 0 || n <= 10000)
 		nthreads = 1;
 	else
-		nthreads = num_cpu_avail(1);
+		nthreads = num_cpu_avail();
 
 	if (nthreads == 1) {
 		asum = sasum_compute(n, x, inc_x);

--- a/kernel/arm64/scnrm2_thunderx2t99.c
+++ b/kernel/arm64/scnrm2_thunderx2t99.c
@@ -321,7 +321,7 @@ FLOAT CNAME(BLASLONG n, FLOAT *x, BLASLONG inc_x)
 	if (n <= 10000)
 		nthreads = 1;
 	else
-		nthreads = num_cpu_avail(1);
+		nthreads = num_cpu_avail();
 
 	if (nthreads == 1) {
 		nrm2_double = nrm2_compute(n, x, inc_x);

--- a/kernel/arm64/zasum_thunderx2t99.c
+++ b/kernel/arm64/zasum_thunderx2t99.c
@@ -233,7 +233,7 @@ FLOAT CNAME(BLASLONG n, FLOAT *x, BLASLONG inc_x)
 	if (inc_x == 0 || n <= 10000)
 		nthreads = 1;
 	else
-		nthreads = num_cpu_avail(1);
+		nthreads = num_cpu_avail();
 
 	if (nthreads == 1) {
 		asum = zasum_compute(n, x, inc_x);

--- a/kernel/arm64/zdot_thunderx2t99.c
+++ b/kernel/arm64/zdot_thunderx2t99.c
@@ -320,7 +320,7 @@ OPENBLAS_COMPLEX_FLOAT CNAME(BLASLONG n, FLOAT *x, BLASLONG inc_x, FLOAT *y, BLA
 	if (inc_x == 0 || inc_y == 0 || n <= 10000)
 		nthreads = 1;
 	else
-		nthreads = num_cpu_avail(1);
+		nthreads = num_cpu_avail();
 
 	if (nthreads == 1) {
 		zdot_compute(n, x, inc_x, y, inc_y, &zdot);

--- a/kernel/x86_64/ddot.c
+++ b/kernel/x86_64/ddot.c
@@ -174,7 +174,7 @@ FLOAT CNAME(BLASLONG n, FLOAT *x, BLASLONG inc_x, FLOAT *y, BLASLONG inc_y)
 	if (inc_x == 0 || inc_y == 0 || n <= 10000)
 		nthreads = 1;
 	else
-		nthreads = num_cpu_avail(1);
+		nthreads = num_cpu_avail();
 
 	if (nthreads == 1) {
 		dot = dot_compute(n, x, inc_x, y, inc_y);


### PR DESCRIPTION
and remove it from all callers, probably moderating the thread limit for small sets could go to interface/?
i have some doubts about extra roll with same num_cpu_avail() in kernel/ ... shouldnt it be all in one place?