### PR TITLE
Fix declaration of input arguments in the Sandybridge GER microkernels

### DIFF
--- a/kernel/x86_64/dger_microk_sandy-2.c
+++ b/kernel/x86_64/dger_microk_sandy-2.c
@@ -106,7 +106,7 @@ static void dger_kernel_16( BLASLONG n, FLOAT *x, FLOAT *y, FLOAT *alpha)
 
 	:
           "+r" (i),	// 0	
-	  "+r" (n),  	// 1
+	  "+r" (n)  	// 1
 	:
           "r" (x),      // 2
           "r" (y),      // 3

--- a/kernel/x86_64/dger_microk_sandy-2.c
+++ b/kernel/x86_64/dger_microk_sandy-2.c
@@ -105,9 +105,9 @@ static void dger_kernel_16( BLASLONG n, FLOAT *x, FLOAT *y, FLOAT *alpha)
 	"vzeroupper					     \n\t"
 
 	:
-        : 
-          "r" (i),	// 0	
-	  "r" (n),  	// 1
+          "+r" (i),	// 0	
+	  "+r" (n),  	// 1
+	:
           "r" (x),      // 2
           "r" (y),      // 3
           "r" (alpha)   // 4

--- a/kernel/x86_64/sger_microk_sandy-2.c
+++ b/kernel/x86_64/sger_microk_sandy-2.c
@@ -105,9 +105,9 @@ static void sger_kernel_16( BLASLONG n, FLOAT *x, FLOAT *y, FLOAT *alpha)
 	"vzeroupper					     \n\t"
 
 	:
-        : 
-          "r" (i),	// 0	
-	  "r" (n),  	// 1
+          "+r" (i),	// 0	
+	  "+r" (n),  	// 1
+	:
           "r" (x),      // 2
           "r" (y),      // 3
           "r" (alpha)   // 4

--- a/kernel/x86_64/sger_microk_sandy-2.c
+++ b/kernel/x86_64/sger_microk_sandy-2.c
@@ -106,7 +106,7 @@ static void sger_kernel_16( BLASLONG n, FLOAT *x, FLOAT *y, FLOAT *alpha)
 
 	:
           "+r" (i),	// 0	
-	  "+r" (n),  	// 1
+	  "+r" (n)  	// 1
 	:
           "r" (x),      // 2
           "r" (y),      // 3


### PR DESCRIPTION
For issue #1964