### PR TITLE
Fix detection of Skylake processors when using GCC

### DIFF
--- a/Makefile.system
+++ b/Makefile.system
@@ -9,6 +9,11 @@ ifndef TOPDIR
 TOPDIR = .
 endif
 
+# If ARCH is not set, we use the host system's architecture.
+ifndef ARCH
+ARCH := $(shell uname -m)
+endif
+
 # Catch conflicting usage of ARCH in some BSD environments
 ifeq ($(ARCH), amd64)
 override ARCH=x86_64
@@ -137,6 +142,10 @@ endif
 endif
 
 
+# On x86_64 build getarch with march=native. This is required to detect AVX512 support in getarch.
+ifeq ($(ARCH), x86_64)
+GETARCH_FLAGS += -march=native
+endif
 
 
 ifdef INTERFACE64

--- a/c_check
+++ b/c_check
@@ -240,7 +240,7 @@ if (($architecture eq "x86") || ($architecture eq "x86_64")) {
 	} else {
 	    $no_avx512 = 0;
 	}
-	unlink("tmpf.o");
+	unlink("$tmpf.o");
     }
 }
 

--- a/cmake/system.cmake
+++ b/cmake/system.cmake
@@ -65,6 +65,11 @@ if (DEFINED TARGET)
   set(GETARCH_FLAGS "-DFORCE_${TARGET}")
 endif ()
 
+# On x86_64 build getarch with march=native. This is required to detect AVX512 support in getarch.
+if (X86_64)
+  set(GETARCH_FLAGS "${GETARCH_FLAGS} -march=native")
+endif ()
+
 if (INTERFACE64)
   message(STATUS "Using 64-bit integers.")
   set(GETARCH_FLAGS	"${GETARCH_FLAGS} -DUSE64BITINT")


### PR DESCRIPTION
21eda8b introduced a check in getarch.c to test if the compiler is capable of AVX512. This check is currently non-functional for GCC for two reasons:
* It checks for the `__AVX2__` macro instead of `__AVX512__`,
* these macros are only defined if getarch itself was compiled with AVX2/AVX512 support (e.g., with `-march=native`).

Instead, we can just test the GCC version as we do for clang. Support for `-march=skylake-avx512`, which is of interest here, was added in GCC 5.3: https://gcc.gnu.org/gcc-5/changes.html

While looking at the CPU detection, I noticed a small error in c_check, trying to unlink a file called `tmpf.o` instead of the actually created temporary object file. This is fixed as well.