### PR TITLE
remove #1782 'first loop'

### DIFF
--- a/driver/others/memory.c
+++ b/driver/others/memory.c
@@ -2560,7 +2560,7 @@ void *blas_memory_alloc(int procpos){
   printf("Alloc Start ...\n");
 #endif
 
-#if defined(WHEREAMI) && !defined(USE_OPENMP)
+/* #if defined(WHEREAMI) && !defined(USE_OPENMP)
 
   mypos = WhereAmI();
 
@@ -2570,12 +2570,12 @@ void *blas_memory_alloc(int procpos){
   do {
     if (!memory[position].used && (memory[position].pos == mypos)) {
       LOCK_COMMAND(&alloc_lock);
-/*      blas_lock(&memory[position].lock);*/
+//      blas_lock(&memory[position].lock);
 
       if (!memory[position].used) goto allocation;
 
       UNLOCK_COMMAND(&alloc_lock);
-/*      blas_unlock(&memory[position].lock);*/
+//      blas_unlock(&memory[position].lock);
     }
 
     position ++;
@@ -2583,7 +2583,7 @@ void *blas_memory_alloc(int procpos){
   } while (position < NUM_BUFFERS);
 
 
-#endif
+#endif */
 
   position = 0;
 


### PR DESCRIPTION
Deactivate optional code that is disabled on all but x86 citing performance concern/absent benefit.
WhereAmI is still ?used? in init.c, so do not weed it out completely.