### PR TITLE
Modrenize R benchmarks slightly

### DIFF
--- a/benchmark/scripts/R/deig.R
+++ b/benchmark/scripts/R/deig.R
@@ -33,7 +33,7 @@ cat(sprintf("      SIZE             Flops                   Time\n"))
 
 n <- nfrom
 while (n <= nto) {
-  A <- matrix(rnorm(n * n), ncol = n, nrow = n)
+  A <- matrix(rnorm(n * n), nrow = n)
   ev <- 0
   z <- system.time(for (l in 1:loops) {
     ev <- eigen(A)

--- a/benchmark/scripts/R/deig.R
+++ b/benchmark/scripts/R/deig.R
@@ -2,6 +2,8 @@
 
 argv <- commandArgs(trailingOnly = TRUE)
 
+if (!is.null(options("matprod")[[1]])) options(matprod = "blas")
+
 nfrom <- 128
 nto <- 2048
 nstep <- 128
@@ -19,7 +21,6 @@ if (length(argv) > 0) {
       loops <- as.numeric(argv[z])
     }
   }
-
 }
 
 p <- Sys.getenv("OPENBLAS_LOOPS")
@@ -27,14 +28,7 @@ if (p != "") {
   loops <- as.numeric(p)
 }
 
-
-cat(sprintf(
-  "From %.0f To %.0f Step=%.0f Loops=%.0f\n",
-  nfrom,
-  nto,
-  nstep,
-  loops
-))
+cat(sprintf("From %.0f To %.0f Step=%.0f Loops=%.0f\n", nfrom, nto, nstep, loops))
 cat(sprintf("      SIZE             Flops                   Time\n"))
 
 n <- nfrom
@@ -45,11 +39,10 @@ while (n <= nto) {
     ev <- eigen(A)
   })
 
-  mflops <- (26.66 * n * n * n) * loops / (z[3] * 1.0e6)
+  mflops <- (26.66 * n * n * n) * loops / (z[3] * 1e+06)
 
   st <- sprintf("%.0fx%.0f :", n, n)
   cat(sprintf("%20s %10.2f MFlops %10.6f sec\n", st, mflops, z[3]))
 
   n <- n + nstep
-
 }

--- a/benchmark/scripts/R/dgemm.R
+++ b/benchmark/scripts/R/dgemm.R
@@ -2,6 +2,8 @@
 
 argv <- commandArgs(trailingOnly = TRUE)
 
+if (!is.null(options("matprod")[[1]])) options(matprod = "blas")
+
 nfrom <- 128
 nto <- 2048
 nstep <- 128
@@ -19,7 +21,6 @@ if (length(argv) > 0) {
       loops <- as.numeric(argv[z])
     }
   }
-
 }
 
 p <- Sys.getenv("OPENBLAS_LOOPS")
@@ -27,26 +28,13 @@ if (p != "") {
   loops <- as.numeric(p)
 }
 
-
-cat(sprintf(
-  "From %.0f To %.0f Step=%.0f Loops=%.0f\n",
-  nfrom,
-  nto,
-  nstep,
-  loops
-))
+cat(sprintf("From %.0f To %.0f Step=%.0f Loops=%.0f\n", nfrom, nto, nstep, loops))
 cat(sprintf("      SIZE             Flops                   Time\n"))
 
 n <- nfrom
 while (n <= nto) {
-  A <- matrix(runif(n * n),
-              ncol = n,
-              nrow = n,
-              byrow = TRUE)
-  B <- matrix(runif(n * n),
-              ncol = n,
-              nrow = n,
-              byrow = TRUE)
+  A <- matrix(runif(n * n), nrow = n)
+  B <- matrix(runif(n * n), nrow = n)
   C <- 1
 
   z <- system.time(for (l in 1:loops) {
@@ -54,11 +42,10 @@ while (n <= nto) {
     l <- l + 1
   })
 
-  mflops <- (2.0 * n * n * n) * loops / (z[3] * 1.0e6)
+  mflops <- (2.0 * n * n * n) * loops / (z[3] * 1e+06)
 
   st <- sprintf("%.0fx%.0f :", n, n)
   cat(sprintf("%20s %10.2f MFlops %10.6f sec\n", st, mflops, z[3]))
 
   n <- n + nstep
-
 }

--- a/benchmark/scripts/R/dsolve.R
+++ b/benchmark/scripts/R/dsolve.R
@@ -2,6 +2,10 @@
 
 argv <- commandArgs(trailingOnly = TRUE)
 
+if (!is.null(options("matprod")[[1]])) {
+  options(matprod = "blas")
+}
+
 nfrom <- 128
 nto <- 2048
 nstep <- 128
@@ -19,7 +23,6 @@ if (length(argv) > 0) {
       loops <- as.numeric(argv[z])
     }
   }
