### PR TITLE
Initialize complex _dot result variable consistently at declaration time

### DIFF
--- a/kernel/arm/zdot.c
+++ b/kernel/arm/zdot.c
@@ -42,15 +42,12 @@ OPENBLAS_COMPLEX_FLOAT CNAME(BLASLONG n, FLOAT *x, BLASLONG inc_x, FLOAT *y, BLA
 	BLASLONG i=0;
 	BLASLONG ix=0,iy=0;
 	FLOAT dot[2];
-	OPENBLAS_COMPLEX_FLOAT result;
+	OPENBLAS_COMPLEX_FLOAT result=OPENBLAS_MAKE_COMPLEX_FLOAT(0.0,0.0);
 	BLASLONG inc_x2;
 	BLASLONG inc_y2;
 
 	dot[0]=0.0;
 	dot[1]=0.0;
-
-	CREAL(result) = 0.0 ;
-	CIMAG(result) = 0.0 ;
 
 	if ( n < 1 )  return(result);
 

--- a/kernel/arm64/zdot_thunderx2t99.c
+++ b/kernel/arm64/zdot_thunderx2t99.c
@@ -312,9 +312,7 @@ OPENBLAS_COMPLEX_FLOAT CNAME(BLASLONG n, FLOAT *x, BLASLONG inc_x, FLOAT *y, BLA
 	int nthreads;
 	FLOAT dummy_alpha;
 #endif
-	OPENBLAS_COMPLEX_FLOAT zdot;
-       CREAL(zdot) = 0.0;
-       CIMAG(zdot) = 0.0;
+	OPENBLAS_COMPLEX_FLOAT zdot = OPENBLAS_MAKE_COMPLEX_FLOAT(0.0,0.0);
 
 #if defined(SMP)
 	if (inc_x == 0 || inc_y == 0 || n <= 10000)

--- a/kernel/mips/cdot_msa.c
+++ b/kernel/mips/cdot_msa.c
@@ -58,13 +58,10 @@ OPENBLAS_COMPLEX_FLOAT CNAME(BLASLONG n, FLOAT *x, BLASLONG inc_x, FLOAT *y, BLA
     v4f32 dot5 = {0, 0, 0, 0};
     v4f32 dot6 = {0, 0, 0, 0};
     v4f32 dot7 = {0, 0, 0, 0};
-    OPENBLAS_COMPLEX_FLOAT result;
+    OPENBLAS_COMPLEX_FLOAT result=OPENBLAS_MAKE_COMPLEX_FLOAT(0.0,0.0);
 
     dot[0] = 0.0;
     dot[1] = 0.0;
-
-    CREAL(result) = 0.0;
-    CIMAG(result) = 0.0;
 
     if (n < 1) return (result);
 

--- a/kernel/mips/zdot.c
+++ b/kernel/mips/zdot.c
@@ -32,15 +32,12 @@ OPENBLAS_COMPLEX_FLOAT CNAME(BLASLONG n, FLOAT *x, BLASLONG inc_x, FLOAT *y, BLA
 	BLASLONG i=0;
 	BLASLONG ix=0,iy=0;
 	FLOAT dot[2];
-	OPENBLAS_COMPLEX_FLOAT result;
+	OPENBLAS_COMPLEX_FLOAT result=OPENBLAS_MAKE_COMPLEX_FLOAT(0.0,0.0);
 	BLASLONG inc_x2;
 	BLASLONG inc_y2;
 
 	dot[0]=0.0;
 	dot[1]=0.0;
-
-	CREAL(result) = 0.0 ;
-	CIMAG(result) = 0.0 ;
 
 	if ( n < 1 )  return(result);
 

--- a/kernel/mips/zdot_msa.c
+++ b/kernel/mips/zdot_msa.c
@@ -58,13 +58,10 @@ OPENBLAS_COMPLEX_FLOAT CNAME(BLASLONG n, FLOAT *x, BLASLONG inc_x, FLOAT *y, BLA
     v2f64 dot6 = {0, 0};
     v2f64 dot7 = {0, 0};
     v2f64 zero = {0, 0};
-    OPENBLAS_COMPLEX_FLOAT result;
+    OPENBLAS_COMPLEX_FLOAT result=OPENBLAS_MAKE_COMPLEX_FLOAT(0.0,0.0);
 
     dot[0] = 0.0;
     dot[1] = 0.0;
-
-    CREAL(result) = 0.0;
-    CIMAG(result) = 0.0;
 
     if (n < 1) return (result);
 

--- a/kernel/zarch/zdot.c
+++ b/kernel/zarch/zdot.c
@@ -154,12 +154,12 @@ static  void zdot_kernel_8(BLASLONG n, FLOAT *x, FLOAT *y, FLOAT *d) {
 OPENBLAS_COMPLEX_FLOAT CNAME(BLASLONG n, FLOAT *x, BLASLONG inc_x, FLOAT *y, BLASLONG inc_y) {
     BLASLONG i = 0;
     BLASLONG ix=0, iy=0;
-    OPENBLAS_COMPLEX_FLOAT result;
+    OPENBLAS_COMPLEX_FLOAT result=OPENBLAS_MAKE_COMPLEX_FLOAT(0.0,0.0);
     FLOAT dot[4] __attribute__ ((aligned(16))) = {0.0, 0.0, 0.0, 0.0};
 
     if (n <= 0) {
-        CREAL(result) = 0.0;
-        CIMAG(result) = 0.0;
+        /* CREAL(result) = 0.0;
+        CIMAG(result) = 0.0; */
         return (result);
 
     }


### PR DESCRIPTION
Fix one bug and wrap similar fragments to avoid confusing static checker that found it (`cppcheck-1.82-lp150.1.1.x86_64`)

@sharkcz should be minor change and for good?
