### PR TITLE
Update common_mips64.h for the 1st loop of blas_memory_alloc

### DIFF
--- a/common_mips64.h
+++ b/common_mips64.h
@@ -94,7 +94,7 @@ static inline unsigned int rpcc(void){
 #define RPCC_DEFINED
 
 #ifndef NO_AFFINITY
-#define WHEREAMI
+//#define WHEREAMI
 static inline int WhereAmI(void){
   int ret=0;
   __asm__ __volatile__(".set push \n"


### PR DESCRIPTION
The 1st loop work on mips64 and x86 32 only, sync mips64 with other platforms.