-
 }
 
 p <- Sys.getenv("OPENBLAS_LOOPS")
@@ -27,31 +30,23 @@ if (p != "") {
   loops <- as.numeric(p)
 }
 
-
-cat(sprintf(
-  "From %.0f To %.0f Step=%.0f Loops=%.0f\n",
-  nfrom,
-  nto,
-  nstep,
-  loops
-))
+cat(sprintf("From %.0f To %.0f Step=%.0f Loops=%.0f\n", nfrom, nto, nstep, loops))
 cat(sprintf("      SIZE             Flops                   Time\n"))
 
 n <- nfrom
 while (n <= nto) {
-  A <- matrix(rnorm(n * n), ncol = n, nrow = n)
-  B <- matrix(rnorm(n * n), ncol = n, nrow = n)
+  A <- matrix(rnorm(n * n), nrow = n)
+  B <- matrix(rnorm(n * n), nrow = n)
 
   z <- system.time(for (l in 1:loops) {
     solve(A, B)
   })
 
-  mflops <-
-    (2.0 / 3.0 * n * n * n + 2.0 * n * n * n) * loops / (z[3] * 1.0e6)
+  mflops <- (2.0/3 * n * n * n + 2 * n * n * n) * loops/ (z[3] * 1e6)
 
   st <- sprintf("%.0fx%.0f :", n, n)
   cat(sprintf("%20s %10.2f MFlops %10.6f sec\n", st, mflops, z[3]))
 
   n <- n + nstep
-
 }
+

--- a/benchmark/scripts/R/dsolve.R
+++ b/benchmark/scripts/R/dsolve.R
@@ -40,7 +40,7 @@ while (n <= nto) {
     solve(A, B)
   })
 
-  mflops <- (2.0/3 * n * n * n + 2 * n * n * n) * loops/ (z[3] * 1e+06)
+  mflops <- (8.0 / 3 * n * n * n) * loops / (z[3] * 1e+06)
 
   st <- sprintf("%.0fx%.0f :", n, n)
   cat(sprintf("%20s %10.2f MFlops %10.6f sec\n", st, mflops, z[3]))

--- a/benchmark/scripts/R/dsolve.R
+++ b/benchmark/scripts/R/dsolve.R
@@ -2,9 +2,7 @@
 
 argv <- commandArgs(trailingOnly = TRUE)
 
-if (!is.null(options("matprod")[[1]])) {
-  options(matprod = "blas")
-}
+if (!is.null(options("matprod")[[1]])) options(matprod = "blas")
 
 nfrom <- 128
 nto <- 2048
@@ -42,11 +40,10 @@ while (n <= nto) {
     solve(A, B)
   })
 
-  mflops <- (2.0/3 * n * n * n + 2 * n * n * n) * loops/ (z[3] * 1e6)
+  mflops <- (2.0/3 * n * n * n + 2 * n * n * n) * loops/ (z[3] * 1e+06)
 
   st <- sprintf("%.0fx%.0f :", n, n)
   cat(sprintf("%20s %10.2f MFlops %10.6f sec\n", st, mflops, z[3]))
 
   n <- n + nstep
 }
-


### PR DESCRIPTION
Disable NaN checks in R>=3.4.0  - we generate matrix() without NaNs, and after that do not care about numeric outcome (1)
Compact vertically - whitespace and let output format exceed 80 chars
Horizontally - simplify formulas and minimize matrix parameter count
 (RNG) runif is about 2x faster than rnorm - i have some dount if (1) is absolutely true though