### PR TITLE
snprintf define consolidated to common.h

### DIFF
--- a/common.h
+++ b/common.h
@@ -85,6 +85,8 @@ extern "C" {
 
 #if !defined(_MSC_VER)
 #include <unistd.h>
+#elif _MSC_VER < 1900
+#define snprintf _snprintf
 #endif
 #include <time.h>
 

--- a/driver/others/openblas_get_config.c
+++ b/driver/others/openblas_get_config.c
@@ -35,12 +35,6 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <string.h>
 
-#if defined(_WIN32) && defined(_MSC_VER)
-#if _MSC_VER < 1900
-#define snprintf _snprintf
-#endif
-#endif
-
 static char* openblas_config_str=""
 "OpenBLAS "
  VERSION

--- a/utest/ctest.h
+++ b/utest/ctest.h
@@ -83,10 +83,6 @@ struct ctest {
 #undef CTEST_SEGFAULT
 #endif
 
-#if _MSC_VER < 1900
-#define snprintf _snprintf
-#endif
-
 #ifndef __cplusplus
 #define inline __inline
 #endif


### PR DESCRIPTION
This is a very minor bug fix for building with MSVC++ 12.0 and earlier.

The current develop branch fails because `snprintf` is not defined in `drivers/others/dynamic.c`.  Rather than adding a third define, I recommend consolidating the existing two into `common.h` so any calls to `snprintf` added in the future will also be covered.

I used the following cmake command:
```
cmake .. -G "Ninja" -DCMAKE_C_COMPILER=clang-cl -DCMAKE_Fortran_COMPILER=flang -DBUILD_WITHOUT_LAPACK=no -DNOFORTRAN=0 -DDYNAMIC_ARCH=ON -DCMAKE_BUILD_TYPE=Release
cmake --build . --config Release
```
With 64 bit MSVC++ 12.0

The output from `openblas_utest.exe` is:
```
TEST 1/20 amax:samax [OK]
TEST 2/20 drotmg:rotmg [OK]
TEST 3/20 drotmg:rotmg_issue1452 [OK]
TEST 4/20 drotmg:rotmg_D1eqD2_X1eqX2 [OK]
TEST 5/20 drotmg:drotmg_D1_big_D2_big_flag_zero [OK]
TEST 6/20 axpy:daxpy_inc_0 [OK]
TEST 7/20 axpy:zaxpy_inc_0 [OK]
TEST 8/20 axpy:saxpy_inc_0 [OK]
TEST 9/20 axpy:caxpy_inc_0 [OK]
TEST 10/20 zdotu:zdotu_n_1 [OK]
TEST 11/20 zdotu:zdotu_offset_1 [OK]
TEST 12/20 dsdot:dsdot_n_1 [OK]
TEST 13/20 rot:drot_inc_0 [OK]
TEST 14/20 rot:zdrot_inc_0 [OK]
TEST 15/20 rot:srot_inc_0 [OK]
TEST 16/20 rot:csrot_inc_0 [OK]
TEST 17/20 swap:dswap_inc_0 [OK]
TEST 18/20 swap:zswap_inc_0 [OK]
TEST 19/20 swap:sswap_inc_0 [OK]
TEST 20/20 swap:cswap_inc_0 [OK]
RESULTS: 20 tests (20 ok, 0 failed, 0 skipped)
```