### PR TITLE
Fix declaration of input arguments in the x86_64 SCAL microkernels

### DIFF
--- a/kernel/x86_64/cscal_microk_bulldozer-2.c
+++ b/kernel/x86_64/cscal_microk_bulldozer-2.c
@@ -116,11 +116,11 @@ static void cscal_kernel_16( BLASLONG n, FLOAT *alpha, FLOAT *x)
 	"vzeroupper					    \n\t"
 
 	:
-        : 
-	  "r" (n),  	// 0
-          "r" (x),      // 1
+	  "+r" (n),  	// 0
+          "+r" (x),      // 1
+        :
           "r" (alpha)   // 2
-	: "cc", //"%0", "%1",
+	: "cc",
 	  "%xmm0", "%xmm1", "%xmm2", "%xmm3", 
 	  "%xmm4", "%xmm5", "%xmm6", "%xmm7", 
 	  "%xmm8", "%xmm9", "%xmm10", "%xmm11", 
@@ -208,11 +208,11 @@ static void cscal_kernel_16_zero_r( BLASLONG n, FLOAT *alpha, FLOAT *x)
 	"vzeroupper					    \n\t"
 
 	:
-        : 
-	  "r" (n),  	// 0
-          "r" (x),      // 1
+	  "+r" (n),  	// 0
+          "+r" (x),     // 1
+        :
           "r" (alpha)   // 2
-	: "cc", //"%0", "%1",
+	: "cc",
 	  "%xmm0", "%xmm1", "%xmm2", "%xmm3", 
 	  "%xmm4", "%xmm5", "%xmm6", "%xmm7", 
 	  "%xmm8", "%xmm9", "%xmm10", "%xmm11", 
@@ -285,11 +285,11 @@ static void cscal_kernel_16_zero_i( BLASLONG n, FLOAT *alpha, FLOAT *x)
 	"vzeroupper					    \n\t"
 
 	:
-        : 
-	  "r" (n),  	// 0
-          "r" (x),      // 1
+	  "+r" (n),  	// 0
+          "+r" (x),     // 1
+        :
           "r" (alpha)   // 2
-	: "cc", //"%0", "%1",
+	: "cc",
 	  "%xmm0", "%xmm1", "%xmm2", "%xmm3", 
 	  "%xmm4", "%xmm5", "%xmm6", "%xmm7", 
 	  "%xmm8", "%xmm9", "%xmm10", "%xmm11", 
@@ -330,11 +330,11 @@ static void cscal_kernel_16_zero( BLASLONG n, FLOAT *alpha, FLOAT *x)
 	"vzeroupper					    \n\t"
 
 	:
-        : 
-	  "r" (n),  	// 0
-          "r" (x),      // 1
+	  "+r" (n),  	// 0
+          "+r" (x),     // 1
+        :
           "r" (alpha)   // 2
-	: "cc", //"%0", "%1",
+	: "cc",
 	  "%xmm0", "%xmm1", "%xmm2", "%xmm3", 
 	  "%xmm4", "%xmm5", "%xmm6", "%xmm7", 
 	  "%xmm8", "%xmm9", "%xmm10", "%xmm11", 

--- a/kernel/x86_64/cscal_microk_bulldozer-2.c
+++ b/kernel/x86_64/cscal_microk_bulldozer-2.c
@@ -117,7 +117,7 @@ static void cscal_kernel_16( BLASLONG n, FLOAT *alpha, FLOAT *x)
 
 	:
 	  "+r" (n),  	// 0
-          "+r" (x),      // 1
+          "+r" (x)      // 1
         :
           "r" (alpha)   // 2
 	: "cc",
@@ -209,7 +209,7 @@ static void cscal_kernel_16_zero_r( BLASLONG n, FLOAT *alpha, FLOAT *x)
 
 	:
 	  "+r" (n),  	// 0
-          "+r" (x),     // 1
+          "+r" (x)      // 1
         :
           "r" (alpha)   // 2
 	: "cc",
