### PR TITLE
TST: add native POWER8 to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,15 @@ matrix:
         - BTYPE="BINARY=64"
 
     - <<: *test-ubuntu
+      os: linux-ppc64le
+      before_script:
+        - COMMON_FLAGS="DYNAMIC_ARCH=1 TARGET=POWER8 NUM_THREADS=32"
+      env:
+        # for matrix annotation only
+        - TARGET_BOX=PPC64LE_LINUX
+        - BTYPE="BINARY=64 USE_OPENMP=1"
+
+    - <<: *test-ubuntu
       env:
         - TARGET_BOX=LINUX64
         - BTYPE="BINARY=64 USE_OPENMP=1"


### PR DESCRIPTION
* add native POWER8 testing to
Travis CI matrix with ppc64le
os entry

The new job ran successfully in about 7 minutes on my fork--let me know if more POWER-specific build flags might be desired? Also, probably a good idea to check the log for the new entry.

I was hesitating to add more stuff to the already-busy Travis matrix, but I see @xianyi is now working to get Azure pipelines up and running, so that should provide a medium for shifting burden off Travis if needed.