### PR TITLE
Convert fldmia/fstmia instructions to UAL syntax for clang7

### DIFF
--- a/kernel/arm/cgemm_ncopy_2_vfp.S
+++ b/kernel/arm/cgemm_ncopy_2_vfp.S
@@ -85,7 +85,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	flds	s6 , [ AO2, #8 ]
 	flds	s7 , [ AO2, #12 ]
 
-	fstmias	BO!, { s0 - s7 }
+	vstmia.f32	BO!, { s0 - s7 }
 	add	AO2, AO2, #16
 
 .endm
@@ -99,7 +99,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	flds	s3 , [ AO2, #4  ]
 
 	add	AO1, AO1, #8
-	fstmias	BO!, { s0 - s3 }
+	vstmia.f32	BO!, { s0 - s3 }
 	add	AO2, AO2, #8
 
 .endm
@@ -111,7 +111,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	flds	s2 , [ AO1, #8 ]
 	flds	s3 , [ AO1, #12 ]
 
-	fstmias	BO!, { s0 - s3 }
+	vstmia.f32	BO!, { s0 - s3 }
 	add	AO1, AO1, #16
 
 .endm
@@ -122,7 +122,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	flds	s0 , [ AO1, #0  ]
 	flds	s1 , [ AO1, #4  ]
 
-	fstmias	BO!, { s0 - s1 }
+	vstmia.f32	BO!, { s0 - s1 }
 	add	AO1, AO1, #8
 
 .endm

--- a/kernel/arm/dgemm_ncopy_2_vfp.S
+++ b/kernel/arm/dgemm_ncopy_2_vfp.S
@@ -73,7 +73,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	fldd	d3 , [ AO2, #8  ]
 
 	add	AO1, AO1, #16
-	fstmiad	BO!, { d0 - d3 }
+	vstmia.f64	BO!, { d0 - d3 }
 	add	AO2, AO2, #16
 
 .endm
@@ -85,7 +85,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	fldd	d1 , [ AO2, #0  ]
 	add	AO1, AO1, #8
 
-	fstmiad	BO!, { d0 - d1 }
+	vstmia.f64	BO!, { d0 - d1 }
 	add	AO2, AO2, #8
 
 .endm
@@ -95,7 +95,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	fldd	d0 , [ AO1, #0  ]
 	fldd	d1 , [ AO1, #8  ]
 
-	fstmiad	BO!, { d0 - d1 }
+	vstmia.f64	BO!, { d0 - d1 }
 	add	AO1, AO1, #16
 
 .endm
@@ -105,7 +105,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 	fldd	d0 , [ AO1, #0  ]
 
-	fstmiad	BO!, { d0 }
+	vstmia.f64	BO!, { d0 }
 	add	AO1, AO1, #8
 
 .endm

--- a/kernel/arm/dgemm_ncopy_4_vfp.S
+++ b/kernel/arm/dgemm_ncopy_4_vfp.S
@@ -105,10 +105,10 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	fldd	d11, [ AO4, #16 ]
 	fldd	d15, [ AO4, #24 ]
 
-	fstmiad	BO!, { d0 - d3 }
+	vstmia.f64	BO!, { d0 - d3 }
 	add	AO4, AO4, #32
-	fstmiad	BO!, { d4 - d7 }
-	fstmiad	BO!, { d8 - d15 }
+	vstmia.f64	BO!, { d4 - d7 }
+	vstmia.f64	BO!, { d8 - d15 }
 
 .endm
 
@@ -122,7 +122,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	fldd	d3 , [ AO4, #0  ]
 
 	add	AO3, AO3, #8
-	fstmiad	BO!, { d0 - d3 }
+	vstmia.f64	BO!, { d0 - d3 }
 	add	AO4, AO4, #8
 
 .endm
@@ -140,7 +140,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	fldd	d5 , [ AO2, #16 ]
 	fldd	d7 , [ AO2, #24 ]
 
-	fstmiad	BO!, { d0 - d7 }
+	vstmia.f64	BO!, { d0 - d7 }
 	add	AO2, AO2, #32
 
 .endm
@@ -152,7 +152,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	fldd	d1 , [ AO2, #0  ]
 	add	AO1, AO1, #8
 
-	fstmiad	BO!, { d0 - d1 }
+	vstmia.f64	BO!, { d0 - d1 }
 	add	AO2, AO2, #8
 
 .endm
@@ -164,7 +164,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	fldd	d2 , [ AO1, #16 ]
 	fldd	d3 , [ AO1, #24 ]
 
-	fstmiad	BO!, { d0 - d3 }
+	vstmia.f64	BO!, { d0 - d3 }
 	add	AO1, AO1, #32
 
 .endm
@@ -174,7 +174,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 	fldd	d0 , [ AO1, #0  ]
 
-	fstmiad	BO!, { d0 }
+	vstmia.f64	BO!, { d0 }
 	add	AO1, AO1, #8
 
 .endm

--- a/kernel/arm/sgemm_ncopy_2_vfp.S
+++ b/kernel/arm/sgemm_ncopy_2_vfp.S
@@ -73,7 +73,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	flds	s3 , [ AO2, #4  ]
 
 	add	AO1, AO1, #8
-	fstmias	BO!, { s0 - s3 }
+	vstmia.f32	BO!, { s0 - s3 }
 	add	AO2, AO2, #8
 
 .endm
@@ -85,7 +85,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	flds	s1 , [ AO2, #0  ]
 	add	AO1, AO1, #4
 
-	fstmias	BO!, { s0 - s1 }
+	vstmia.f32	BO!, { s0 - s1 }
 	add	AO2, AO2, #4
 
 .endm
@@ -95,7 +95,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	flds	s0 , [ AO1, #0  ]
 	flds	s1 , [ AO1, #4  ]
 
-	fstmias	BO!, { s0 - s1 }
+	vstmia.f32	BO!, { s0 - s1 }
 	add	AO1, AO1, #8
 
 .endm
@@ -105,7 +105,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 	flds	s0 , [ AO1, #0  ]
 
-	fstmias	BO!, { s0 }
+	vstmia.f32	BO!, { s0 }
 	add	AO1, AO1, #4
 
 .endm

--- a/kernel/arm/sgemm_ncopy_4_vfp.S
+++ b/kernel/arm/sgemm_ncopy_4_vfp.S
@@ -100,10 +100,10 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	flds s11, [ AO4, #8 ]
 	flds s15, [ AO4, #12 ]
 
-	fstmias	BO!, { s0 - s3 }
+	vstmia.f32	BO!, { s0 - s3 }
 	add	AO4, AO4, #16
-	fstmias	BO!, { s4 - s7 }
-	fstmias	BO!, { s8 - s15 }
+	vstmia.f32	BO!, { s4 - s7 }
+	vstmia.f32	BO!, { s8 - s15 }
 
 .endm
 
@@ -117,7 +117,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	flds s3 , [ AO4, #0  ]
 
 	add	AO3, AO3, #4
-	fstmias	BO!, { s0 - s3 }
+	vstmia.f32	BO!, { s0 - s3 }
 	add	AO4, AO4, #4
 
 .endm
@@ -135,7 +135,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	flds s5 , [ AO2, #8 ]
 	flds s7 , [ AO2, #12 ]
 
-	fstmias	BO!, { s0 - s7 }
+	vstmia.f32	BO!, { s0 - s7 }
 	add	AO2, AO2, #16
 
 .endm
@@ -147,7 +147,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	flds s1 , [ AO2, #0  ]
 	add	AO1, AO1, #4
 
-	fstmias	BO!, { s0 - s1 }
+	vstmia.f32	BO!, { s0 - s1 }
 	add	AO2, AO2, #4
 
 .endm
@@ -159,7 +159,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	flds s2 , [ AO1, #8 ]
 	flds s3 , [ AO1, #12 ]
 
-	fstmias	BO!, { s0 - s3 }
+	vstmia.f32	BO!, { s0 - s3 }
 	add	AO1, AO1, #16
 
 .endm
@@ -169,7 +169,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 	flds s0 , [ AO1, #0  ]
 
-	fstmias	BO!, { s0 }
+	vstmia.f32	BO!, { s0 }
 	add	AO1, AO1, #4
 
 .endm

--- a/kernel/arm/zgemm_ncopy_2_vfp.S
+++ b/kernel/arm/zgemm_ncopy_2_vfp.S
@@ -87,7 +87,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	fldd	d6 , [ AO2, #16 ]
 	fldd	d7 , [ AO2, #24 ]
 
-	fstmiad	BO!, { d0 - d7 }
+	vstmia.f64	BO!, { d0 - d7 }
 	add	AO2, AO2, #32
 
 .endm
@@ -101,7 +101,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	fldd	d3 , [ AO2, #8  ]
 
 	add	AO1, AO1, #16
-	fstmiad	BO!, { d0 - d3 }
+	vstmia.f64	BO!, { d0 - d3 }
 	add	AO2, AO2, #16
 
 .endm
@@ -113,7 +113,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	fldd	d2 , [ AO1, #16 ]
 	fldd	d3 , [ AO1, #24 ]
 
-	fstmiad	BO!, { d0 - d3 }
+	vstmia.f64	BO!, { d0 - d3 }
 	add	AO1, AO1, #32
 
 .endm
@@ -124,7 +124,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	fldd	d0 , [ AO1, #0  ]
 	fldd	d1 , [ AO1, #8  ]
 
-	fstmiad	BO!, { d0 - d1 }
+	vstmia.f64	BO!, { d0 - d1 }
 	add	AO1, AO1, #16
 
 .endm

--- a/kernel/arm/ztrmm_kernel_2x2_vfp.S
+++ b/kernel/arm/ztrmm_kernel_2x2_vfp.S
@@ -385,7 +385,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	FMAC_R2 d6 , d1 , d11
 	FMAC_I2	d7 , d1 , d10
 
-	fstmiad CO1, { d4 - d7 }
+	vstmia.f64 CO1, { d4 - d7 }
 
 	fldd		d4 , FP_ZERO
 	vmov.f64	d5 , d4
@@ -402,7 +402,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	FMAC_R2 d6 , d1 , d15
 	FMAC_I2	d7 , d1 , d14
 
-	fstmiad CO2, { d4 - d7 }
+	vstmia.f64 CO2, { d4 - d7 }
 
 	add	CO1, CO1, #32
 
@@ -567,7 +567,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	FMAC_R2 d4 , d1 , d9
 	FMAC_I2	d5 , d1 , d8
 
-	fstmiad CO1, { d4 - d5 }
+	vstmia.f64 CO1, { d4 - d5 }
 
 	fldd		d4 , FP_ZERO
 	vmov.f64	d5 , d4
@@ -577,7 +577,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	FMAC_R2 d4 , d1 , d13
 	FMAC_I2	d5 , d1 , d12
 
-	fstmiad CO2, { d4 - d5 }
+	vstmia.f64 CO2, { d4 - d5 }
 
 	add	CO1, CO1, #16
 
@@ -747,7 +747,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	FMAC_R2 d6 , d1 , d11
 	FMAC_I2	d7 , d1 , d10
 
-	fstmiad CO1, { d4 - d7 }
+	vstmia.f64 CO1, { d4 - d7 }
 
 	add	CO1, CO1, #32
 
@@ -872,7 +872,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	FMAC_R2 d4 , d1 , d9
 	FMAC_I2	d5 , d1 , d8
 
-	fstmiad CO1, { d4 - d5 }
+	vstmia.f64 CO1, { d4 - d5 }
 
 	add	CO1, CO1, #16
 

--- a/kernel/arm/ztrmm_kernel_2x2_vfpv3.S
+++ b/kernel/arm/ztrmm_kernel_2x2_vfpv3.S
@@ -391,8 +391,8 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	FMAC_R2 d10, d1 , d23
 	FMAC_I2	d11, d1 , d22
 
-	fstmiad CO1, { d4 - d7 }
-	fstmiad CO2, { d8 - d11 }
+	vstmia.f64 CO1, { d4 - d7 }
+	vstmia.f64 CO2, { d8 - d11 }
 
 	add	CO1, CO1, #32
 
@@ -569,8 +569,8 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	FMAC_R2 d8 , d1 , d21
 	FMAC_I2	d9 , d1 , d20
 
-	fstmiad CO1, { d4 - d5 }
-	fstmiad CO2, { d8 - d9  }
+	vstmia.f64 CO1, { d4 - d5 }
+	vstmia.f64 CO2, { d8 - d9  }
 
 	add	CO1, CO1, #16
 
@@ -747,7 +747,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	FMAC_R2 d6 , d1 , d19
 	FMAC_I2	d7 , d1 , d18
 
-	fstmiad CO1, { d4 - d7 }
+	vstmia.f64 CO1, { d4 - d7 }
 
 	add	CO1, CO1, #32
 
@@ -872,7 +872,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	FMAC_R2 d4 , d1 , d17
 	FMAC_I2	d5 , d1 , d16
 
-	fstmiad CO1, { d4 - d5 }
+	vstmia.f64 CO1, { d4 - d5 }
 
 	add	CO1, CO1, #16
 


### PR DESCRIPTION
second part of fix for #1774, containing files missed in #1775