### PR TITLE
Shift transition to multithreading towards larger matrix sizes

### DIFF
--- a/interface/trsm.c
+++ b/interface/trsm.c
@@ -82,9 +82,9 @@
 #endif
 
 #ifndef COMPLEX
-#define SMP_FACTOR 8
+#define SMP_FACTOR 256
 #else
-#define SMP_FACTOR 4
+#define SMP_FACTOR 128
 #endif
 
 static int (*trsm[])(blas_arg_t *, BLASLONG *, BLASLONG *, FLOAT *, FLOAT *, BLASLONG) = {
@@ -372,11 +372,15 @@ void CNAME(enum CBLAS_ORDER order,
   mode |= (trans << BLAS_TRANSA_SHIFT);
   mode |= (side  << BLAS_RSIDE_SHIFT);
 
-  if ( args.m < SMP_FACTOR * GEMM_MULTITHREAD_THRESHOLD )
+/*
+  if ( args.m < 2 * GEMM_MULTITHREAD_THRESHOLD )
 	args.nthreads = 1;
   else
-	if ( args.n < SMP_FACTOR * GEMM_MULTITHREAD_THRESHOLD )
+	if ( args.n < 2 * GEMM_MULTITHREAD_THRESHOLD )
 		args.nthreads = 1;
+*/
+  if ( args.m * args.n < SMP_FACTOR * GEMM_MULTITHREAD_THRESHOLD)
+	args.nthreads = 1;
   else
 	args.nthreads = num_cpu_avail(3);
 		

--- a/interface/trsm.c
+++ b/interface/trsm.c
@@ -81,6 +81,12 @@
 #endif
 #endif
 
+#ifndef COMPLEX
+#define SMP_FACTOR 8
+#else
+#define SMP_FACTOR 4
+#endif
+
 static int (*trsm[])(blas_arg_t *, BLASLONG *, BLASLONG *, FLOAT *, FLOAT *, BLASLONG) = {
 #ifndef TRMM
   TRSM_LNUU, TRSM_LNUN, TRSM_LNLU, TRSM_LNLN,
@@ -366,10 +372,10 @@ void CNAME(enum CBLAS_ORDER order,
   mode |= (trans << BLAS_TRANSA_SHIFT);
   mode |= (side  << BLAS_RSIDE_SHIFT);
 
-  if ( args.m < 2*GEMM_MULTITHREAD_THRESHOLD )
+  if ( args.m < SMP_FACTOR * GEMM_MULTITHREAD_THRESHOLD )
 	args.nthreads = 1;
   else
-	if ( args.n < 2*GEMM_MULTITHREAD_THRESHOLD )
+	if ( args.n < SMP_FACTOR * GEMM_MULTITHREAD_THRESHOLD )
 		args.nthreads = 1;
   else
 	args.nthreads = num_cpu_avail(3);


### PR DESCRIPTION
See #1886 and JuliaRobotics issue 500. trsm benchmarks on Haswell and Zen showed that with these values performance is roughly doubled for matrix sizes between 8x8 and 14x14, and still 10 to 20 percent better near the new cutoff at 32x32.