### PR TITLE
Drone CI for arm64 native builds

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -41,3 +41,47 @@ steps:
     - make -C test $COMMON_FLAGS
     - make -C ctest $COMMON_FLAGS
     - make -C utest $COMMON_FLAGS
+
+---
+kind: pipeline
+name: arm64_gcc_cmake
+
+platform:
+  os: linux
+  arch: arm64
+
+steps:
+- name: Build and Test
+  image: ubuntu:18.04
+  environment:
+    CC: gcc
+    CMAKE_FLAGS: '-DDYNAMIC_ARCH=1 -DTARGET=ARMV8 -DNUM_THREADS=32'
+  commands:
+    - apt-get update -y
+    - apt-get install -y make $CC gfortran perl cmake
+    - mkdir build && cd build
+    - cmake $CMAKE_FLAGS ..
+    - cmake --build .
+    - ctest
+
+---
+kind: pipeline
+name: arm64_clang_cmake
+
+platform:
+  os: linux
+  arch: arm64
+
+steps:
+- name: Build and Test
+  image: ubuntu:18.04
+  environment:
+    CC: clang
+    CMAKE_FLAGS: '-DDYNAMIC_ARCH=1 -DTARGET=ARMV8 -DNUM_THREADS=32'
+  commands:
+    - apt-get update -y
+    - apt-get install -y make $CC gfortran perl cmake
+    - mkdir build && cd build
+    - cmake $CMAKE_FLAGS ..
+    - cmake --build .
+    - ctest

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,0 +1,19 @@
+---
+kind: pipeline
+name: arm64_gcc
+
+platform:
+  os: linux
+  arch: arm64
+
+steps:
+- name: Build
+  image: centos:7
+  environment:
+    CC: gcc
+    COMMON_FLAGS: 'DYNAMIC_ARCH=1 TARGET=ARMV8 NUM_THREADS=32'
+  commands:
+    - make QUIET_MAKE=1 $COMMON_FLAGS
+    - make -C test $COMMON_FLAGS
+    - make -C ctest $COMMON_FLAGS
+    - make -C utest $COMMON_FLAGS"

--- a/.drone.yml
+++ b/.drone.yml
@@ -28,11 +28,11 @@ name: arm32_gcc_make
 
 platform:
   os: linux
-  arch: arm64
+  arch: arm
 
 steps:
 - name: Build and Test
-  image: ubuntu:18.04
+  image: ubuntu:19.04
   environment:
     CC: gcc
     COMMON_FLAGS: 'DYNAMIC_ARCH=1 TARGET=ARMV6 NUM_THREADS=32'

--- a/.drone.yml
+++ b/.drone.yml
@@ -11,10 +11,10 @@ steps:
   image: ubuntu:18.04
   environment:
     CC: gcc
-    COMMON_FLAGS: 'DYNAMIC_ARCH=1 TARGET=ARMV8 NUM_THREADS=32 -j'
+    COMMON_FLAGS: 'DYNAMIC_ARCH=1 TARGET=ARMV8 NUM_THREADS=32'
   commands:
     - apt-get update -y
-    - apt-get install -y make gcc gfortran perl clang
+    - apt-get install -y make $CC gfortran perl
     - make QUIET_MAKE=1 $COMMON_FLAGS
     - make -C test $COMMON_FLAGS
     - make -C ctest $COMMON_FLAGS
@@ -33,10 +33,10 @@ steps:
   image: ubuntu:18.04
   environment:
     CC: clang
-    COMMON_FLAGS: 'DYNAMIC_ARCH=1 TARGET=ARMV8 NUM_THREADS=32 -j'
+    COMMON_FLAGS: 'DYNAMIC_ARCH=1 TARGET=ARMV8 NUM_THREADS=32'
   commands:
     - apt-get update -y
-    - apt-get install -y make gcc gfortran perl clang
+    - apt-get install -y make $CC gfortran perl
     - make QUIET_MAKE=1 $COMMON_FLAGS
     - make -C test $COMMON_FLAGS
     - make -C ctest $COMMON_FLAGS

--- a/.drone.yml
+++ b/.drone.yml
@@ -7,12 +7,13 @@ platform:
   arch: arm64
 
 steps:
