### PR TITLE
Fix for DYNAMIC_ARCH builds made on a AVX512-capable host

### DIFF
--- a/Makefile.x86_64
+++ b/Makefile.x86_64
@@ -9,6 +9,7 @@ endif
 endif
 
 ifeq ($(CORE), SKYLAKEX)
+ifndef DYNAMIC_ARCH
 ifndef NO_AVX512
 CCOMMON_OPT += -march=skylake-avx512
 FCOMMON_OPT += -march=skylake-avx512
@@ -18,6 +19,7 @@ endif
 ifeq ($(OSNAME), WINNT)
 ifeq ($(C_COMPILER), GCC)
 CCOMMON_OPT += -fno-asynchronous-unwind-tables
+endif
 endif
 endif
 endif

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -6,7 +6,11 @@ TOPDIR	= ..
 include $(TOPDIR)/Makefile.system
 
 ifdef TARGET_CORE
+ifeq ($(TARGET_CORE), SKYLAKEX)
+override CFLAGS += -DBUILD_KERNEL -DTABLE_NAME=gotoblas_$(TARGET_CORE) -march=skylake-avx512
+else
 override CFLAGS += -DBUILD_KERNEL -DTABLE_NAME=gotoblas_$(TARGET_CORE)
+endif
 BUILD_KERNEL = 1
 KDIR =
 TSUFFIX = _$(TARGET_CORE)

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -7,7 +7,15 @@ include $(TOPDIR)/Makefile.system
 
 ifdef TARGET_CORE
 ifeq ($(TARGET_CORE), SKYLAKEX)
-override CFLAGS += -DBUILD_KERNEL -DTABLE_NAME=gotoblas_$(TARGET_CORE) -march=skylake-avx512
+ override CFLAGS += -DBUILD_KERNEL -DTABLE_NAME=gotoblas_$(TARGET_CORE) -march=skylake-avx512
+ ifeq ($(OSNAME), CYGWIN_NT)
+  override CFLAGS += -fno-asynchronous-unwind-tables
+ endif
+ ifeq ($(OSNAME), WINNT)
+  ifeq ($(C_COMPILER), GCC)
+   override CFLAGS += -fno-asynchronous-unwind-tables
+  endif
+ endif
 else
 override CFLAGS += -DBUILD_KERNEL -DTABLE_NAME=gotoblas_$(TARGET_CORE)
 endif


### PR DESCRIPTION
Problem noticed in #1909 - the -march=skylake-avx512 option would get added even to the shared parts of the code when the build host itself was SkylakeX, potentially making the library unusable on less capable hardware despite the intention of DYNAMIC_ARCH. 