### PR TITLE
Fix unknown type name __WAIT_STATUS on RHEL5

### DIFF
--- a/utest/test_fork.c
+++ b/utest/test_fork.c
@@ -31,10 +31,10 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 **********************************************************************************/
 
-#include "openblas_utest.h"
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <cblas.h>
+#include "openblas_utest.h"
 
 void* xmalloc(size_t n)
 {


### PR DESCRIPTION
With glibc 2.5 one must have #define _XOPEN_SOURCE >= 500 to use wait.
But reading glibc code this is actually needed only if stdlib.h was
included before sys/wait.h. This was the case here through
openblas_utest.h. So changing include fix compilation on RHEL5 and
should ne hurt with more recent distro.

* Problem found when using with gcc 5.5 and 4.7.2 on RHEL5/CENTOS5
* Fix #1519