### PR TITLE
 Fix declaration of input arguments in x86_64 GEMV, SYMV and DSCAL

### DIFF
--- a/kernel/x86_64/dgemv_n_4.c
+++ b/kernel/x86_64/dgemv_n_4.c
@@ -111,9 +111,9 @@ static void dgemv_kernel_4x2( BLASLONG n, FLOAT **ap, FLOAT *x, FLOAT *y, FLOAT 
 	"jnz		1b		       \n\t"
 
 	:
-        : 
-          "r" (i),	// 0	
-	  "r" (n),  	// 1
+          "+r" (i),	// 0	
+	  "+r" (n)  	// 1
+        :
           "r" (x),      // 2
           "r" (y),      // 3
           "r" (ap[0]),  // 4
@@ -166,9 +166,9 @@ static void dgemv_kernel_4x1(BLASLONG n, FLOAT *ap, FLOAT *x, FLOAT *y, FLOAT *a
         "jnz            1b               \n\t"
 
         :
+          "+r" (i),     // 0    
+          "+r" (n)      // 1
         :
-          "r" (i),      // 0    
-          "r" (n),      // 1
           "r" (x),      // 2
           "r" (y),      // 3
           "r" (ap),     // 4

--- a/kernel/x86_64/dgemv_t_4.c
+++ b/kernel/x86_64/dgemv_t_4.c
@@ -127,9 +127,9 @@ static void dgemv_kernel_4x2(BLASLONG n, FLOAT *ap0, FLOAT *ap1, FLOAT *x, FLOAT
 	"movsd	       %%xmm11,8(%2)	        \n\t"
 
         :
-   	:
-	"r" (i),	 // 0
-	"r" (n),	 // 1
+	"+r" (i),	 // 0
+	"+r" (n)	 // 1
+	:
         "r" (y),         // 2    
         "r" (ap0),       // 3
         "r" (ap1),       // 4
@@ -195,9 +195,9 @@ static void dgemv_kernel_4x1(BLASLONG n, FLOAT *ap, FLOAT *x, FLOAT *y)
 	"movsd	       %%xmm10, (%2)	        \n\t"
 
         :
-   	:
-	"r" (i),	 // 0
-	"r" (n),	 // 1
+	"+r" (i),	 // 0
+	"+r" (n)	 // 1
+	:
         "r" (y),         // 2    
         "r" (ap),        // 3
         "r" (x)          // 4
@@ -259,9 +259,9 @@ static void add_y(BLASLONG n, FLOAT da , FLOAT *src, FLOAT *dest, BLASLONG inc_d
         "jnz            1b              \n\t"
 
         :
-   	:
-	"r" (i),	  // 0
-	"r" (n),	  // 1
+	"+r" (i),	  // 0
+	"+r" (n)	  // 1
+	:
         "r" (&da),        // 2    
         "r" (src),        // 3
         "r" (dest)        // 4

--- a/kernel/x86_64/dscal.c
+++ b/kernel/x86_64/dscal.c
@@ -136,8 +136,8 @@ static void dscal_kernel_inc_8(BLASLONG n, FLOAT *alpha, FLOAT *x, BLASLONG inc_
 	"jnz    1b					    \n\t"
 
         :
+          "+r" (n)      // 0
         :
-          "r" (n),      // 0
           "r" (x),      // 1
           "r" (x1),     // 2
           "r" (alpha),  // 3

--- a/kernel/x86_64/dsymv_L_microk_bulldozer-2.c
+++ b/kernel/x86_64/dsymv_L_microk_bulldozer-2.c
@@ -113,8 +113,8 @@ static void dsymv_kernel_4x4(BLASLONG from, BLASLONG to, FLOAT **a, FLOAT *x, FL
 	"vmovsd         %%xmm3 ,24(%9)		\n\t"	// save temp2
 
 	:
-        : 
-          "r" (from),	// 0	
+          "+r" (from)	// 0	
+        :
 	  "r" (to),  	// 1
           "r" (x),      // 2
           "r" (y),      // 3

--- a/kernel/x86_64/dsymv_L_microk_haswell-2.c
+++ b/kernel/x86_64/dsymv_L_microk_haswell-2.c
@@ -105,8 +105,8 @@ static void dsymv_kernel_4x4(BLASLONG from, BLASLONG to, FLOAT **a, FLOAT *x, FL
 	"vzeroupper				     \n\t"
 
 	:
-        : 
-          "r" (from),	// 0	
+          "+r" (from)	// 0	
+        :
 	  "r" (to),  	// 1
           "r" (x),      // 2
           "r" (y),      // 3

--- a/kernel/x86_64/dsymv_L_microk_nehalem-2.c
+++ b/kernel/x86_64/dsymv_L_microk_nehalem-2.c
@@ -108,8 +108,8 @@ static void dsymv_kernel_4x4(BLASLONG from, BLASLONG to, FLOAT **a, FLOAT *x, FL
 	"movsd         %%xmm3 , 24(%9)		\n\t"	// save temp2
 
 	:
-        : 
-          "r" (from),	// 0	
+          "+r" (from)	// 0	
+        :
 	  "r" (to),  	// 1
           "r" (x),      // 2
           "r" (y),      // 3

--- a/kernel/x86_64/dsymv_L_microk_sandy-2.c
+++ b/kernel/x86_64/dsymv_L_microk_sandy-2.c
@@ -114,8 +114,8 @@ static void dsymv_kernel_4x4(BLASLONG from, BLASLONG to, FLOAT **a, FLOAT *x, FL
 	"vzeroupper				     \n\t"
 
 	:
-        : 
-          "r" (from),	// 0	
+          "+r" (from)	// 0	
+        :
 	  "r" (to),  	// 1
           "r" (x),      // 2
           "r" (y),      // 3

--- a/kernel/x86_64/dsymv_U_microk_bulldozer-2.c
+++ b/kernel/x86_64/dsymv_U_microk_bulldozer-2.c
@@ -106,9 +106,9 @@ static void dsymv_kernel_4x4(BLASLONG n, FLOAT *a0, FLOAT *a1, FLOAT *a2, FLOAT 
 	"vmovsd         %%xmm3 ,24(%9)		\n\t"	// save temp2
 
 	:
-        : 
-          "r" (i),	// 0	
-	  "r" (n),  	// 1
+          "+r" (i),	// 0	
+	  "+r" (n)  	// 1
+        :
           "r" (x),      // 2
           "r" (y),      // 3
           "r" (a0),     // 4

--- a/kernel/x86_64/dsymv_U_microk_haswell-2.c
+++ b/kernel/x86_64/dsymv_U_microk_haswell-2.c
@@ -107,9 +107,9 @@ static void dsymv_kernel_4x4(BLASLONG n, FLOAT *a0, FLOAT *a1, FLOAT *a2, FLOAT 
 	"vzeroupper				     \n\t"
 
 	:
-        : 
-          "r" (i),	// 0	
-	  "r" (n),  	// 1
+          "+r" (i),	// 0	
+	  "+r" (n)  	// 1
+        :
           "r" (x),      // 2
           "r" (y),      // 3
           "r" (a0),	// 4

--- a/kernel/x86_64/dsymv_U_microk_nehalem-2.c
+++ b/kernel/x86_64/dsymv_U_microk_nehalem-2.c
@@ -101,9 +101,9 @@ static void dsymv_kernel_4x4(BLASLONG n, FLOAT *a0, FLOAT *a1, FLOAT *a2, FLOAT 
 	"movsd         %%xmm3 , 24(%9)		\n\t"	// save temp2
 
 	:
-        : 
-          "r" (i),	// 0	
-	  "r" (n),  	// 1
+          "+r" (i),	// 0	
+	  "+r" (n)  	// 1
+        :
           "r" (x),      // 2
           "r" (y),      // 3
           "r" (a0),     // 4

--- a/kernel/x86_64/dsymv_U_microk_sandy-2.c
+++ b/kernel/x86_64/dsymv_U_microk_sandy-2.c
@@ -116,9 +116,9 @@ static void dsymv_kernel_4x4(BLASLONG n, FLOAT *a0, FLOAT *a1, FLOAT *a2, FLOAT 
 	"vzeroupper				     \n\t"
 
 	:
-        : 
-          "r" (i),	// 0	
-	  "r" (n),  	// 1
+          "+r" (i),	// 0	
+	  "+r" (n)  	// 1
+        :
           "r" (x),      // 2
           "r" (y),      // 3
           "r" (a0),	// 4

--- a/kernel/x86_64/sgemv_n_4.c
+++ b/kernel/x86_64/sgemv_n_4.c
@@ -149,9 +149,9 @@ static void sgemv_kernel_4x2( BLASLONG n, FLOAT **ap, FLOAT *x, FLOAT *y, FLOAT 
 	"jnz		1b		       \n\t"
 
 	:
-        : 
-          "r" (i),	// 0	
-	  "r" (n),  	// 1
+          "+r" (i),	// 0	
+	  "+r" (n)  	// 1
+	:
           "r" (x),      // 2
           "r" (y),      // 3
           "r" (ap[0]),  // 4
@@ -223,9 +223,9 @@ static void sgemv_kernel_4x1(BLASLONG n, FLOAT *ap, FLOAT *x, FLOAT *y, FLOAT *a
 
         "3:      			 \n\t" 
         :
+          "+r" (i),     // 0    
+          "+r" (n1)     // 1
         :
-          "r" (i),      // 0    
-          "r" (n1),     // 1
           "r" (x),      // 2
           "r" (y),      // 3
           "r" (ap),     // 4
@@ -277,9 +277,9 @@ static void add_y(BLASLONG n, FLOAT *src, FLOAT *dest, BLASLONG inc_dest)
         "jnz            1b              \n\t"
 
         :
+        "+r" (i),         // 0
+        "+r" (n)          // 1
         :
-        "r" (i),          // 0
-        "r" (n),          // 1
         "r" (src),        // 2
         "r" (dest)        // 3
         : "cc",

--- a/kernel/x86_64/sgemv_t_4.c
+++ b/kernel/x86_64/sgemv_t_4.c
@@ -139,9 +139,9 @@ static void sgemv_kernel_4x2(BLASLONG n, FLOAT *ap0, FLOAT *ap1, FLOAT *x, FLOAT
 	"movss	       %%xmm11,4(%2)	        \n\t"
 
         :
-   	:
-	"r" (i),	 // 0
-	"r" (n),	 // 1
+	"+r" (i),	 // 0
+	"+r" (n)	 // 1
+	:
         "r" (y),         // 2    
         "r" (ap0),       // 3
         "r" (ap1),       // 4
@@ -208,9 +208,9 @@ static void sgemv_kernel_4x1(BLASLONG n, FLOAT *ap, FLOAT *x, FLOAT *y)
 	"movss	       %%xmm10, (%2)	        \n\t"
 
         :
-   	:
-	"r" (i),	 // 0
-	"r" (n),	 // 1
+	"+r" (i),	 // 0
+	"+r" (n)	 // 1
+	:
         "r" (y),         // 2    
         "r" (ap),        // 3
         "r" (x)          // 4
@@ -272,9 +272,9 @@ static void add_y(BLASLONG n, FLOAT da , FLOAT *src, FLOAT *dest, BLASLONG inc_d
         "jnz            1b              \n\t"
 
         :
-   	:
-	"r" (i),	  // 0
-	"r" (n),	  // 1
+	"+r" (i),	  // 0
+	"+r" (n)	  // 1
+	:
         "r" (&da),        // 2    
         "r" (src),        // 3
         "r" (dest)        // 4

--- a/kernel/x86_64/ssymv_L_microk_bulldozer-2.c
+++ b/kernel/x86_64/ssymv_L_microk_bulldozer-2.c
@@ -98,8 +98,8 @@ static void ssymv_kernel_4x4(BLASLONG from, BLASLONG to, FLOAT **a, FLOAT *x, FL
 	"vmovss         %%xmm3 ,12(%9)		\n\t"	// save temp2
 
 	:
-        : 
-          "r" (from),	// 0	
+          "+r" (from)	// 0	
+        :
 	  "r" (to),  	// 1
           "r" (x),      // 2
           "r" (y),      // 3

--- a/kernel/x86_64/ssymv_L_microk_haswell-2.c
+++ b/kernel/x86_64/ssymv_L_microk_haswell-2.c
@@ -99,8 +99,8 @@ static void ssymv_kernel_4x4(BLASLONG from, BLASLONG to, FLOAT **a, FLOAT *x, FL
 	"vzeroupper				     \n\t"
 
 	:
-        : 
-          "r" (from),	// 0	
+          "+r" (from)	// 0	
+        :
 	  "r" (to),  	// 1
           "r" (x),      // 2
           "r" (y),      // 3

--- a/kernel/x86_64/ssymv_L_microk_nehalem-2.c
+++ b/kernel/x86_64/ssymv_L_microk_nehalem-2.c
@@ -113,8 +113,8 @@ static void ssymv_kernel_4x4(BLASLONG from, BLASLONG to,  FLOAT **a, FLOAT *x, F
 	"movss         %%xmm3 , 12(%9)		\n\t"	// save temp2
 
 	:
-        : 
-          "r" (from),	// 0	
+          "+r" (from)	// 0	
+        :
 	  "r" (to),  	// 1
           "r" (x),      // 2
           "r" (y),      // 3

--- a/kernel/x86_64/ssymv_L_microk_sandy-2.c
+++ b/kernel/x86_64/ssymv_L_microk_sandy-2.c
@@ -109,8 +109,8 @@ static void ssymv_kernel_4x4(BLASLONG from, BLASLONG to, FLOAT **a, FLOAT *x, FL
 	"vzeroupper				     \n\t"
 
 	:
-        : 
-          "r" (from),	// 0	
+          "+r" (from)	// 0	
+        :
 	  "r" (to),  	// 1
           "r" (x),      // 2
           "r" (y),      // 3
@@ -217,8 +217,8 @@ static void ssymv_kernel_4x4(BLASLONG from, BLASLONG to, FLOAT **a, FLOAT *x, FL
 	"vzeroupper				     \n\t"
 
 	:
-        : 
-          "r" (from),	// 0	
+          "+r" (from)	// 0	
+        :
 	  "r" (to),  	// 1
           "r" (x),      // 2
           "r" (y),      // 3

--- a/kernel/x86_64/ssymv_U_microk_bulldozer-2.c
+++ b/kernel/x86_64/ssymv_U_microk_bulldozer-2.c
@@ -90,9 +90,9 @@ static void ssymv_kernel_4x4(BLASLONG n, FLOAT *a0, FLOAT *a1, FLOAT *a2, FLOAT 
 	"vmovss         %%xmm3 ,12(%9)		\n\t"	// save temp2
 
 	:
-        : 
-          "r" (i),	// 0	
-	  "r" (n),  	// 1
+          "+r" (i),	// 0	
+	  "+r" (n)  	// 1
+        :
           "r" (x),      // 2
           "r" (y),      // 3
           "r" (a0),     // 4

--- a/kernel/x86_64/ssymv_U_microk_haswell-2.c
+++ b/kernel/x86_64/ssymv_U_microk_haswell-2.c
@@ -112,9 +112,9 @@ static void ssymv_kernel_4x4(BLASLONG n, FLOAT *a0, FLOAT *a1, FLOAT *a2, FLOAT 
 	"vzeroupper				     \n\t"
 
 	:
-        : 
-          "r" (i),	// 0	
-	  "r" (n),  	// 1
+          "+r" (i),	// 0	
+	  "+r" (n)  	// 1
+        :
           "r" (x),      // 2
           "r" (y),      // 3
           "r" (a0),	// 4

--- a/kernel/x86_64/ssymv_U_microk_nehalem-2.c
+++ b/kernel/x86_64/ssymv_U_microk_nehalem-2.c
@@ -106,9 +106,9 @@ static void ssymv_kernel_4x4(BLASLONG n, FLOAT *a0, FLOAT *a1, FLOAT *a2, FLOAT 
 	"movss         %%xmm3 , 12(%9)		\n\t"	// save temp2
 
 	:
-        : 
-          "r" (i),	// 0	
-	  "r" (n),  	// 1
+          "+r" (i),	// 0	
+	  "+r" (n)  	// 1
+        :
           "r" (x),      // 2
           "r" (y),      // 3
           "r" (a0),     // 4

--- a/kernel/x86_64/ssymv_U_microk_sandy-2.c
+++ b/kernel/x86_64/ssymv_U_microk_sandy-2.c
@@ -120,9 +120,9 @@ static void ssymv_kernel_4x4(BLASLONG n, FLOAT *a0, FLOAT *a1, FLOAT *a2, FLOAT 
 	"vzeroupper				     \n\t"
 
 	:
-        : 
-          "r" (i),	// 0	
-	  "r" (n),  	// 1
+          "+r" (i),	// 0	
+	  "+r" (n)  	// 1
+        :
           "r" (x),      // 2
           "r" (y),      // 3
           "r" (a0),	// 4


### PR DESCRIPTION
Arguments 0 and 1 need to be tagged as both input and output. Apparently these files were missed when the related microkernels were corrected. Expected to fix #2009