### PR TITLE
Delay _hemv threading in attempt to address #1820

### DIFF
--- a/interface/zhemv.c
+++ b/interface/zhemv.c
@@ -195,7 +195,12 @@ void CNAME(enum CBLAS_ORDER order, enum CBLAS_UPLO Uplo, blasint n, void *VALPHA
   buffer = (FLOAT *)blas_memory_alloc(1);
 
 #ifdef SMP
-  nthreads = num_cpu_avail(2);
+  // see graph in issue #1820 for explanation and room for improvement
+  if (n<362) {
+	  nthreads = 1 ;
+  } else {
+  	  nthreads = num_cpu_avail(2);
+  };
 
   if (nthreads == 1) {
 #endif

--- a/interface/zhemv.c
+++ b/interface/zhemv.c
@@ -43,6 +43,10 @@
 #include "functable.h"
 #endif
 
+// this is smallest dimension N of square input a to permit threading
+// see graph in issue #1820 for explanation
+#define MULTI_THREAD_MINIMAL 362
+
 #ifdef XDOUBLE
 #define ERROR_NAME "XHEMV "
 #elif defined(DOUBLE)
@@ -195,8 +199,7 @@ void CNAME(enum CBLAS_ORDER order, enum CBLAS_UPLO Uplo, blasint n, void *VALPHA
   buffer = (FLOAT *)blas_memory_alloc(1);
 
 #ifdef SMP
-  // see graph in issue #1820 for explanation and room for improvement
-  if (n<362) {
+  if (n<MULTI_THREAD_MINIMAL) {
 	  nthreads = 1 ;
   } else {
   	  nthreads = num_cpu_avail(2);


### PR DESCRIPTION
Use more than one thread once there is improvement as illustrated in a graph.
Since there is still a heap of uncertainty and room fro improvement left take following shortcuts:
* use same pre-computed threshold for c_ and z_ versions (see graph in issue - z_ gains from multiple threads, c_ uses second when its gain gets stable)
* dont read global CPU number if we decide one is enough

