### PR TITLE
revert MIPS64 xDOT kernel changes from #1832

### DIFF
--- a/kernel/mips64/KERNEL
+++ b/kernel/mips64/KERNEL
@@ -1,9 +1,9 @@
 CAXPYKERNEL = ../mips/zaxpy.c
 ZAXPYKERNEL = ../mips/zaxpy.c
-SROTKERNEL = ../mips/rot.c
-DROTKERNEL = ../mips/rot.c
-CROTKERNEL = ../mips/zrot.c
-ZROTKERNEL = ../mips/zrot.c
+SROTKERNEL  = ../mips/rot.c
+DROTKERNEL  = ../mips/rot.c
+CROTKERNEL  = ../mips/zrot.c
+ZROTKERNEL  = ../mips/zrot.c
 CSWAPKERNEL = ../mips/zswap.c
 ZSWAPKERNEL = ../mips/zswap.c
 

--- a/kernel/mips64/KERNEL.LOONGSON3A
+++ b/kernel/mips64/KERNEL.LOONGSON3A
@@ -63,6 +63,7 @@ ZTRSMKERNEL_LT	= ../generic/trsm_kernel_LT.c
 ZTRSMKERNEL_RN	= ../generic/trsm_kernel_RN.c
 ZTRSMKERNEL_RT	= ../generic/trsm_kernel_RT.c
 
+DSDOTKERNEL     = ../mips/dot.c
 
 
 


### PR DESCRIPTION
use generic C implementation for DSDOTKERNEL on Loongson3A instead as it seems my hackish fix
from #1684 does not work well on serious hardware.