### PR TITLE
Check for Immintrin.h presence in the AVX512 compatibility test as well

### DIFF
--- a/c_check
+++ b/c_check
@@ -205,7 +205,7 @@ $binformat    = bin64  if ($data =~ /BINARY_64/);
 $no_avx512= 0;
 if (($architecture eq "x86") || ($architecture eq "x86_64")) {
     $code = '"vbroadcastss -4 * 4(%rsi), %zmm2"';
-    print $tmpf "int main(void){ __asm__ volatile($code); }\n";
+    print $tmpf "#include <immintrin.h>\n\nint main(void){ __asm__ volatile($code); }\n";
     $args = " -march=skylake-avx512 -o $tmpf.o -x c $tmpf";
     my @cmd = ("$compiler_name $args >/dev/null 2>/dev/null");
     system(@cmd) == 0;

--- a/cmake/system_check.cmake
+++ b/cmake/system_check.cmake
@@ -67,7 +67,7 @@ else()
 endif()
 
 if (X86_64 OR X86)
-  file(WRITE ${PROJECT_BINARY_DIR}/avx512.tmp "int main(void){ __asm__ volatile(\"vbroadcastss -4 * 4(%rsi), %zmm2\"); }")
+  file(WRITE ${PROJECT_BINARY_DIR}/avx512.tmp "#include <immintrin.h>\n\nint main(void){ __asm__ volatile(\"vbroadcastss -4 * 4(%rsi), %zmm2\"); }")
 execute_process(COMMAND ${CMAKE_C_COMPILER} -march=skylake-avx512 -v -o ${PROJECT_BINARY_DIR}/avx512.o -x c ${PROJECT_BINARY_DIR}/avx512.tmp OUTPUT_QUIET ERROR_QUIET RESULT_VARIABLE NO_AVX512)
 if (NO_AVX512 EQUAL 1)
 set (CCOMMON_OPT "${CCOMMON_OPT} -DNO_AVX512")


### PR DESCRIPTION
as more of the SkylakeX code is relying on Intel intrinsics rather than plain assembly for AVX512