### PR TITLE
Correct range limiting in trmv_thread and re-enable TRMV multithreading

### DIFF
--- a/driver/level2/trmv_thread.c
+++ b/driver/level2/trmv_thread.c
@@ -346,8 +346,8 @@ int CNAME(BLASLONG m, FLOAT *a, BLASLONG lda, FLOAT *x, BLASLONG incx, FLOAT *bu
 
     range_m[MAX_CPU_NUMBER - num_cpu - 1] = range_m[MAX_CPU_NUMBER - num_cpu] - width;
     range_n[num_cpu] = num_cpu * (((m + 15) & ~15) + 16);
-    if (range_n[num_cpu] > m) range_n[num_cpu] = m;
-
+    if (range_n[num_cpu] > m * num_cpu) range_n[num_cpu] = m * num_cpu;
+    }
     queue[num_cpu].mode    = mode;
     queue[num_cpu].routine = trmv_kernel;
     queue[num_cpu].args    = &args;
@@ -386,8 +386,7 @@ int CNAME(BLASLONG m, FLOAT *a, BLASLONG lda, FLOAT *x, BLASLONG incx, FLOAT *bu
 
     range_m[num_cpu + 1] = range_m[num_cpu] + width;
     range_n[num_cpu] = num_cpu * (((m + 15) & ~15) + 16);
-    if (range_n[num_cpu] > m) range_n[num_cpu] = m;
-
+    if (range_n[num_cpu] > m * num_cpu) range_n[num_cpu] = m * num_cpu;
     queue[num_cpu].mode    = mode;
     queue[num_cpu].routine = trmv_kernel;
     queue[num_cpu].args    = &args;

--- a/driver/level2/trmv_thread.c
+++ b/driver/level2/trmv_thread.c
@@ -347,7 +347,7 @@ int CNAME(BLASLONG m, FLOAT *a, BLASLONG lda, FLOAT *x, BLASLONG incx, FLOAT *bu
     range_m[MAX_CPU_NUMBER - num_cpu - 1] = range_m[MAX_CPU_NUMBER - num_cpu] - width;
     range_n[num_cpu] = num_cpu * (((m + 15) & ~15) + 16);
     if (range_n[num_cpu] > m * num_cpu) range_n[num_cpu] = m * num_cpu;
-    }
+
     queue[num_cpu].mode    = mode;
     queue[num_cpu].routine = trmv_kernel;
     queue[num_cpu].args    = &args;
@@ -387,6 +387,7 @@ int CNAME(BLASLONG m, FLOAT *a, BLASLONG lda, FLOAT *x, BLASLONG incx, FLOAT *bu
     range_m[num_cpu + 1] = range_m[num_cpu] + width;
     range_n[num_cpu] = num_cpu * (((m + 15) & ~15) + 16);
     if (range_n[num_cpu] > m * num_cpu) range_n[num_cpu] = m * num_cpu;
+
     queue[num_cpu].mode    = mode;
     queue[num_cpu].routine = trmv_kernel;
     queue[num_cpu].args    = &args;

--- a/interface/trmv.c
+++ b/interface/trmv.c
@@ -218,11 +218,8 @@ void CNAME(enum CBLAS_ORDER order, enum CBLAS_UPLO Uplo,
   buffer = (FLOAT *)blas_memory_alloc(1);
 
 #ifdef SMP
-/*  nthreads = num_cpu_avail(2);
+  nthreads = num_cpu_avail(2);
 
-FIXME trmv_thread was found to be broken, see issue 1332 */
-  nthreads = 1;
-  
   if (nthreads == 1) {
 #endif
 

--- a/interface/ztrmv.c
+++ b/interface/ztrmv.c
@@ -239,9 +239,6 @@ void CNAME(enum CBLAS_ORDER order, enum CBLAS_UPLO Uplo,
   } else
       nthreads = 1;
 
-/* FIXME TRMV multithreading appears to be broken, see issue 1332*/
-  nthreads = 1;
-
   if(nthreads > 1) {
     buffer_size = n > 16 ? 0 : n * 4 + 40;
   }


### PR DESCRIPTION
reverts a workaround introduced for #1332 by fixing the problem introduced with #1262. Somehow I had managed to miss trmv_thread.c in/after the earlier PR#1388 that took care of the same problem in related files, although I had suggested a link to this issue there.