### PR TITLE
Fix freebsd clang compilation of skylakex

### DIFF
--- a/kernel/x86_64/sgemm_beta_skylakex.c
+++ b/kernel/x86_64/sgemm_beta_skylakex.c
@@ -56,7 +56,7 @@ int CNAME(BLASLONG m, BLASLONG n, BLASLONG dummy1, FLOAT beta,
   }
 
   if (n == 0 || m == 0)
-	return;
+	return 0;
 
   c_offset = c;
 


### PR DESCRIPTION
Other compilers dont seem to mind, even gcc in same system.