-- name: Build
+- name: Build and Test
   image: centos:7
   environment:
     CC: gcc
     COMMON_FLAGS: 'DYNAMIC_ARCH=1 TARGET=ARMV8 NUM_THREADS=32'
   commands:
+    - sudo yum -y install make
     - make QUIET_MAKE=1 $COMMON_FLAGS
     - make -C test $COMMON_FLAGS
     - make -C ctest $COMMON_FLAGS

--- a/.drone.yml
+++ b/.drone.yml
@@ -59,16 +59,15 @@ steps:
   image: ubuntu:18.04
   environment:
     CC: gcc
-    CXX: g++
     CMAKE_FLAGS: '-DDYNAMIC_ARCH=1 -DTARGET=ARMV8 -DNUM_THREADS=32 -DNOFORTRAN=ON -DBUILD_WITHOUT_LAPACK=ON'
   commands:
     - echo "CMAKE_FLAGS:= $CMAKE_FLAGS"
     - apt-get update -y
-    - apt-get install -y make $CC $CXX g++ perl cmake
+    - apt-get install -y make $CC g++ perl cmake
     - $CC --version
     - mkdir build && cd build
     - cmake $CMAKE_FLAGS ..
-    - cmake --build .
+    - make -j
     - ctest
 
 ---
@@ -84,14 +83,13 @@ steps:
   image: ubuntu:18.04
   environment:
     CC: clang
-    CXX: clang++
     CMAKE_FLAGS: '-DDYNAMIC_ARCH=1 -DTARGET=ARMV8 -DNUM_THREADS=32 -DNOFORTRAN=ON -DBUILD_WITHOUT_LAPACK=ON'
   commands:
     - echo "CMAKE_FLAGS:= $CMAKE_FLAGS"
     - apt-get update -y
-    - apt-get install -y make $CC $CXX perl cmake
+    - apt-get install -y make $CC g++ perl cmake
     - $CC --version
     - mkdir build && cd build
     - cmake $CMAKE_FLAGS ..
-    - cmake --build .
+    - make -j
     - ctest

--- a/.drone.yml
+++ b/.drone.yml
@@ -59,11 +59,12 @@ steps:
   image: ubuntu:18.04
   environment:
     CC: gcc
-    CMAKE_FLAGS: '-DDYNAMIC_ARCH=1 -DTARGET=ARMV8 -DNUM_THREADS=32'
+    CXX: g++
+    CMAKE_FLAGS: '-DDYNAMIC_ARCH=1 -DTARGET=ARMV8 -DNUM_THREADS=32 -DNOFORTRAN=ON -DBUILD_WITHOUT_LAPACK=ON'
   commands:
     - echo "CMAKE_FLAGS:= $CMAKE_FLAGS"
     - apt-get update -y
-    - apt-get install -y make $CC gfortran perl cmake
+    - apt-get install -y make $CC $CXX g++ perl cmake
     - $CC --version
     - mkdir build && cd build
     - cmake $CMAKE_FLAGS ..
@@ -83,11 +84,12 @@ steps:
   image: ubuntu:18.04
   environment:
     CC: clang
-    CMAKE_FLAGS: '-DDYNAMIC_ARCH=1 -DTARGET=ARMV8 -DNUM_THREADS=32'
+    CXX: clang++
+    CMAKE_FLAGS: '-DDYNAMIC_ARCH=1 -DTARGET=ARMV8 -DNUM_THREADS=32 -DNOFORTRAN=ON -DBUILD_WITHOUT_LAPACK=ON'
   commands:
     - echo "CMAKE_FLAGS:= $CMAKE_FLAGS"
     - apt-get update -y
-    - apt-get install -y make $CC gfortran perl cmake
+    - apt-get install -y make $CC $CXX perl cmake
     - $CC --version
     - mkdir build && cd build
     - cmake $CMAKE_FLAGS ..

--- a/.drone.yml
+++ b/.drone.yml
@@ -13,7 +13,7 @@ steps:
     CC: gcc
     COMMON_FLAGS: 'DYNAMIC_ARCH=1 TARGET=ARMV8 NUM_THREADS=32'
   commands:
-    - yum -y install make gcc
+    - yum -y install make gcc perl
     - make QUIET_MAKE=1 $COMMON_FLAGS
     - make -C test $COMMON_FLAGS
     - make -C ctest $COMMON_FLAGS

