### PR TITLE
Include complex rather than complex.h in C++ contexts

### DIFF
--- a/lapack-netlib/LAPACKE/include/lapacke.h
+++ b/lapack-netlib/LAPACKE/include/lapacke.h
@@ -86,7 +86,11 @@ lapack_complex_float lapack_make_complex_float( float re, float im );
 
 /* Complex type (double precision) */
 #ifndef lapack_complex_double
+#ifndef __cplusplus
 #include <complex.h>
+#else
+#include <complex>
+#endif
 #define lapack_complex_double   double _Complex
 #endif
 


### PR DESCRIPTION
to avoid name clashes e.g. with boost headers that use I as a generic placeholder.
Fixes #1992 as suggested by aprokop in that issue ticket.