### PR TITLE
Do not compile in AVX512 check if AVX support is disabled

### DIFF
--- a/driver/others/dynamic.c
+++ b/driver/others/dynamic.c
@@ -322,7 +322,7 @@ int support_avx2(){
 }
 
 int support_avx512(){
-#ifndef NO_AVX512
+#if !defined(NO_AVX) && !defined(NO_AVX512)
   int eax, ebx, ecx, edx;
   int ret=0;
 


### PR DESCRIPTION
Availability of helper function xgetbv depends on NO_AVX being undefined - we could change that too, but that combo is unlikely to work anyway. For #2033