--- a/.drone.yml
+++ b/.drone.yml
@@ -1,6 +1,6 @@
 ---
 kind: pipeline
-name: arm64_gcc
+name: arm64_gcc_make
 
 platform:
   os: linux
@@ -13,7 +13,28 @@ steps:
     CC: gcc
     COMMON_FLAGS: 'DYNAMIC_ARCH=1 TARGET=ARMV8 NUM_THREADS=32'
   commands:
-    - yum -y install make gcc perl
+    - yum -y install make gcc gfortran perl
+    - make QUIET_MAKE=1 $COMMON_FLAGS
+    - make -C test $COMMON_FLAGS
+    - make -C ctest $COMMON_FLAGS
+    - make -C utest $COMMON_FLAGS"
+
+---
+kind: pipeline
+name: arm64_clang_make
+
+platform:
+  os: linux
+  arch: arm64
+
+steps:
+- name: Build and Test
+  image: centos:7
+  environment:
+    CC: clang
+    COMMON_FLAGS: 'DYNAMIC_ARCH=1 TARGET=ARMV8 NUM_THREADS=32'
+  commands:
+    - yum -y install make gcc gfortran perl clang
     - make QUIET_MAKE=1 $COMMON_FLAGS
     - make -C test $COMMON_FLAGS
     - make -C ctest $COMMON_FLAGS

--- a/.drone.yml
+++ b/.drone.yml
@@ -13,7 +13,8 @@ steps:
     CC: gcc
     COMMON_FLAGS: 'DYNAMIC_ARCH=1 TARGET=ARMV8 NUM_THREADS=32 -j'
   commands:
-    - apt install make gcc gfortran perl clang
+    - apt-get update
+    - apt-get install make gcc gfortran perl clang
     - make QUIET_MAKE=1 $COMMON_FLAGS
     - make -C test $COMMON_FLAGS
     - make -C ctest $COMMON_FLAGS
@@ -34,7 +35,8 @@ steps:
     CC: clang
     COMMON_FLAGS: 'DYNAMIC_ARCH=1 TARGET=ARMV8 NUM_THREADS=32 -j'
   commands:
-    - apt install make gcc gfortran perl clang
+    - apt-get update
+    - apt-get install make gcc gfortran perl clang
     - make QUIET_MAKE=1 $COMMON_FLAGS
     - make -C test $COMMON_FLAGS
     - make -C ctest $COMMON_FLAGS

--- a/.drone.yml
+++ b/.drone.yml
@@ -8,7 +8,7 @@ platform:
 
 steps:
 - name: Build and Test
-  image: ubuntu:18.04
+  image: ubuntu:19.04
   environment:
     CC: gcc
     COMMON_FLAGS: 'DYNAMIC_ARCH=1 TARGET=ARMV8 NUM_THREADS=32'

--- a/.drone.yml
+++ b/.drone.yml
@@ -13,7 +13,7 @@ steps:
     CC: gcc
     COMMON_FLAGS: 'DYNAMIC_ARCH=1 TARGET=ARMV8 NUM_THREADS=32'
   commands:
-    - yum -y install make
+    - yum -y install make gcc
     - make QUIET_MAKE=1 $COMMON_FLAGS
     - make -C test $COMMON_FLAGS
     - make -C ctest $COMMON_FLAGS

--- a/.drone.yml
+++ b/.drone.yml
@@ -8,12 +8,12 @@ platform:
 
 steps:
 - name: Build and Test
-  image: centos:7
+  image: ubuntu:18.04
   environment:
     CC: gcc
-    COMMON_FLAGS: 'DYNAMIC_ARCH=1 TARGET=ARMV8 NUM_THREADS=32'
+    COMMON_FLAGS: 'DYNAMIC_ARCH=1 TARGET=ARMV8 NUM_THREADS=32 -j'
   commands:
-    - yum -y install make gcc gcc-gfortran perl
+    - apt install make gcc gfortran perl clang
     - make QUIET_MAKE=1 $COMMON_FLAGS
     - make -C test $COMMON_FLAGS
     - make -C ctest $COMMON_FLAGS
@@ -29,12 +29,12 @@ platform:
 
 steps:
 - name: Build and Test
-  image: centos:7
+  image: ubuntu:18.04
   environment:
     CC: clang
