### PR TITLE
AIX asm syntax changes needed for shared object creation

### DIFF
--- a/common_power.h
+++ b/common_power.h
@@ -598,9 +598,14 @@ REALNAME:;\
 #ifndef __64BIT__
 #define PROLOGUE \
 	.machine "any";\
+	.toc;\
 	.globl .REALNAME;\
+	.globl REALNAME;\
+	.csect REALNAME[DS],3;\
+REALNAME:;\
+	.long .REALNAME, TOC[tc0], 0;\
 	.csect .text[PR],5;\
-.REALNAME:;
+.REALNAME:
 
 #define EPILOGUE \
 _section_.text:;\
@@ -611,9 +616,14 @@ _section_.text:;\
 
 #define PROLOGUE \
 	.machine "any";\
+	.toc;\
 	.globl .REALNAME;\
+	.globl REALNAME;\
+	.csect REALNAME[DS],3;\
+REALNAME:;\
+	.llong .REALNAME, TOC[tc0], 0;\
 	.csect .text[PR], 5;\
-.REALNAME:;
+.REALNAME:
 
 #define EPILOGUE \
 _section_.text:;\


### PR DESCRIPTION
As mentioned in the issue #1997 , for shared object creation in AIX from archives, one has to use export file to export the symbols. There are two standard scripts out there to create the export file from an archive, CreateExportList (comes from XLC fileset ) & GNU libtool (m4/libtool.m4). Both the scripts ignores the symbols in the object files that starts with "." 
So the current AIX specific asm syntax needs change to avoid missing out necessary symbols while creating shared object from the final archive. 