### PR TITLE
Query AVX2 and AVX512VL support when selecting x86 kernels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -153,7 +153,7 @@ matrix:
       before_script:
         - COMMON_FLAGS="DYNAMIC_ARCH=1 TARGET=NEHALEM NUM_THREADS=32"
         - brew update
-        - brew install gcc # for gfortran
+        - travis_wait 30 brew install gcc # for gfortran
       script:
         - travis_wait 45 make QUIET_MAKE=1 $COMMON_FLAGS $BTYPE
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -149,11 +149,11 @@ matrix:
 
     - &test-macos
       os: osx
-      osx_image: xcode8
+      osx_image: xcode8.3
       before_script:
         - COMMON_FLAGS="DYNAMIC_ARCH=1 TARGET=NEHALEM NUM_THREADS=32"
         - brew update
-        - travis_wait 30 brew install gcc # for gfortran
+        - brew install gcc # for gfortran
       script:
         - travis_wait 45 make QUIET_MAKE=1 $COMMON_FLAGS $BTYPE
       env:

--- a/common_x86_64.h
+++ b/common_x86_64.h
@@ -134,7 +134,7 @@ static __inline void cpuid(int op, int *eax, int *ebx, int *ecx, int *edx){
 			     "=b" (*ebx),
 			     "=c" (*ecx),
 			     "=d" (*edx)
-			     : "0" (op));
+			     : "0" (op), "c"(0));
 #endif
 }
 

--- a/cpuid.h
+++ b/cpuid.h
@@ -139,6 +139,7 @@
 #define HAVE_FMA4     (1 <<  19)
 #define HAVE_FMA3     (1 <<  20)
 #define HAVE_AVX512VL (1 <<  21)
+#define HAVE_AVX2     (1 <<  22)
 
 #define CACHE_INFO_L1_I     1
 #define CACHE_INFO_L1_D     2

--- a/cpuid_x86.c
+++ b/cpuid_x86.c
@@ -239,6 +239,8 @@ int support_avx512(){
       ret=0;  //OS does not even support AVX2
   }
   if((ebx & (1<<31)) != 0){
+    xgetbv(0, &eax, &edx); 
+    if((eax & 0xe0) == 0xe0)
       ret=1;  //OS supports AVX512VL
   }
   return ret;

--- a/driver/others/dynamic.c
+++ b/driver/others/dynamic.c
@@ -346,7 +346,7 @@ extern void openblas_warning(int verbose, const char * msg);
 #define FALLBACK_VERBOSE 1
 #define NEHALEM_FALLBACK "OpenBLAS : Your OS does not support AVX instructions. OpenBLAS is using Nehalem kernels as a fallback, which may give poorer performance.\n"
 #define SANDYBRIDGE_FALLBACK "OpenBLAS : Your OS does not support AVX2 instructions. OpenBLAS is using Sandybridge kernels as a fallback, which may give poorer performance.\n"
-#define HASWELL_FALLBACK "OpenBLAS : Your OS does not support AVX512 instructions. OpenBLAS is using Haswell kernels as a fallback, which may give poorer performance.\n"
+#define HASWELL_FALLBACK "OpenBLAS : Your OS does not support AVX512VL instructions. OpenBLAS is using Haswell kernels as a fallback, which may give poorer performance.\n"
 #define BARCELONA_FALLBACK "OpenBLAS : Your OS does not support AVX instructions. OpenBLAS is using Barcelona kernels as a fallback, which may give poorer performance.\n"
 
 static int get_vendor(void){
@@ -526,8 +526,10 @@ static gotoblas_t *get_coretype(void){
 	// Intel Skylake X
           if (support_avx512()) 
 	    return &gotoblas_SKYLAKEX;
-	  if(support_avx2())
+	  if(support_avx2()){
+	    openblas_warning(FALLBACK_VERBOSE, HASWELL_FALLBACK);
 	    return &gotoblas_HASWELL;
+          }
 	  if(support_avx()) {
 	    openblas_warning(FALLBACK_VERBOSE, SANDYBRIDGE_FALLBACK);
 	    return &gotoblas_SANDYBRIDGE;
@@ -550,8 +552,10 @@ static gotoblas_t *get_coretype(void){
 	}
 	//Intel Phi Knights Landing
 	if (model == 7) {
-	  if(support_avx2())
+	  if(support_avx2()){
+	    openblas_warning(FALLBACK_VERBOSE, HASWELL_FALLBACK);
 	    return &gotoblas_HASWELL;
+	  }  
 	  if(support_avx()) {
 	    openblas_warning(FALLBACK_VERBOSE, SANDYBRIDGE_FALLBACK);
 	    return &gotoblas_SANDYBRIDGE;

--- a/driver/others/dynamic.c
+++ b/driver/others/dynamic.c
@@ -332,6 +332,8 @@ int support_avx512(){
       ret=0;  //OS does not even support AVX2
   }
   if((ebx & (1<<31)) != 0){
+    xgetbv(0, &eax, &edx);
+    if((eax & 0xe0) == 0xe0)
       ret=1;  //OS supports AVX512VL
   }
   return ret;


### PR DESCRIPTION
For #1947 (and corresponding earlier cases involving Haswell) where VM or OS limitations made otherwise standard features of the correctly detected CPU model unavailable.