-    COMMON_FLAGS: 'DYNAMIC_ARCH=1 TARGET=ARMV8 NUM_THREADS=32'
+    COMMON_FLAGS: 'DYNAMIC_ARCH=1 TARGET=ARMV8 NUM_THREADS=32 -j'
   commands:
-    - yum -y install make gcc gcc-gfortran perl clang
+    - apt install make gcc gfortran perl clang
     - make QUIET_MAKE=1 $COMMON_FLAGS
     - make -C test $COMMON_FLAGS
     - make -C ctest $COMMON_FLAGS

--- a/.drone.yml
+++ b/.drone.yml
@@ -13,8 +13,10 @@ steps:
     CC: gcc
     COMMON_FLAGS: 'DYNAMIC_ARCH=1 TARGET=ARMV8 NUM_THREADS=32'
   commands:
+    - echo "MAKE_FLAGS:= $COMMON_FLAGS"
     - apt-get update -y
     - apt-get install -y make $CC gfortran perl
+    - $CC --version
     - make QUIET_MAKE=1 $COMMON_FLAGS
     - make -C test $COMMON_FLAGS
     - make -C ctest $COMMON_FLAGS
@@ -35,8 +37,10 @@ steps:
     CC: clang
     COMMON_FLAGS: 'DYNAMIC_ARCH=1 TARGET=ARMV8 NUM_THREADS=32'
   commands:
+    - echo "MAKE_FLAGS:= $COMMON_FLAGS"
     - apt-get update -y
     - apt-get install -y make $CC gfortran perl
+    - $CC --version
     - make QUIET_MAKE=1 $COMMON_FLAGS
     - make -C test $COMMON_FLAGS
     - make -C ctest $COMMON_FLAGS
@@ -57,8 +61,10 @@ steps:
     CC: gcc
     CMAKE_FLAGS: '-DDYNAMIC_ARCH=1 -DTARGET=ARMV8 -DNUM_THREADS=32'
   commands:
+    - echo "CMAKE_FLAGS:= $CMAKE_FLAGS"
     - apt-get update -y
     - apt-get install -y make $CC gfortran perl cmake
+    - $CC --version
     - mkdir build && cd build
     - cmake $CMAKE_FLAGS ..
     - cmake --build .
@@ -79,8 +85,10 @@ steps:
     CC: clang
     CMAKE_FLAGS: '-DDYNAMIC_ARCH=1 -DTARGET=ARMV8 -DNUM_THREADS=32'
   commands:
+    - echo "CMAKE_FLAGS:= $CMAKE_FLAGS"
     - apt-get update -y
     - apt-get install -y make $CC gfortran perl cmake
+    - $CC --version
     - mkdir build && cd build
     - cmake $CMAKE_FLAGS ..
     - cmake --build .

--- a/.drone.yml
+++ b/.drone.yml
@@ -18,7 +18,7 @@ steps:
     - make QUIET_MAKE=1 $COMMON_FLAGS
     - make -C test $COMMON_FLAGS
     - make -C ctest $COMMON_FLAGS
-    - make -C utest $COMMON_FLAGS"
+    - make -C utest $COMMON_FLAGS
 
 ---
 kind: pipeline
@@ -40,4 +40,4 @@ steps:
     - make QUIET_MAKE=1 $COMMON_FLAGS
     - make -C test $COMMON_FLAGS
     - make -C ctest $COMMON_FLAGS
-    - make -C utest $COMMON_FLAGS"
+    - make -C utest $COMMON_FLAGS

--- a/.drone.yml
+++ b/.drone.yml
@@ -13,7 +13,7 @@ steps:
     CC: gcc
     COMMON_FLAGS: 'DYNAMIC_ARCH=1 TARGET=ARMV8 NUM_THREADS=32'
   commands:
-    - yum -y install make gcc gfortran perl
+    - yum -y install make gcc gcc-gfortran perl
     - make QUIET_MAKE=1 $COMMON_FLAGS
     - make -C test $COMMON_FLAGS
     - make -C ctest $COMMON_FLAGS
@@ -34,7 +34,7 @@ steps:
     CC: clang
     COMMON_FLAGS: 'DYNAMIC_ARCH=1 TARGET=ARMV8 NUM_THREADS=32'
   commands:
