### PR TITLE
Correct length of name string in xerbla call

### DIFF
--- a/interface/trsm.c
+++ b/interface/trsm.c
@@ -204,7 +204,7 @@ void NAME(char *SIDE, char *UPLO, char *TRANS, char *DIAG,
   if (side  < 0)                info =  1;
 
   if (info != 0) {
-    BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME));
+    BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME)-1);
     return;
   }
 


### PR DESCRIPTION
to avoid truncation of the xerbla message by the null character