### PR TITLE
Address warning in memory.c

### DIFF
--- a/driver/others/memory.c
+++ b/driver/others/memory.c
@@ -2584,7 +2584,7 @@ void *blas_memory_alloc(int procpos){
 
   int position;
 #if defined(WHEREAMI) && !defined(USE_OPENMP)
-  int mypos;
+  int mypos = 0;
 #endif
 
   void *map_address;


### PR DESCRIPTION
Complete #1814 lock cleanup, what was missed that excess locking code actually initialized the var as a side effect.