@@ -286,7 +286,7 @@ static void cscal_kernel_16_zero_i( BLASLONG n, FLOAT *alpha, FLOAT *x)
 
 	:
 	  "+r" (n),  	// 0
-          "+r" (x),     // 1
+          "+r" (x)      // 1
         :
           "r" (alpha)   // 2
 	: "cc",
@@ -331,7 +331,7 @@ static void cscal_kernel_16_zero( BLASLONG n, FLOAT *alpha, FLOAT *x)
 
 	:
 	  "+r" (n),  	// 0
-          "+r" (x),     // 1
+          "+r" (x)      // 1
         :
           "r" (alpha)   // 2
 	: "cc",

--- a/kernel/x86_64/cscal_microk_haswell-2.c
+++ b/kernel/x86_64/cscal_microk_haswell-2.c
@@ -117,7 +117,7 @@ static void cscal_kernel_16( BLASLONG n, FLOAT *alpha, FLOAT *x)
 
 	:
 	  "+r" (n),  	// 0
-          "+r" (x),      // 1
+          "+r" (x)      // 1
         :
           "r" (alpha)   // 2
 	: "cc",
@@ -209,7 +209,7 @@ static void cscal_kernel_16_zero_r( BLASLONG n, FLOAT *alpha, FLOAT *x)
 
 	:
 	  "+r" (n),  	// 0
-          "+r" (x),     // 1
+          "+r" (x)      // 1
         :
           "r" (alpha)   // 2
 	: "cc", // "0", "1",
@@ -286,7 +286,7 @@ static void cscal_kernel_16_zero_i( BLASLONG n, FLOAT *alpha, FLOAT *x)
 
 	:
 	  "+r" (n),  	// 0
-          "+r" (x),     // 1
+          "+r" (x)      // 1
         :
           "r" (alpha)   // 2
 	: "cc", //"%0", "%1",
@@ -331,7 +331,7 @@ static void cscal_kernel_16_zero( BLASLONG n, FLOAT *alpha, FLOAT *x)
 
 	: 
 	  "+r" (n),  	// 0
-          "+r" (x),     // 1
+          "+r" (x)      // 1
         :
           "r" (alpha)   // 2
 	: "cc",

--- a/kernel/x86_64/cscal_microk_haswell-2.c
+++ b/kernel/x86_64/cscal_microk_haswell-2.c
@@ -116,11 +116,11 @@ static void cscal_kernel_16( BLASLONG n, FLOAT *alpha, FLOAT *x)
 	"vzeroupper					    \n\t"
 
 	:
-        : 
-	  "r" (n),  	// 0
-          "r" (x),      // 1
+	  "+r" (n),  	// 0
+          "+r" (x),      // 1
+        :
           "r" (alpha)   // 2
-	: "cc", //"0", "1",
+	: "cc",
 	  "%xmm0", "%xmm1", "%xmm2", "%xmm3", 
 	  "%xmm4", "%xmm5", "%xmm6", "%xmm7", 
 	  "%xmm8", "%xmm9", "%xmm10", "%xmm11", 
@@ -208,9 +208,9 @@ static void cscal_kernel_16_zero_r( BLASLONG n, FLOAT *alpha, FLOAT *x)
 	"vzeroupper					    \n\t"
 
 	:
-        : 
-	  "r" (n),  	// 0
-          "r" (x),      // 1
+	  "+r" (n),  	// 0
+          "+r" (x),     // 1
+        :
           "r" (alpha)   // 2
 	: "cc", // "0", "1",
 	  "%xmm0", "%xmm1", "%xmm2", "%xmm3", 
@@ -285,9 +285,9 @@ static void cscal_kernel_16_zero_i( BLASLONG n, FLOAT *alpha, FLOAT *x)
 	"vzeroupper					    \n\t"
 
 	:
-        : 
-	  "r" (n),  	// 0
-          "r" (x),      // 1
+	  "+r" (n),  	// 0
+          "+r" (x),     // 1
+        :
           "r" (alpha)   // 2
 	: "cc", //"%0", "%1",
 	  "%xmm0", "%xmm1", "%xmm2", "%xmm3", 