-    - yum -y install make gcc gfortran perl clang
+    - yum -y install make gcc gcc-gfortran perl clang
     - make QUIET_MAKE=1 $COMMON_FLAGS
     - make -C test $COMMON_FLAGS
     - make -C ctest $COMMON_FLAGS

--- a/.drone.yml
+++ b/.drone.yml
@@ -24,6 +24,30 @@ steps:
 
 ---
 kind: pipeline
+name: arm32_gcc_make
+
+platform:
+  os: linux
+  arch: arm64
+
+steps:
+- name: Build and Test
+  image: ubuntu:18.04
+  environment:
+    CC: gcc
+    COMMON_FLAGS: 'DYNAMIC_ARCH=1 TARGET=ARMV6 NUM_THREADS=32'
+  commands:
+    - echo "MAKE_FLAGS:= $COMMON_FLAGS"
+    - apt-get update -y
+    - apt-get install -y make $CC gfortran perl
+    - $CC --version
+    - make QUIET_MAKE=1 $COMMON_FLAGS
+    - make -C test $COMMON_FLAGS
+    - make -C ctest $COMMON_FLAGS
+    - make -C utest $COMMON_FLAGS
+
+---
+kind: pipeline
 name: arm64_clang_make
 
 platform:
@@ -45,6 +69,30 @@ steps:
     - make -C test $COMMON_FLAGS
     - make -C ctest $COMMON_FLAGS
     - make -C utest $COMMON_FLAGS
+
+---
+kind: pipeline
+name: arm32_clang_cmake
+
+platform:
+  os: linux
+  arch: arm
+
+steps:
+- name: Build and Test
+  image: ubuntu:18.04
+  environment:
+    CC: clang
+    CMAKE_FLAGS: '-DDYNAMIC_ARCH=1 -DTARGET=ARMV6 -DNUM_THREADS=32 -DNOFORTRAN=ON -DBUILD_WITHOUT_LAPACK=ON'
+  commands:
+    - echo "CMAKE_FLAGS:= $CMAKE_FLAGS"
+    - apt-get update -y
+    - apt-get install -y make $CC g++ perl cmake
+    - $CC --version
+    - mkdir build && cd build
+    - cmake $CMAKE_FLAGS ..
+    - make -j
+    - ctest
 
 ---
 kind: pipeline

--- a/.drone.yml
+++ b/.drone.yml
@@ -13,7 +13,7 @@ steps:
     CC: gcc
     COMMON_FLAGS: 'DYNAMIC_ARCH=1 TARGET=ARMV8 NUM_THREADS=32'
   commands:
-    - sudo yum -y install make
+    - yum -y install make
     - make QUIET_MAKE=1 $COMMON_FLAGS
     - make -C test $COMMON_FLAGS
     - make -C ctest $COMMON_FLAGS

--- a/.drone.yml
+++ b/.drone.yml
@@ -13,8 +13,8 @@ steps:
     CC: gcc
     COMMON_FLAGS: 'DYNAMIC_ARCH=1 TARGET=ARMV8 NUM_THREADS=32 -j'
   commands:
-    - apt-get update
-    - apt-get install make gcc gfortran perl clang
+    - apt-get update -y
+    - apt-get install -y make gcc gfortran perl clang
     - make QUIET_MAKE=1 $COMMON_FLAGS
     - make -C test $COMMON_FLAGS
     - make -C ctest $COMMON_FLAGS
@@ -35,8 +35,8 @@ steps:
     CC: clang
     COMMON_FLAGS: 'DYNAMIC_ARCH=1 TARGET=ARMV8 NUM_THREADS=32 -j'
   commands:
-    - apt-get update
-    - apt-get install make gcc gfortran perl clang
+    - apt-get update -y
+    - apt-get install -y make gcc gfortran perl clang
     - make QUIET_MAKE=1 $COMMON_FLAGS
     - make -C test $COMMON_FLAGS
     - make -C ctest $COMMON_FLAGS

--- a/.travis.yml
+++ b/.travis.yml
@@ -193,13 +193,6 @@ matrix:
                                  -D CMAKE_BUILD_TYPE=Release ../  &&  \
             cmake --build ." > Dockerfile
         docker build .
