### PR TITLE
ctest.c : add __POWERPC__ for PowerMac

### DIFF
--- a/ctest.c
+++ b/ctest.c
@@ -113,7 +113,7 @@ ARCH_X86
 ARCH_X86_64
 #endif
 
-#if defined(__powerpc___) || defined(__PPC__) || defined(_POWER)
+#if defined(__powerpc___) || defined(__PPC__) || defined(_POWER) || defined(__POWERPC__)
 ARCH_POWER
 #endif
 


### PR DESCRIPTION
this extra definition satisfies the gcc compiler on PowerPC Apple computers