@@ -329,12 +329,12 @@ static void cscal_kernel_16_zero( BLASLONG n, FLOAT *alpha, FLOAT *x)
 
 	"vzeroupper					    \n\t"
 
-	:
-        : 
-	  "r" (n),  	// 0
-          "r" (x),      // 1
+	: 
+	  "+r" (n),  	// 0
+          "+r" (x),     // 1
+        :
           "r" (alpha)   // 2
-	: "cc", //"0", "1",
+	: "cc",
 	  "%xmm0", "%xmm1", "%xmm2", "%xmm3", 
 	  "%xmm4", "%xmm5", "%xmm6", "%xmm7", 
 	  "%xmm8", "%xmm9", "%xmm10", "%xmm11", 

--- a/kernel/x86_64/cscal_microk_steamroller-2.c
+++ b/kernel/x86_64/cscal_microk_steamroller-2.c
@@ -118,7 +118,7 @@ static void cscal_kernel_16( BLASLONG n, FLOAT *alpha, FLOAT *x)
 
 	:
 	  "+r" (n),  	// 0
-          "+r" (x),     // 1
+          "+r" (x)      // 1
 	:
           "r" (alpha)   // 2
 	: "cc",
@@ -210,7 +210,7 @@ static void cscal_kernel_16_zero_r( BLASLONG n, FLOAT *alpha, FLOAT *x)
 
 	: 
 	  "+r" (n),  	// 0
-          "+r" (x),     // 1
+          "+r" (x)      // 1
 	:
           "r" (alpha)   // 2
 	: "cc",
@@ -287,7 +287,7 @@ static void cscal_kernel_16_zero_i( BLASLONG n, FLOAT *alpha, FLOAT *x)
 
 	:
 	  "+r" (n),  	// 0
-          "+r" (x),     // 1
+          "+r" (x)      // 1
 	:
           "r" (alpha)   // 2
 	: "cc",
@@ -332,7 +332,7 @@ static void cscal_kernel_16_zero( BLASLONG n, FLOAT *alpha, FLOAT *x)
 
 	:
 	  "+r" (n),  	// 0
-          "+r" (x),     // 1
+          "+r" (x)      // 1
 	:
           "r" (alpha)   // 2
 	: "cc",

--- a/kernel/x86_64/cscal_microk_steamroller-2.c
+++ b/kernel/x86_64/cscal_microk_steamroller-2.c
@@ -117,11 +117,11 @@ static void cscal_kernel_16( BLASLONG n, FLOAT *alpha, FLOAT *x)
 	"vzeroupper					    \n\t"
 
 	:
-        : 
-	  "r" (n),  	// 0
-          "r" (x),      // 1
+	  "+r" (n),  	// 0
+          "+r" (x),     // 1
+	:
           "r" (alpha)   // 2
-	: "cc", //"0", "1",
+	: "cc",
 	  "%xmm0", "%xmm1", "%xmm2", "%xmm3", 
 	  "%xmm4", "%xmm5", "%xmm6", "%xmm7", 
 	  "%xmm8", "%xmm9", "%xmm10", "%xmm11", 
@@ -208,12 +208,12 @@ static void cscal_kernel_16_zero_r( BLASLONG n, FLOAT *alpha, FLOAT *x)
 
 	"vzeroupper					    \n\t"
 
+	: 
+	  "+r" (n),  	// 0
+          "+r" (x),     // 1
 	:
-        : 
-	  "r" (n),  	// 0
-          "r" (x),      // 1
           "r" (alpha)   // 2
-	: "cc", //"0", "1",
+	: "cc",
 	  "%xmm0", "%xmm1", "%xmm2", "%xmm3", 
 	  "%xmm4", "%xmm5", "%xmm6", "%xmm7", 
 	  "%xmm8", "%xmm9", "%xmm10", "%xmm11", 
