### PR TITLE
Fix for #2063

### DIFF
--- a/driver/others/blas_server_win32.c
+++ b/driver/others/blas_server_win32.c
@@ -461,12 +461,17 @@ int BLASFUNC(blas_thread_shutdown)(void){
     SetEvent(pool.killed);
 
     for(i = 0; i < blas_num_threads - 1; i++){
+      // Could also just use WaitForMultipleObjects
       WaitForSingleObject(blas_threads[i], 5);  //INFINITE);
 #ifndef OS_WINDOWSSTORE
 // TerminateThread is only available with WINAPI_DESKTOP and WINAPI_SYSTEM not WINAPI_APP in UWP
       TerminateThread(blas_threads[i],0);
 #endif
+      CloseHandle(blas_threads[i]);
     }
+
+    CloseHandle(pool.filled);
+    CloseHandle(pool.killed);
 
     blas_server_avail = 0;
   }

--- a/driver/others/memory.c
+++ b/driver/others/memory.c
@@ -1313,6 +1313,13 @@ void blas_memory_free_nolock(void * map_address) {
   free(map_address);
 }
 
+#ifdef SMP
+void blas_thread_memory_cleanup(void) {
+    blas_memory_cleanup((void*)get_memory_table());
+}
+#endif
+
+
 void blas_shutdown(void){
 #ifdef SMP
   BLASFUNC(blas_thread_shutdown)();
@@ -1322,7 +1329,7 @@ void blas_shutdown(void){
   /* Only cleanupIf we were built for threading and TLS was initialized */
   if (local_storage_key)
 #endif
-    blas_memory_cleanup((void*)get_memory_table());
+    blas_thread_memory_cleanup();
 
 #ifdef SEEK_ADDRESS
   base_address      = 0UL;
@@ -1552,7 +1559,7 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD  ul_reason_for_call, LPVOID lpReser
       break;
     case DLL_THREAD_DETACH:
 #if defined(SMP)
-      blas_memory_cleanup((void*)get_memory_table());
+      blas_thread_memory_cleanup();
 #endif
       break;
     case DLL_PROCESS_DETACH:

--- a/exports/dllinit.c
+++ b/exports/dllinit.c
@@ -56,7 +56,7 @@ BOOL APIENTRY DllMain(HINSTANCE hInst, DWORD reason, LPVOID reserved) {
         break;
       case DLL_THREAD_DETACH:
 #if defined(SMP) && defined(USE_TLS)
-        blas_thread_memory_cleanup(void);
+        blas_thread_memory_cleanup();
 #endif
         break;
   }

--- a/exports/dllinit.c
+++ b/exports/dllinit.c
@@ -40,15 +40,25 @@
 
 void gotoblas_init(void);
 void gotoblas_quit(void);
+#if defined(SMP) && defined(USE_TLS)
+void blas_thread_memory_cleanup(void);
+#endif
 
 BOOL APIENTRY DllMain(HINSTANCE hInst, DWORD reason, LPVOID reserved) {
-
-  if (reason == DLL_PROCESS_ATTACH) {
-    gotoblas_init();
-  }
-
-  if (reason == DLL_PROCESS_DETACH) {
-    gotoblas_quit();
+  switch(reason) {
+      case DLL_PROCESS_ATTACH:
+        gotoblas_init();
+        break;
+      case DLL_PROCESS_DETACH:
+        gotoblas_quit();
+        break;
+      case DLL_THREAD_ATTACH:
+        break;
+      case DLL_THREAD_DETACH:
+#if defined(SMP) && defined(USE_TLS)
+        blas_thread_memory_cleanup(void);
+#endif
+        break;
   }
 
   return TRUE;


### PR DESCRIPTION
The `DllMain` used in Cygwin did not run the thread memory pool cleanup upon `DLL_THREAD_DETACH` which is needed when compiled with `USE_TLS=1`.

There is also a `DllMain` implemented in memory.c for some reason, which is not used on Cygwin (just plain Windows), and also has some special bits for when OpenBLAS is used as a static lib.  If anyone who understands this better thinks it would be good to use this on Cygwin instead, and has a good idea how it would be nice to get some input on this.

But otherwise I don't see a cleaner way to do this.  It seems to work perfectly though to fix the memory leak reported in #2063.