### PR TITLE
Do not fix on /usr/bin/perl, use plain perl instead.

### DIFF
--- a/c_check
+++ b/c_check
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use File::Basename;
 use File::Temp qw(tempfile);

--- a/exports/gensymbol
+++ b/exports/gensymbol
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 # Changelog
 # 2017/09/03 staticfloat

--- a/f_check
+++ b/f_check
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 $hostos   = `uname -s | sed -e s/\-.*//`;    chop($hostos);
 


### PR DESCRIPTION
Prefer invoking perl command from path, e.g. yocto sdk - called poky - would set PERL5LIB to own perl library path in case local perl is installed,  breaking /usr/bin/perl 
