### PR TITLE
Ensure that blas_thread_init has been called in openblas_set_num_threads

### DIFF
--- a/driver/others/blas_server.c
+++ b/driver/others/blas_server.c
@@ -850,6 +850,11 @@ void goto_set_num_threads(int num_threads) {
 
   long i;
 
+#ifdef SMP_SERVER
+  // Handle lazy re-init of the thread-pool after a POSIX fork
+  if (unlikely(blas_server_avail == 0)) blas_thread_init();
+#endif
+
   if (num_threads < 1) num_threads = blas_num_threads;
 
 #ifndef NO_AFFINITY

--- a/driver/others/blas_server_win32.c
+++ b/driver/others/blas_server_win32.c
@@ -478,7 +478,12 @@ int BLASFUNC(blas_thread_shutdown)(void){
 
 void goto_set_num_threads(int num_threads)
 {
-	 long i;
+	long i;
+
+#if defined(SMP_SERVER) && defined(OS_CYGWIN_NT)
+	// Handle lazy re-init of the thread-pool after a POSIX fork
+	if (unlikely(blas_server_avail == 0)) blas_thread_init();
+#endif
 
 	if (num_threads < 1) num_threads = blas_cpu_number;
 


### PR DESCRIPTION
Not doing so can lead to bugs if the process happens to have been forked at some point.  For example:

```c
pid = fork();
if (pid) {
    openblas_set_num_thread(8);
    // <call some multi-threaded blas function (dgemm, etc.)>
}
```

This leads to segfaults because currently `openblas_set_num_threads` assumes `blas_thread_init()` has already been called and `blas_server_avail == 1`.  But after a fork, due to the `pthread_atfork` handler which calls `blas_thread_shutdown`, this is no longer the case.  But then when you get into `exec_blas_async` it does call `blas_thread_init()` even though there are already threads running, creating a likelihood that one or more of those threads segfault.