### PR TITLE
Use correct ARCH name on BSD powerpc64

### DIFF
--- a/Makefile.system
+++ b/Makefile.system
@@ -11,7 +11,11 @@ endif
 
 # Catch conflicting usage of ARCH in some BSD environments
 ifeq ($(ARCH), amd64)
-override ARCH=x86_64
+override ARCH=x86_64 
+else ifeq ($(ARCH), powerpc64)
+override ARCH=power
+endif
+
 endif
 
 NETLIB_LAPACK_DIR = $(TOPDIR)/lapack-netlib
@@ -1060,11 +1064,7 @@ endif
 
 KERNELDIR	= $(TOPDIR)/kernel/$(ARCH)
 
-ifneq ($(ARCH), powerpc64)
 include $(TOPDIR)/Makefile.$(ARCH)
-else
-include $(TOPDIR)/Makefile.power
-endif
 
 CCOMMON_OPT	+= -DASMNAME=$(FU)$(*F) -DASMFNAME=$(FU)$(*F)$(BU) -DNAME=$(*F)$(BU) -DCNAME=$(*F) -DCHAR_NAME=\"$(*F)$(BU)\" -DCHAR_CNAME=\"$(*F)\"
 

--- a/Makefile.system
+++ b/Makefile.system
@@ -1060,7 +1060,11 @@ endif
 
 KERNELDIR	= $(TOPDIR)/kernel/$(ARCH)
 
+ifneq ($(ARCH), powerpc64)
 include $(TOPDIR)/Makefile.$(ARCH)
+else
+include $(TOPDIR)/Makefile.power
+endif
 
 CCOMMON_OPT	+= -DASMNAME=$(FU)$(*F) -DASMFNAME=$(FU)$(*F)$(BU) -DNAME=$(*F)$(BU) -DCNAME=$(*F) -DCHAR_NAME=\"$(*F)$(BU)\" -DCHAR_CNAME=\"$(*F)\"
 

--- a/Makefile.system
+++ b/Makefile.system
@@ -16,8 +16,6 @@ else ifeq ($(ARCH), powerpc64)
 override ARCH=power
 endif
 
-endif
-
 NETLIB_LAPACK_DIR = $(TOPDIR)/lapack-netlib
 
 # Default C compiler


### PR DESCRIPTION
FreeBSD uses powerpc64 name for POWER architecture. Use correct Makefile for this platform.