### PR TITLE
TST: add SkylakeX AVX512 CI test

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,3 +25,27 @@ jobs:
             make -C utest $COMMON_FLAGS $BTYPE" > Dockerfile
       docker build .
     displayName: Run manylinux1 docker build
+- job: Intel_SDE_skx
+  pool:
+    vmImage: 'ubuntu-16.04'
+  steps:
+  - script: |
+      # at the time of writing the available Azure Ubuntu vm image
+      # does not support AVX512VL, so use more recent LTS version
+      echo "FROM ubuntu:bionic
+      COPY . /tmp/openblas
+      RUN apt-get -y update && apt-get -y install \\
+          cmake \\
+          gfortran \\
+          make \\
+          wget
+      RUN mkdir /tmp/SDE && cd /tmp/SDE && \\
+          mkdir sde-external-8.35.0-2019-03-11-lin && \\
+          wget --quiet -O sde-external-8.35.0-2019-03-11-lin.tar.bz2 https://www.dropbox.com/s/fopsnzj67572sj5/sde-external-8.35.0-2019-03-11-lin.tar.bz2?dl=0 && \\
+          tar -xjvf sde-external-8.35.0-2019-03-11-lin.tar.bz2 -C /tmp/SDE/sde-external-8.35.0-2019-03-11-lin --strip-components=1
+      RUN cd /tmp/openblas && CC=gcc make QUIET_MAKE=1 DYNAMIC_ARCH=1 NUM_THREADS=32 BINARY=64
+      CMD cd /tmp/openblas && echo 0 > /proc/sys/kernel/yama/ptrace_scope && CC=gcc OPENBLAS_VERBOSE=2 /tmp/SDE/sde-external-8.35.0-2019-03-11-lin/sde64 -cpuid_in /tmp/SDE/sde-external-8.35.0-2019-03-11-lin/misc/cpuid/skx/cpuid.def -- make -C utest DYNAMIC_ARCH=1 NUM_THREADS=32 BINARY=64" > Dockerfile
+      docker build -t intel_sde .
+      # we need a privileged docker run for sde process attachment
+      docker run --privileged intel_sde
+    displayName: 'Run AVX512 SkylakeX docker build / test'

--- a/utest/CMakeLists.txt
+++ b/utest/CMakeLists.txt
@@ -38,6 +38,7 @@ if (NOT NO_LAPACK)
 set(OpenBLAS_utest_src
   ${OpenBLAS_utest_src}
   test_potrs.c
+  test_kernel_regress.c
   )
 endif()
 

--- a/utest/Makefile
+++ b/utest/Makefile
@@ -13,6 +13,7 @@ OBJS=utest_main.o test_amax.o test_rotmg.o test_axpy.o test_dotu.o test_dsdot.o 
 
 ifneq ($(NO_LAPACK), 1)
 OBJS += test_potrs.o
+OBJS += test_kernel_regress.o
 endif
 
 #this does not work with OpenMP nor with native Windows or Android threads

--- a/utest/test_kernel_regress.c
+++ b/utest/test_kernel_regress.c
@@ -1,0 +1,50 @@
+#include "openblas_utest.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <cblas.h>
+
+#define LAPACK_ROW_MAJOR               101
+blasint LAPACKE_dgesvd( blasint matrix_layout, char jobu, char jobvt,
+                           blasint m, blasint n, double* a,
+                           blasint lda, double* s, double* u, blasint ldu,
+                           double* vt, blasint ldvt, double* superb );
+                                                                                 
+
+#define DATASIZE 100
+
+double s[DATASIZE];
+double u[DATASIZE*DATASIZE];
+double vt[DATASIZE*DATASIZE];
+double X[DATASIZE*DATASIZE];
+double superb[DATASIZE];
+double tmp[DATASIZE*DATASIZE];
+double m[DATASIZE*DATASIZE];
+
+CTEST(kernel_regress,skx_avx)
+{
+    double norm;
+    int i, j, info;
+    srand(0);
+	for (i = 0; i < DATASIZE*DATASIZE; i++) {
+        m[i] = (rand()+0.0)/RAND_MAX * 10;
+        tmp[i] = m[i];
+    }
+
+    info = LAPACKE_dgesvd( LAPACK_ROW_MAJOR, 'A', 'A', DATASIZE, DATASIZE, m, DATASIZE,
+                        s, u, DATASIZE, vt, DATASIZE, superb);
+
+	for (i = 0; i < DATASIZE; i++) {
+	    for (j = 0; j < DATASIZE; j++) {
+            u[i*DATASIZE+j] = u[i*DATASIZE+j]*s[j];
+        }
+    }
+    cblas_dgemm(CblasRowMajor, CblasNoTrans, CblasNoTrans, 
+                DATASIZE, DATASIZE, DATASIZE, 1, u, DATASIZE, vt, DATASIZE, 0, X, DATASIZE);
+
+	for (i = 0; i < DATASIZE*DATASIZE; i++) {
+        X[i] = X[i] - tmp[i];
+    }
+    
+    norm = cblas_dnrm2(DATASIZE*DATASIZE, X, 1);
+    ASSERT_DBL_NEAR_TOL(0.0, norm, 1e-10);
+}


### PR DESCRIPTION
* adapt the C-level reproducer code for some
recent SkylakeX AVX512 kernel issues, provided
by Isuru Fernando and modified by Martin Kroeker,
for usage in the utest suite

* add an Intel SDE SkylakeX emulation utest run to
the Azure CI matrix; a custom Docker build was required
because Ubuntu image provided by Azure does not support
AVX512VL instructions

If you're like me and don't believe regression tests until you've seen the failure, [here's the same CI run](https://dev.azure.com/tylerjereddy/openblas-fork/_build/results?buildId=896) on a branch off OpenBLAS at 3f427c0c, the most problematic recent build used in NumPy ecosystem. After demonstrating that failure, I ported the relevant changes over to this PR branch.

The hope is that this can supersede the Intel SDE skx regression guards for:
- NumPy: https://github.com/numpy/numpy/pull/13466  
- SciPy: https://github.com/scipy/scipy/pull/10145
- etc.

and provide a faster feedback loop in SkylakeX AVX512 kernel issues directly / automatically at the source, rather than downstream.

This took rather longer to draft than I had hoped--one unfortunate issue is the way we `echo` to Dockerfiles rather than just putting well-formatted Dockerfiles into the repo proper, and the fact that `docker build` doesn't support `--privileged` as required for SDE process attachment.

Of course, there are still a few issues open about SkylakeX AVX512 matters, so this may simply be the start of related regression guards. And as Isuru previously noted, BLIS actually iterates over a few different emulation archs, so you / we might consider building up to that I suppose.