### PR TITLE
Fix detection of Ryzen2 (missing CORE_ZEN)

### DIFF
--- a/cpuid_x86.c
+++ b/cpuid_x86.c
@@ -2009,6 +2009,8 @@ int get_coretype(void){
 	switch (model) {
 	case 1:
 	  // AMD Ryzen
+	case 8:
+	  // Ryzen 2		
 	  if(support_avx())
 #ifndef NO_AVX2
 	    return CORE_ZEN;


### PR DESCRIPTION
omission in #1665 - fixes #1835 (and #1664)