@@ -286,11 +286,11 @@ static void cscal_kernel_16_zero_i( BLASLONG n, FLOAT *alpha, FLOAT *x)
 	"vzeroupper					    \n\t"
 
 	:
-        : 
-	  "r" (n),  	// 0
-          "r" (x),      // 1
+	  "+r" (n),  	// 0
+          "+r" (x),     // 1
+	:
           "r" (alpha)   // 2
-	: "cc", //"%0", "%1",
+	: "cc",
 	  "%xmm0", "%xmm1", "%xmm2", "%xmm3", 
 	  "%xmm4", "%xmm5", "%xmm6", "%xmm7", 
 	  "%xmm8", "%xmm9", "%xmm10", "%xmm11", 
@@ -331,11 +331,11 @@ static void cscal_kernel_16_zero( BLASLONG n, FLOAT *alpha, FLOAT *x)
 	"vzeroupper					    \n\t"
 
 	:
-        : 
-	  "r" (n),  	// 0
-          "r" (x),      // 1
+	  "+r" (n),  	// 0
+          "+r" (x),     // 1
+	:
           "r" (alpha)   // 2
-	: "cc", //"0", "1",
+	: "cc",
 	  "%xmm0", "%xmm1", "%xmm2", "%xmm3", 
 	  "%xmm4", "%xmm5", "%xmm6", "%xmm7", 
 	  "%xmm8", "%xmm9", "%xmm10", "%xmm11", 

--- a/kernel/x86_64/dscal_microk_bulldozer-2.c
+++ b/kernel/x86_64/dscal_microk_bulldozer-2.c
@@ -123,7 +123,7 @@ static void dscal_kernel_8( BLASLONG n, FLOAT *alpha, FLOAT *x)
 
 	:
 	  "+r" (n1),  	// 0
-          "+r" (x),     // 1
+          "+r" (x)      // 1
 	:
           "r" (alpha),  // 2
 	  "r" (n2)   	// 3
@@ -189,7 +189,7 @@ static void dscal_kernel_8_zero( BLASLONG n, FLOAT *alpha, FLOAT *x)
 
 	:
 	  "+r" (n1),  	// 0
-          "+r" (x),     // 1
+          "+r" (x)      // 1
 	:
           "r" (alpha),  // 2
 	  "r" (n2)   	// 3

--- a/kernel/x86_64/dscal_microk_bulldozer-2.c
+++ b/kernel/x86_64/dscal_microk_bulldozer-2.c
@@ -122,9 +122,9 @@ static void dscal_kernel_8( BLASLONG n, FLOAT *alpha, FLOAT *x)
 	"vzeroupper					    \n\t"
 
 	:
-        : 
-	  "r" (n1),  	// 0
-          "r" (x),      // 1
+	  "+r" (n1),  	// 0
+          "+r" (x),     // 1
+	:
           "r" (alpha),  // 2
 	  "r" (n2)   	// 3
 	: "cc", 
@@ -188,9 +188,9 @@ static void dscal_kernel_8_zero( BLASLONG n, FLOAT *alpha, FLOAT *x)
 	"vzeroupper					    \n\t"
 
 	:
-        : 
-	  "r" (n1),  	// 0
-          "r" (x),      // 1
+	  "+r" (n1),  	// 0
+          "+r" (x),     // 1
+	:
           "r" (alpha),  // 2
 	  "r" (n2)   	// 3
 	: "cc", 

--- a/kernel/x86_64/dscal_microk_haswell-2.c
+++ b/kernel/x86_64/dscal_microk_haswell-2.c
@@ -123,7 +123,7 @@ static void dscal_kernel_8( BLASLONG n, FLOAT *alpha, FLOAT *x)
 
 	:
 	  "+r" (n1),  	// 0
-          "+r" (x),     // 1
+          "+r" (x)      // 1
 	:
           "r" (alpha),  // 2
 	  "r" (n2)   	// 3
@@ -189,7 +189,7 @@ static void dscal_kernel_8_zero( BLASLONG n, FLOAT *alpha, FLOAT *x)
 
 	: 
 	  "+r" (n1),  	// 0
