### PR TITLE
Re-calibrate _AXPY functions

### DIFF
--- a/interface/axpy.c
+++ b/interface/axpy.c
@@ -46,6 +46,10 @@
 #else
 #define MULTI_THREAD_MINIMAL  10000
 #endif
+#if defined(ARCH_X86) || defined(ARCH_X86_64)
+#define MULTI_THREAD_MAX_NUM 2
+#endif
+
 #ifndef CBLAS
 
 void NAME(blasint *N, FLOAT *ALPHA, FLOAT *x, blasint *INCX, FLOAT *y, blasint *INCY){
@@ -91,7 +95,11 @@ void CNAME(blasint n, FLOAT alpha, FLOAT *x, blasint incx, FLOAT *y, blasint inc
   if (incx == 0 || incy == 0 || n <= MULTI_THREAD_MINIMAL)
 	  nthreads = 1;
   else
+#ifdef MULTI_THREAD_MAX_NUM
+	  nthreads = MIN(MULTI_THREAD_MAX_NUM,num_cpu_avail(1));
+#else
 	  nthreads = num_cpu_avail(1);
+#endif
 
   if (nthreads == 1) {
 #endif

--- a/interface/zaxpy.c
+++ b/interface/zaxpy.c
@@ -46,6 +46,9 @@
 #else
 #define MULTI_THREAD_MINIMAL  10000
 #endif
+#if defined(ARCH_X86) || defined(ARCH_X86_64)
+#define MULTI_THREAD_MAX_NUM 2
+#endif
 #ifndef CBLAS
 
 void NAME(blasint *N, FLOAT *ALPHA, FLOAT *x, blasint *INCX, FLOAT *y, blasint *INCY){
@@ -98,7 +101,11 @@ void CNAME(blasint n, FLOAT *ALPHA, FLOAT *x, blasint incx, FLOAT *y, blasint in
   if (incx == 0 || incy == 0 || n <= MULTI_THREAD_MINIMAL)
 	  nthreads = 1;
   else
+#ifdef MULTI_THREAD_MAX_NUM
+          nthreads = MIN(MULTI_THREAD_MAX_NUM,num_cpu_avail(1));
+#else
 	  nthreads = num_cpu_avail(1);
+#endif
 
   if (nthreads == 1) {
 #endif


### PR DESCRIPTION
Sadly did not stand a chance to to view this in scope of #1883 
* Sweet spot to switch on 2nd thread would be between 30-40kB input and adds 20-30% performance after (with 20x regression when input measures 2kB, below existing threshold), current threshold is close to optimal and keeps pessimal range out for good.
* adding 3rd and 4th core to work gives lower than 1-core performance up until about 20-25MB there, reaching 2-core speed, but using all CPU cores fully, as seen from system side.
* (presumably memory controller saturates, if we have two they have separate memories attached, unlikely to get set up/scheduled gainfully for this case)
* speculatively accommodate X86, as even preserved, real X86 would not have much cores, so the X86 coDe is more likely to use real X86_64.
* we just let system park/reuse other cores, so we get smaller power budget & hopefully 1usec faster result.
