### PR TITLE
use blas lock on LOONGSON3A

### DIFF
--- a/common.h
+++ b/common.h
@@ -208,6 +208,13 @@ extern "C" {
 #undef	USE_PTHREAD_SPINLOCK
 #endif
 
+#ifdef OS_LINUX
+#ifdef LOONGSON3A 
+#undef  USE_PTHREAD_LOCK
+#undef  USE_PTHREAD_SPINLOCK
+#endif
+#endif
+
 #if   defined(USE_PTHREAD_LOCK)
 #define   LOCK_COMMAND(x)   pthread_mutex_lock(x)
 #define UNLOCK_COMMAND(x)   pthread_mutex_unlock(x)

--- a/common_mips64.h
+++ b/common_mips64.h
@@ -94,7 +94,7 @@ static inline unsigned int rpcc(void){
 #define RPCC_DEFINED
 
 #ifndef NO_AFFINITY
-#define WHEREAMI
+//#define WHEREAMI
 static inline int WhereAmI(void){
   int ret=0;
   __asm__ __volatile__(".set push \n"

--- a/driver/others/memory.c
+++ b/driver/others/memory.c
@@ -2587,20 +2587,20 @@ void *blas_memory_alloc(int procpos){
 
   position = 0;
 
+  LOCK_COMMAND(&alloc_lock);
   do {
 /*    if (!memory[position].used) { */
-      LOCK_COMMAND(&alloc_lock);
 /*      blas_lock(&memory[position].lock);*/
 
       if (!memory[position].used) goto allocation;
       
-      UNLOCK_COMMAND(&alloc_lock);
 /*      blas_unlock(&memory[position].lock);*/
 /*    } */
 
     position ++;
 
   } while (position < NUM_BUFFERS);
+  UNLOCK_COMMAND(&alloc_lock);
 
   goto error;
 

--- a/kernel/mips64/sgemm_kernel_8x4_ps.S
+++ b/kernel/mips64/sgemm_kernel_8x4_ps.S
@@ -146,11 +146,11 @@
 	sd	$21,  40($sp)
 	sd	$22,  48($sp)
 
-	ST	$f24, 56($sp)
-	ST	$f25, 64($sp)
-	ST	$f26, 72($sp)
-	ST	$f27, 80($sp)
-	ST	$f28, 88($sp)
+	sdc1	$f24, 56($sp)
+	sdc1	$f25, 64($sp)
+	sdc1	$f26, 72($sp)
+	sdc1	$f27, 80($sp)
+	sdc1	$f28, 88($sp)
 
 #if defined(TRMMKERNEL)
 	sd	$23,  96($sp)
@@ -161,10 +161,10 @@
 #endif
 
 #ifndef __64BIT__
-	ST	$f20,120($sp)
-	ST	$f21,128($sp)
-	ST	$f22,136($sp)
-	ST	$f23,144($sp)
+	sdc1	$f20,120($sp)
+	sdc1	$f21,128($sp)
+	sdc1	$f22,136($sp)
+	sdc1	$f23,144($sp)
 #endif
 
 	.align	4
@@ -7766,11 +7766,11 @@
 	ld	$21,  40($sp)
 	ld	$22,  48($sp)
 
-	LD	$f24, 56($sp)
-	LD	$f25, 64($sp)
-	LD	$f26, 72($sp)
-	LD	$f27, 80($sp)
-	LD	$f28, 88($sp)
+	ldc1	$f24, 56($sp)
+	ldc1	$f25, 64($sp)
+	ldc1	$f26, 72($sp)
+	ldc1	$f27, 80($sp)
+	ldc1	$f28, 88($sp)
 
 #if defined(TRMMKERNEL)
 	ld	$23,  96($sp)
@@ -7779,10 +7779,10 @@
 #endif
 
 #ifndef __64BIT__
-	LD	$f20,120($sp)
-	LD	$f21,128($sp)
-	LD	$f22,136($sp)
-	LD	$f23,144($sp)
+	ldc1	$f20,120($sp)
+	ldc1	$f21,128($sp)
+	ldc1	$f22,136($sp)
+	ldc1	$f23,144($sp)
 #endif
 
 	daddiu	$sp,$sp,STACKSIZE


### PR DESCRIPTION
Time wasted on pthread_lock/unlock on LOONGSON3A platform.  Blas_lock/unlock can increase speed about 50%.