### PR TITLE
Fix missing clobber in x86/x86_64 blas_quickdivide inline assembly function

### DIFF
--- a/common_x86.h
+++ b/common_x86.h
@@ -187,7 +187,7 @@ static __inline int blas_quickdivide(unsigned int x, unsigned int y){
 	
   y = blas_quick_divide_table[y];
 
-  __asm__ __volatile__  ("mull %0" :"=d" (result) :"+a"(x), "0" (y));
+  __asm__ __volatile__  ("mull %0" :"=d" (result), "+a"(x): "0" (y));
 
   return result;
 #endif

--- a/common_x86.h
+++ b/common_x86.h
@@ -187,7 +187,7 @@ static __inline int blas_quickdivide(unsigned int x, unsigned int y){
 	
   y = blas_quick_divide_table[y];
 
-  __asm__ __volatile__  ("mull %0" :"=d" (result) :"a"(x), "0" (y));
+  __asm__ __volatile__  ("mull %0" :"=d" (result) :"+a"(x), "0" (y));
 
   return result;
 #endif

--- a/common_x86_64.h
+++ b/common_x86_64.h
@@ -210,7 +210,7 @@ static __inline int blas_quickdivide(unsigned int x, unsigned int y){
 	
   y = blas_quick_divide_table[y];
 
-  __asm__ __volatile__  ("mull %0" :"=d" (result) :"a"(x), "0" (y));
+  __asm__ __volatile__  ("mull %0" :"=d" (result) :"+a"(x), "0" (y));
 
   return result;
 }

--- a/common_x86_64.h
+++ b/common_x86_64.h
@@ -210,7 +210,7 @@ static __inline int blas_quickdivide(unsigned int x, unsigned int y){
 	
   y = blas_quick_divide_table[y];
 
-  __asm__ __volatile__  ("mull %0" :"=d" (result) :"+a"(x), "0" (y));
+  __asm__ __volatile__  ("mull %0" :"=d" (result), "+a"(x) : "0" (y));
 
   return result;
 }


### PR DESCRIPTION
Fixes #2014 as suggested by StefanBruens there.