### PR TITLE
Add -lm and disable EXPRECISION support on *BSD

### DIFF
--- a/cmake/os.cmake
+++ b/cmake/os.cmake
@@ -8,6 +8,11 @@ if (${CMAKE_SYSTEM_NAME} STREQUAL "Linux")
   set(NO_EXPRECISION 1)
 endif ()
 
+if (${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD|OpenBSD|NetBSD|DragonFly")
+  set(EXTRALIB "${EXTRALIB} -lm")
+  set(NO_EXPRECISION 1)
+endif ()
+
 if (${CMAKE_SYSTEM_NAME} STREQUAL "AIX")
   set(EXTRALIB "${EXTRALIB} -lm")
 endif ()


### PR DESCRIPTION
fixes #2075 and (possibly just works around) cmake build problem seen in #2076