### PR TITLE
Attempt to maintain cache line alignment in BLAS L1 work splitter.

### DIFF
--- a/driver/others/blas_l1_thread.c
+++ b/driver/others/blas_l1_thread.c
@@ -65,7 +65,7 @@ int blas_level1_thread(int mode, BLASLONG m, BLASLONG n, BLASLONG k, void *alpha
     /* Adjust Parameters */
     width  = blas_quickdivide(i + nthreads - num_cpu - 1,
 			      nthreads - num_cpu);
-
+    width = MAX(width,((width-1)&~15)+16);
     i -= width;
     if (i < 0) width = width + i;
 
@@ -136,7 +136,7 @@ int blas_level1_thread_with_return_value(int mode, BLASLONG m, BLASLONG n, BLASL
     /* Adjust Parameters */
     width  = blas_quickdivide(i + nthreads - num_cpu - 1,
 			      nthreads - num_cpu);
-
+    width = MAX(width,((width-1)&~15)+16);
     i -= width;
     if (i < 0) width = width + i;
 


### PR DESCRIPTION
Ugly one-liner to take out easily because of being incomplete as follows:
It aligns to 16 elements which makes 64bytes for S and multiples thereof for others. Still devlivers promise in subject.

... measuring axpy 3rd thread (unconstrained at interface) makes result always few percent better than 2 first only, no matter arg size or thread oddness, they were before ups and downs.
... Threading threshold can be much lower than 2MB estimated before for axpy etc (more PRs to follow), there is small improvement in all odd-sized cases even with current thresholds.
