### PR TITLE
Fix two mistakes on Arm64 builds

### DIFF
--- a/Makefile.arm64
+++ b/Makefile.arm64
@@ -30,8 +30,8 @@ FCOMMON_OPT += -march=armv8-a -mtune=thunderx
 endif
 
 ifeq ($(CORE), FALKOR)
-CCOMMON_OPT += -march=armv8.1-a -mtune=falkor
-FCOMMON_OPT += -march=armv8.1-a -mtune=falkor
+CCOMMON_OPT += -march=armv8-a -mtune=falkor
+FCOMMON_OPT += -march=armv8-a -mtune=falkor
 endif
 
 ifeq ($(CORE), THUNDERX2T99)

--- a/cpuid_arm64.c
+++ b/cpuid_arm64.c
@@ -270,7 +270,7 @@ void get_cpuconfig(void)
 			break;
 
 		case CPU_THUNDERX2T99:
-			printf("#define VULCAN                        \n");
+			printf("#define THUNDERX2T99                  \n");
 			printf("#define L1_CODE_SIZE         32768    \n");
 			printf("#define L1_CODE_LINESIZE     64       \n");
 			printf("#define L1_CODE_ASSOCIATIVE  8        \n");


### PR DESCRIPTION
 * Falkor is an ARMv8.0 with ARMv8.1 features, and chosing armv8.1-a for
   march generates instructions it cannot cope with. Reverting it back
   to armv8-a.
 * ThunderX2's build was left with a #define VULCAN, which made it miss
   the right compiler flags in Makefile.arm64, although it did create
   the right library in the end.