-          "+r" (x),     // 1
+          "+r" (x)      // 1
 	:
           "r" (alpha),  // 2
 	  "r" (n2)   	// 3

--- a/kernel/x86_64/dscal_microk_haswell-2.c
+++ b/kernel/x86_64/dscal_microk_haswell-2.c
@@ -122,9 +122,9 @@ static void dscal_kernel_8( BLASLONG n, FLOAT *alpha, FLOAT *x)
 	"vzeroupper					    \n\t"
 
 	:
-        : 
-	  "r" (n1),  	// 0
-          "r" (x),      // 1
+	  "+r" (n1),  	// 0
+          "+r" (x),     // 1
+	:
           "r" (alpha),  // 2
 	  "r" (n2)   	// 3
 	: "cc", 
@@ -187,10 +187,10 @@ static void dscal_kernel_8_zero( BLASLONG n, FLOAT *alpha, FLOAT *x)
 
 	"vzeroupper					    \n\t"
 
+	: 
+	  "+r" (n1),  	// 0
+          "+r" (x),     // 1
 	:
-        : 
-	  "r" (n1),  	// 0
-          "r" (x),      // 1
           "r" (alpha),  // 2
 	  "r" (n2)   	// 3
 	: "cc", 

--- a/kernel/x86_64/dscal_microk_sandy-2.c
+++ b/kernel/x86_64/dscal_microk_sandy-2.c
@@ -123,7 +123,7 @@ static void dscal_kernel_8( BLASLONG n, FLOAT *alpha, FLOAT *x)
 
 	:
 	  "+r" (n1),  	// 0
-          "+r" (x),     // 1
+          "+r" (x)      // 1
 	:
           "r" (alpha),  // 2
 	  "r" (n2)   	// 3
@@ -189,7 +189,7 @@ static void dscal_kernel_8_zero( BLASLONG n, FLOAT *alpha, FLOAT *x)
 
 	: 
 	  "+r" (n1),  	// 0
-          "+r" (x),     // 1
+          "+r" (x)      // 1
 	:
           "r" (alpha),  // 2
 	  "r" (n2)   	// 3

--- a/kernel/x86_64/dscal_microk_sandy-2.c
+++ b/kernel/x86_64/dscal_microk_sandy-2.c
@@ -122,9 +122,9 @@ static void dscal_kernel_8( BLASLONG n, FLOAT *alpha, FLOAT *x)
 	"vzeroupper					    \n\t"
 
 	:
-        : 
-	  "r" (n1),  	// 0
-          "r" (x),      // 1
+	  "+r" (n1),  	// 0
+          "+r" (x),     // 1
+	:
           "r" (alpha),  // 2
 	  "r" (n2)   	// 3
 	: "cc", 
@@ -187,10 +187,10 @@ static void dscal_kernel_8_zero( BLASLONG n, FLOAT *alpha, FLOAT *x)
 
 	"vzeroupper					    \n\t"
 
+	: 
+	  "+r" (n1),  	// 0
+          "+r" (x),     // 1
 	:
-        : 
-	  "r" (n1),  	// 0
-          "r" (x),      // 1
           "r" (alpha),  // 2
 	  "r" (n2)   	// 3
 	: "cc", 

--- a/kernel/x86_64/zscal_microk_bulldozer-2.c
+++ b/kernel/x86_64/zscal_microk_bulldozer-2.c
@@ -116,11 +116,11 @@ static void zscal_kernel_8( BLASLONG n, FLOAT *alpha, FLOAT *x)
 	"vzeroupper					    \n\t"
 
 	:
-        : 
-	  "r" (n),  	// 0
-          "r" (x),      // 1
+	  "+r" (n),  	// 0
+          "+r" (x),     // 1
+	:
           "r" (alpha)   // 2
