### PR TITLE
Fix DTRMMKERNEL register save for power8 64-bit mode (Fix for #2166)

### DIFF
--- a/kernel/power/dtrmm_kernel_16x4_power8.S
+++ b/kernel/power/dtrmm_kernel_16x4_power8.S
@@ -257,8 +257,6 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         stvx    v31, r11, r0
         li r11,0
 
-	stw	r31,  144(SP)
-
 	stfd	f1,  ALPHA_SP
 	stw	r0,  FZERO
 


### PR DESCRIPTION
This commit fixes #2166 