### PR TITLE
Remove unnecessary locking code in allocation serialisation code.

### DIFF
--- a/driver/others/memory.c
+++ b/driver/others/memory.c
@@ -2560,7 +2560,7 @@ void *blas_memory_alloc(int procpos){
   printf("Alloc Start ...\n");
 #endif
 
-#if defined(WHEREAMI) && !defined(USE_OPENMP)
+/* #if defined(WHEREAMI) && !defined(USE_OPENMP)
 
   mypos = WhereAmI();
 
@@ -2570,12 +2570,12 @@ void *blas_memory_alloc(int procpos){
   do {
     if (!memory[position].used && (memory[position].pos == mypos)) {
       LOCK_COMMAND(&alloc_lock);
-/*      blas_lock(&memory[position].lock);*/
+//      blas_lock(&memory[position].lock);
 
       if (!memory[position].used) goto allocation;
 
       UNLOCK_COMMAND(&alloc_lock);
-/*      blas_unlock(&memory[position].lock);*/
+//      blas_unlock(&memory[position].lock);
     }
 
     position ++;
@@ -2583,7 +2583,7 @@ void *blas_memory_alloc(int procpos){
   } while (position < NUM_BUFFERS);
 
 
-#endif
+#endif */
 
   position = 0;
 


### PR DESCRIPTION
Should apply #1782 change to x86 and remove dubious code from future use 