-	: "cc", //"%0", "%1",
+	: "cc",
 	  "%xmm0", "%xmm1", "%xmm2", "%xmm3", 
 	  "%xmm4", "%xmm5", "%xmm6", "%xmm7", 
 	  "%xmm8", "%xmm9", "%xmm10", "%xmm11", 
@@ -208,11 +208,11 @@ static void zscal_kernel_8_zero_r( BLASLONG n, FLOAT *alpha, FLOAT *x)
 	"vzeroupper					    \n\t"
 
 	:
-        : 
-	  "r" (n),  	// 0
-          "r" (x),      // 1
+	  "+r" (n),  	// 0
+          "+r" (x),     // 1
+	:
           "r" (alpha)   // 2
-	: "cc", //"%0", "%1",
+	: "cc",
 	  "%xmm0", "%xmm1", "%xmm2", "%xmm3", 
 	  "%xmm4", "%xmm5", "%xmm6", "%xmm7", 
 	  "%xmm8", "%xmm9", "%xmm10", "%xmm11", 

--- a/kernel/x86_64/zscal_microk_bulldozer-2.c
+++ b/kernel/x86_64/zscal_microk_bulldozer-2.c
@@ -117,7 +117,7 @@ static void zscal_kernel_8( BLASLONG n, FLOAT *alpha, FLOAT *x)
 
 	:
 	  "+r" (n),  	// 0
-          "+r" (x),     // 1
+          "+r" (x)      // 1
 	:
           "r" (alpha)   // 2
 	: "cc",
@@ -209,7 +209,7 @@ static void zscal_kernel_8_zero_r( BLASLONG n, FLOAT *alpha, FLOAT *x)
 
 	:
 	  "+r" (n),  	// 0
-          "+r" (x),     // 1
+          "+r" (x)      // 1
 	:
           "r" (alpha)   // 2
 	: "cc",
@@ -285,9 +285,9 @@ static void zscal_kernel_8_zero_i( BLASLONG n, FLOAT *alpha, FLOAT *x)
 	"vzeroupper					    \n\t"
 
 	:
-        : 
-	  "r" (n),  	// 0
-          "r" (x),      // 1
+	  "+r" (n),  	// 0
+          "+r" (x)      // 1
+	:
           "r" (alpha)   // 2
 	: "cc", //"%0", "%1",
 	  "%xmm0", "%xmm1", "%xmm2", "%xmm3", 
@@ -329,10 +329,10 @@ static void zscal_kernel_8_zero( BLASLONG n, FLOAT *alpha, FLOAT *x)
 
 	"vzeroupper					    \n\t"
 
+	: 
+	  "+r" (n),  	// 0
+          "+r" (x)      // 1
 	:
-        : 
-	  "r" (n),  	// 0
-          "r" (x),      // 1
           "r" (alpha)   // 2
 	: "cc", //"%0", "%1",
 	  "%xmm0", "%xmm1", "%xmm2", "%xmm3", 

--- a/kernel/x86_64/zscal_microk_haswell-2.c
+++ b/kernel/x86_64/zscal_microk_haswell-2.c
@@ -116,11 +116,11 @@ static void zscal_kernel_8( BLASLONG n, FLOAT *alpha, FLOAT *x)
 	"vzeroupper					    \n\t"
 
 	:
-        : 
-	  "r" (n),  	// 0
-          "r" (x),      // 1
+	  "+r" (n),  	// 0
+          "+r" (x),     // 1
+	:
           "r" (alpha)   // 2
-	: "cc", //"%0", "%1",
+	: "cc",
 	  "%xmm0", "%xmm1", "%xmm2", "%xmm3", 
 	  "%xmm4", "%xmm5", "%xmm6", "%xmm7", 
 	  "%xmm8", "%xmm9", "%xmm10", "%xmm11", 
@@ -208,11 +208,11 @@ static void zscal_kernel_8_zero_r( BLASLONG n, FLOAT *alpha, FLOAT *x)
 	"vzeroupper					    \n\t"
 
 	:
-        : 
-	  "r" (n),  	// 0
-          "r" (x),      // 1
+	  "+r" (n),  	// 0
+          "+r" (x),     // 1
+	:
           "r" (alpha)   // 2