-    - <<: *emulated-arm
-      env: IMAGE_ARCH=arm64 TARGET_ARCH=ARMV8 COMPILER=clang
-      name: "Emulated Build for ARMV8 with clang"
-
-  allow_failures:
-    - env: IMAGE_ARCH=arm32 TARGET_ARCH=ARMV6 COMPILER=clang
-    - env: IMAGE_ARCH=arm64 TARGET_ARCH=ARMV8 COMPILER=clang
 
 # whitelist
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -173,27 +173,6 @@ matrix:
       env:
         - BTYPE="BINARY=32"
 
-    - &emulated-arm
-      dist: trusty
-      sudo: required
-      services: docker
-      env: IMAGE_ARCH=arm32 TARGET_ARCH=ARMV6 COMPILER=clang
-      name: "Emulated Build for ARMV6 with clang"
-      before_install: sudo docker run --rm --privileged multiarch/qemu-user-static:register --reset
-      script: |
-        echo "FROM openblas/alpine:${IMAGE_ARCH}
-        COPY . /tmp/openblas
-        RUN mkdir /tmp/openblas/build                             &&  \
-            cd /tmp/openblas/build                                &&  \
-            CC=${COMPILER} cmake -D DYNAMIC_ARCH=OFF                  \
-                                 -D TARGET=${TARGET_ARCH}             \
-                                 -D BUILD_SHARED_LIBS=ON              \
-                                 -D BUILD_WITHOUT_LAPACK=ON           \
-                                 -D BUILD_WITHOUT_CBLAS=ON            \
-                                 -D CMAKE_BUILD_TYPE=Release ../  &&  \
-            cmake --build ." > Dockerfile
-        docker build .
-
 # whitelist
 branches:
   only:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,26 +26,6 @@ jobs:
             cmake --build ." > Dockerfile
       docker build .
     displayName: Run ARMV6 docker build
-- job: ARMv8_gcc
-  pool:
-    vmImage: 'ubuntu-16.04'
-  steps:
-  - script: |
-      docker run --rm --privileged multiarch/qemu-user-static:register --reset
-      echo "FROM openblas/alpine:arm64
-        COPY . /tmp/openblas
-        RUN mkdir /tmp/openblas/build                             &&  \
-            cd /tmp/openblas/build                                &&  \
-            CC=gcc cmake -D DYNAMIC_ARCH=OFF                          \
-                                 -D TARGET=ARMV8                      \
-                                 -D NOFORTRAN=ON                      \
-                                 -D BUILD_SHARED_LIBS=ON              \
-                                 -D BUILD_WITHOUT_LAPACK=ON           \
-                                 -D BUILD_WITHOUT_CBLAS=ON            \
-                                 -D CMAKE_BUILD_TYPE=Release ../  &&  \
-            cmake --build ." > Dockerfile
-      docker build .
-    displayName: Run ARMV8 docker build   
 # manylinux1 is useful to test because the
 # standard Docker container uses an old version
 # of gcc / glibc

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,26 +6,6 @@ trigger:
       - develop
 
 jobs:
-- job: ARMv6_gcc
-  pool:
-    vmImage: 'ubuntu-16.04'
-  steps:
-  - script: |
-      docker run --rm --privileged multiarch/qemu-user-static:register --reset
-      echo "FROM openblas/alpine:arm32
-        COPY . /tmp/openblas
-        RUN mkdir /tmp/openblas/build                             &&  \
-            cd /tmp/openblas/build                                &&  \
-            CC=gcc cmake -D DYNAMIC_ARCH=OFF                          \
-                                 -D TARGET=ARMV6                      \
-                                 -D NOFORTRAN=ON                      \
-                                 -D BUILD_SHARED_LIBS=ON              \
-                                 -D BUILD_WITHOUT_LAPACK=ON           \
-                                 -D BUILD_WITHOUT_CBLAS=ON            \
-                                 -D CMAKE_BUILD_TYPE=Release ../  &&  \
-            cmake --build ." > Dockerfile
-      docker build .
-    displayName: Run ARMV6 docker build
 # manylinux1 is useful to test because the
 # standard Docker container uses an old version
 # of gcc / glibc


### PR DESCRIPTION
There are 4 jobs for compilers gcc and clang and build system make and cmake.
I disabled lapack on cmake build as it was failing to build in cmake. (CMake build system gives a warning that openblas cmake supports only x86)