### PR TITLE
Delete the pthread key on cleanup in TLS mode

### DIFF
--- a/driver/others/memory.c
+++ b/driver/others/memory.c
@@ -1073,6 +1073,11 @@ static volatile int memory_initialized = 0;
     }
     free(table);
   }
+#if defined(OS_WINDOWS)
+  TlsFree(local_storage_key);
+#else
+  pthread_key_delete(local_storage_key);
+#endif		
 }
 
 static void blas_memory_init(){


### PR DESCRIPTION
to avoid a crash when OpenBLAS was loaded via dlopen and libc tries to clean up the leaked TLS after dlclose
Fixes #1720 as suggested by amurzeau in that PR.