-	: "cc", //"%0", "%1",
+	: "cc",
 	  "%xmm0", "%xmm1", "%xmm2", "%xmm3", 
 	  "%xmm4", "%xmm5", "%xmm6", "%xmm7", 
 	  "%xmm8", "%xmm9", "%xmm10", "%xmm11", 
@@ -285,11 +285,11 @@ static void zscal_kernel_8_zero_i( BLASLONG n, FLOAT *alpha, FLOAT *x)
 	"vzeroupper					    \n\t"
 
 	:
-        : 
-	  "r" (n),  	// 0
-          "r" (x),      // 1
+	  "+r" (n),  	// 0
+          "+r" (x),     // 1
+	:
           "r" (alpha)   // 2
-	: "cc", //"%0", "%1",
+	: "cc",
 	  "%xmm0", "%xmm1", "%xmm2", "%xmm3", 
 	  "%xmm4", "%xmm5", "%xmm6", "%xmm7", 
 	  "%xmm8", "%xmm9", "%xmm10", "%xmm11", 
@@ -330,11 +330,11 @@ static void zscal_kernel_8_zero( BLASLONG n, FLOAT *alpha, FLOAT *x)
 	"vzeroupper					    \n\t"
 
 	:
-        : 
-	  "r" (n),  	// 0
-          "r" (x),      // 1
+	  "+r" (n),  	// 0
+          "+r" (x),     // 1
+	:
           "r" (alpha)   // 2
-	: "cc", //"%0", "%1",
+	: "cc",
 	  "%xmm0", "%xmm1", "%xmm2", "%xmm3", 
 	  "%xmm4", "%xmm5", "%xmm6", "%xmm7", 
 	  "%xmm8", "%xmm9", "%xmm10", "%xmm11", 

--- a/kernel/x86_64/zscal_microk_haswell-2.c
+++ b/kernel/x86_64/zscal_microk_haswell-2.c
@@ -117,7 +117,7 @@ static void zscal_kernel_8( BLASLONG n, FLOAT *alpha, FLOAT *x)
 
 	:
 	  "+r" (n),  	// 0
-          "+r" (x),     // 1
+          "+r" (x)      // 1
 	:
           "r" (alpha)   // 2
 	: "cc",
@@ -209,7 +209,7 @@ static void zscal_kernel_8_zero_r( BLASLONG n, FLOAT *alpha, FLOAT *x)
 
 	:
 	  "+r" (n),  	// 0
-          "+r" (x),     // 1
+          "+r" (x)      // 1
 	:
           "r" (alpha)   // 2
 	: "cc",
@@ -286,7 +286,7 @@ static void zscal_kernel_8_zero_i( BLASLONG n, FLOAT *alpha, FLOAT *x)
 
 	:
 	  "+r" (n),  	// 0
-          "+r" (x),     // 1
+          "+r" (x)      // 1
 	:
           "r" (alpha)   // 2
 	: "cc",
@@ -331,7 +331,7 @@ static void zscal_kernel_8_zero( BLASLONG n, FLOAT *alpha, FLOAT *x)
 
 	:
 	  "+r" (n),  	// 0
-          "+r" (x),     // 1
+          "+r" (x)      // 1
 	:
           "r" (alpha)   // 2
 	: "cc",

--- a/kernel/x86_64/zscal_microk_steamroller-2.c
+++ b/kernel/x86_64/zscal_microk_steamroller-2.c
@@ -118,7 +118,7 @@ static void zscal_kernel_8( BLASLONG n, FLOAT *alpha, FLOAT *x)
 
 	: 
 	  "+r" (n),  	// 0
-          "+r" (x),     // 1
+          "+r" (x)      // 1
 	:
           "r" (alpha)   // 2
 	: "cc",
@@ -210,7 +210,7 @@ static void zscal_kernel_8_zero_r( BLASLONG n, FLOAT *alpha, FLOAT *x)
 
 	:
 	  "+r" (n),  	// 0
