### PR TITLE
address #1782 2nd loop

### DIFF
--- a/driver/others/memory.c
+++ b/driver/others/memory.c
@@ -2587,20 +2587,20 @@ void *blas_memory_alloc(int procpos){
 
   position = 0;
 
+  LOCK_COMMAND(&alloc_lock);
   do {
 /*    if (!memory[position].used) { */
-      LOCK_COMMAND(&alloc_lock);
 /*      blas_lock(&memory[position].lock);*/
 
       if (!memory[position].used) goto allocation;
       
-      UNLOCK_COMMAND(&alloc_lock);
 /*      blas_unlock(&memory[position].lock);*/
 /*    } */
 
     position ++;
 
   } while (position < NUM_BUFFERS);
+  UNLOCK_COMMAND(&alloc_lock);
 
   goto error;
 


### PR DESCRIPTION
IMO first loop exactly tries to pinch free memory position without lock, then shoots with lock 2nd time. full wrap with locks would make whole code useless, it would check position availability twice under lock, so this wraps only 2nd loop with locks.