### PR TITLE
Correct link flags for PGI compiler.

### DIFF
--- a/f_check
+++ b/f_check
@@ -292,9 +292,6 @@ if ($link ne "") {
 	    && ($flags !~ /^-LIST:/)
 	    && ($flags !~ /^-LANG:/)
 	    ) {
-	    if ($vendor eq "PGI") {
-		$flags =~ s/lib$/libso/;
-	    }
 	    $linker_L .= $flags . " ";
 	}
 
@@ -311,17 +308,11 @@ if ($link ne "") {
 
 	if ($flags =~ /^\-rpath\@/) {
 	    $flags =~ s/\@/\,/g;
-	    if ($vendor eq "PGI") {
-		$flags =~ s/lib$/libso/;
-	    }
 	    $linker_L .= "-Wl,". $flags . " " ;
 	}
 
 	if ($flags =~ /^\-rpath-link\@/) {
 	    $flags =~ s/\@/\,/g;
-	    if ($vendor eq "PGI") {
-		$flags =~ s/lib$/libso/;
-	    }
 	    $linker_L .= "-Wl,". $flags . " " ;
 	}
 
@@ -330,7 +321,6 @@ if ($link ne "") {
 	    && ($flags !~ /gfortranbegin/)
 	    && ($flags !~ /frtbegin/)
 	    && ($flags !~ /pathfstart/)
-	    && ($flags !~ /numa/)
 	    && ($flags !~ /crt[0-9]/)
 	    && ($flags !~ /gcc/)
 	    && ($flags !~ /user32/)


### PR DESCRIPTION
I have recently been building openblas with the PGI fortran compiler (18.4) and bumped into a couple of issues. The code from `f_check` for the PGI compiler is dating from the initial import from GOTOblas according from git blame, but even so I am still wondering what the original motivation was.

* f_check currently replace `lib` by `libso` for the path of libraries, specifically for the PGI compiler without explanations. This is also wrong with a recent version of the compiler. Those path are extracted from a verbose call to the compiler and there is no reasons for them to have ever been wrong (that I can fathom).

* Still from the initial import from GOTOblas some libraries are arbitrarily removed from the list of libraries. However in recent version of pgfortran `-lnuma` is needed for openmp support so it shouldn't be filtered.