-          "+r" (x),     // 1
+          "+r" (x)      // 1
 	:
           "r" (alpha)   // 2
 	: "cc",
@@ -287,7 +287,7 @@ static void zscal_kernel_8_zero_i( BLASLONG n, FLOAT *alpha, FLOAT *x)
 
 	:
 	  "+r" (n),  	// 0
-          "+r" (x),     // 1
+          "+r" (x)      // 1
 	:
           "r" (alpha)   // 2
 	: "cc",
@@ -332,7 +332,7 @@ static void zscal_kernel_8_zero( BLASLONG n, FLOAT *alpha, FLOAT *x)
 
 	:
 	  "+r" (n),  	// 0
-          "+r" (x),     // 1
+          "+r" (x)      // 1
 	:
           "r" (alpha)   // 2
 	: "cc",

--- a/kernel/x86_64/zscal_microk_steamroller-2.c
+++ b/kernel/x86_64/zscal_microk_steamroller-2.c
@@ -116,12 +116,12 @@ static void zscal_kernel_8( BLASLONG n, FLOAT *alpha, FLOAT *x)
 
 	"vzeroupper					    \n\t"
 
+	: 
+	  "+r" (n),  	// 0
+          "+r" (x),     // 1
 	:
-        : 
-	  "r" (n),  	// 0
-          "r" (x),      // 1
           "r" (alpha)   // 2
-	: "cc", //"%0", "%1",
+	: "cc",
 	  "%xmm0", "%xmm1", "%xmm2", "%xmm3", 
 	  "%xmm4", "%xmm5", "%xmm6", "%xmm7", 
 	  "%xmm8", "%xmm9", "%xmm10", "%xmm11", 
@@ -209,11 +209,11 @@ static void zscal_kernel_8_zero_r( BLASLONG n, FLOAT *alpha, FLOAT *x)
 	"vzeroupper					    \n\t"
 
 	:
-        : 
-	  "r" (n),  	// 0
-          "r" (x),      // 1
+	  "+r" (n),  	// 0
+          "+r" (x),     // 1
+	:
           "r" (alpha)   // 2
-	: "cc", //"%0", "%1",
+	: "cc",
 	  "%xmm0", "%xmm1", "%xmm2", "%xmm3", 
 	  "%xmm4", "%xmm5", "%xmm6", "%xmm7", 
 	  "%xmm8", "%xmm9", "%xmm10", "%xmm11", 
@@ -286,11 +286,11 @@ static void zscal_kernel_8_zero_i( BLASLONG n, FLOAT *alpha, FLOAT *x)
 	"vzeroupper					    \n\t"
 
 	:
-        : 
-	  "r" (n),  	// 0
-          "r" (x),      // 1
+	  "+r" (n),  	// 0
+          "+r" (x),     // 1
+	:
           "r" (alpha)   // 2
-	: "cc", //"%0", "%1",
+	: "cc",
 	  "%xmm0", "%xmm1", "%xmm2", "%xmm3", 
 	  "%xmm4", "%xmm5", "%xmm6", "%xmm7", 
 	  "%xmm8", "%xmm9", "%xmm10", "%xmm11", 
@@ -331,11 +331,11 @@ static void zscal_kernel_8_zero( BLASLONG n, FLOAT *alpha, FLOAT *x)
 	"vzeroupper					    \n\t"
 
 	:
-        : 
-	  "r" (n),  	// 0
-          "r" (x),      // 1
+	  "+r" (n),  	// 0
+          "+r" (x),     // 1
+	:
           "r" (alpha)   // 2
-	: "cc", //"%0", "%1",
+	: "cc",
 	  "%xmm0", "%xmm1", "%xmm2", "%xmm3", 
 	  "%xmm4", "%xmm5", "%xmm6", "%xmm7", 
 	  "%xmm8", "%xmm9", "%xmm10", "%xmm11", 


### PR DESCRIPTION
For issue #1964, this could also explain why these inputs were originally put on the clobber list