### PR TITLE
Do not play with thread affinity under OpenMP

### DIFF
--- a/Makefile.system
+++ b/Makefile.system
@@ -222,6 +222,10 @@ override USE_THREAD = 0
 override USE_OPENMP = 0
 endif
 
+ifeq ($(USE_OPENMP),1)
+override NO_AFFINITY=1
+endif
+
 ifdef USE_THREAD
 ifeq ($(USE_THREAD), 0)
 SMP =


### PR DESCRIPTION
Inspired by example in #2030
OpenMP has its own sophisticated affinity handling, If we try to outsmart it we can only make things worse (we do set affinity mask to one core, they may try to land bunch of threads in same CPU socket where automatic process migration is cheap enough to ignore)
