### PR TITLE
Optimize busy loop for modern linux by default

### DIFF
--- a/common.h
+++ b/common.h
@@ -366,7 +366,11 @@ typedef int blasint;
 */
 
 #ifndef YIELDING
-#define YIELDING	sched_yield()
+#define YIELDING nanosleep((const struct timespec[]){{0,10000L}},NULL);
+// Line above is equal to following, but compliant with much older POSIX spec
+// #define YIELDING usleep(10);
+// Linux 2.4 might gain from implied scheduler programming instead
+// #define YIELDING	sched_yield()
 #endif
 
 /***


### PR DESCRIPTION
Use just clock wait in place of sched_yield that is heavy in modern kernel side, also when called from light virtualisations like LXC or chroots.
I managed to make 8000 sched_yields per second without pti and 5000 with it, so this is already better for cases where zero threading threshold is in force, and with no kernel bombing also for turbo CPUs.
It dropped about 5% of time spent in gemm on huge set, I did not test much more.
Explanation from different point in file.
This does not solve problem of busy loop being employed, where some light IPC could work, it just eases life of current code.