### PR TITLE
Fix build on FreeBSD/powerpc64.

### DIFF
--- a/common_power.h
+++ b/common_power.h
@@ -499,7 +499,7 @@ static inline int blas_quickdivide(blasint x, blasint y){
 
 #if defined(ASSEMBLER) && !defined(NEEDPARAM)
 
-#ifdef OS_LINUX
+#if defined(OS_LINUX) || defined(OS_FREEBSD)
 #ifndef __64BIT__
 #define PROLOGUE \
 	.section .text;\
@@ -784,7 +784,7 @@ Lmcount$lazy_ptr:
 
 #define HALT		mfspr	r0, 1023
 
-#ifdef OS_LINUX
+#if defined(OS_LINUX) || defined(OS_FREEBSD)
 #if defined(PPC440) || defined(PPC440FP2)
 #undef  MAX_CPU_NUMBER
 #define MAX_CPU_NUMBER 1
@@ -829,7 +829,7 @@ Lmcount$lazy_ptr:
 #define MAP_ANONYMOUS MAP_ANON
 #endif
 
-#ifdef OS_LINUX
+#if defined(OS_LINUX) || defined(OS_FREEBSD)
 #ifndef __64BIT__
 #define FRAMESLOT(X) (((X) * 4) + 8)
 #else

--- a/kernel/power/axpy.S
+++ b/kernel/power/axpy.S
@@ -39,7 +39,7 @@
 #define ASSEMBLER
 #include "common.h"
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define N	r3
 #define X	r6

--- a/kernel/power/axpy_ppc440.S
+++ b/kernel/power/axpy_ppc440.S
@@ -39,7 +39,7 @@
 #define ASSEMBLER
 #include "common.h"
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define N	r3
 #define X	r6

--- a/kernel/power/cgemm_kernel_8x4_power8.S
+++ b/kernel/power/cgemm_kernel_8x4_power8.S
@@ -97,7 +97,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define	N	r4
 #define	K	r5
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define A	r6
 #define	B	r7
@@ -265,7 +265,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	stfs	f2,  ALPHA_I_SP
 	// stw	r0,  FZERO
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifdef __64BIT__
 	ld	LDC, FRAMESLOT(0) + 0(FRAMEPOINTER)
 #endif
@@ -286,7 +286,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endif
 
 #ifdef TRMMKERNEL
-#if defined(linux) && defined(__64BIT__)
+#if (defined(linux) || defined(__FreeBSD__)) && defined(__64BIT__)
 	ld	OFFSET,  FRAMESLOT(1) + 0(FRAMEPOINTER)
 #endif
 

--- a/kernel/power/ctrmm_kernel_8x4_power8.S
+++ b/kernel/power/ctrmm_kernel_8x4_power8.S
@@ -98,7 +98,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define	N	r4
 #define	K	r5
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define A	r6
 #define	B	r7
@@ -264,7 +264,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	stfs	f2,  ALPHA_I_SP
 	// stw	r0,  FZERO
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifdef __64BIT__
 	ld	LDC, FRAMESLOT(0) + STACKSIZE(SP)
 #endif
@@ -285,7 +285,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endif
 
 #ifdef TRMMKERNEL
-#if defined(linux) && defined(__64BIT__)
+#if (defined(linux) || defined(__FreeBSD__)) && defined(__64BIT__)
 	ld	OFFSET,  FRAMESLOT(1) + STACKSIZE(SP)
 #endif
 

--- a/kernel/power/dgemm_kernel_16x4_power8.S
+++ b/kernel/power/dgemm_kernel_16x4_power8.S
@@ -97,7 +97,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define	N	r4
 #define	K	r5
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define A	r6
 #define	B	r7
@@ -271,7 +271,7 @@ li r11,0
 	slwi	LDC, LDC, BASE_SHIFT
 
 #if defined(TRMMKERNEL)
-#if defined(linux) && defined(__64BIT__)
+#if (defined(linux) || defined(__FreeBSD__)) && defined(__64BIT__)
 	ld	OFFSET,  FRAMESLOT(0) + STACKSIZE(SP)
 #endif
 

--- a/kernel/power/dtrmm_kernel_16x4_power8.S
+++ b/kernel/power/dtrmm_kernel_16x4_power8.S
@@ -96,7 +96,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define	N	r4
 #define	K	r5
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define A	r6
 #define	B	r7
@@ -269,7 +269,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	slwi	LDC, LDC, BASE_SHIFT
 
 #if defined(TRMMKERNEL)
-#if defined(linux) && defined(__64BIT__)
+#if (defined(linux) || defined(__FreeBSD__)) && defined(__64BIT__)
 	ld	OFFSET,  FRAMESLOT(0) + STACKSIZE(SP)
 #endif
 

--- a/kernel/power/dtrsm_kernel_LT_16x4_power8.S
+++ b/kernel/power/dtrsm_kernel_LT_16x4_power8.S
@@ -61,7 +61,7 @@
 #define	N	r4
 #define	K	r5
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define A	r6
 #define	B	r7
@@ -217,7 +217,7 @@ li r11,0
 #endif
 
 
-#if defined(linux) && defined(__64BIT__)
+#if (defined(linux) || defined(__FreeBSD__)) && defined(__64BIT__)
 	ld	OFFSET,  FRAMESLOT(0) + STACKSIZE(SP)
 #endif
 

--- a/kernel/power/gemm_beta.S
+++ b/kernel/power/gemm_beta.S
@@ -62,7 +62,7 @@
 	stfd	f31,   16(SP)
 	stw	r0,    24(SP)
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 	lwz	LDC,    FRAMESLOT(0) + STACKSIZE(SP)
 #else

--- a/kernel/power/gemm_kernel.S
+++ b/kernel/power/gemm_kernel.S
@@ -59,7 +59,7 @@
 #define	N	r4
 #define	K	r5
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define A	r6
 #define	B	r7
@@ -186,7 +186,7 @@
 	slwi	LDC, LDC, BASE_SHIFT
 
 #if defined(TRMMKERNEL)
-#if defined(linux) && defined(__64BIT__)
+#if (defined(linux) || defined(__FreeBSD__)) && defined(__64BIT__)
 	ld	OFFSET,   FRAMESLOT(0) + STACKSIZE(SP)
 #endif
 
@@ -228,7 +228,7 @@
 
 #else
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 	mr	PREA,  r10
 	lwz	PREB,  FRAMESLOT(0) + STACKSIZE(SP)

--- a/kernel/power/gemm_kernel_altivec.S
+++ b/kernel/power/gemm_kernel_altivec.S
@@ -58,7 +58,7 @@
 #define	N	r4
 #define	K	r5
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define A	r6
 #define	B	r7

--- a/kernel/power/gemm_kernel_altivec_cell.S
+++ b/kernel/power/gemm_kernel_altivec_cell.S
@@ -58,7 +58,7 @@
 #define	N	r4
 #define	K	r5
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define A	r6
 #define	B	r7

--- a/kernel/power/gemm_kernel_altivec_g4.S
+++ b/kernel/power/gemm_kernel_altivec_g4.S
@@ -58,7 +58,7 @@
 #define	N	r4
 #define	K	r5
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define A	r6
 #define	B	r7

--- a/kernel/power/gemm_kernel_cell.S
+++ b/kernel/power/gemm_kernel_cell.S
@@ -59,7 +59,7 @@
 #define	N	r4
 #define	K	r5
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define A	r6
 #define	B	r7
@@ -192,7 +192,7 @@
 	slwi	LDC, LDC, BASE_SHIFT
 
 #if defined(TRMMKERNEL)
-#if defined(linux) && defined(__64BIT__)
+#if (defined(linux) || defined(__FreeBSD__)) && defined(__64BIT__)
 	ld	OFFSET, FRAMESLOT(0) + STACKSIZE(SP)
 #endif
 
@@ -226,7 +226,7 @@
 	li	PREC,   4 * SIZE
 #endif
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 	mr	PREA,  r10
 	lwz	PREB,  FRAMESLOT(0) + STACKSIZE(SP)

--- a/kernel/power/gemm_kernel_g4.S
+++ b/kernel/power/gemm_kernel_g4.S
@@ -59,7 +59,7 @@
 #define	N	r4
 #define	K	r5
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define A	r6
 #define	B	r7
@@ -184,7 +184,7 @@
 	slwi	LDC, LDC, BASE_SHIFT
 
 #if defined(TRMMKERNEL)
-#if defined(linux) && defined(__64BIT__)
+#if (defined(linux) || defined(__FreeBSD__)) && defined(__64BIT__)
 	ld	OFFSET, FRAMESLOT(0) + STACKSIZE(SP)
 #endif
 

--- a/kernel/power/gemm_kernel_hummer.S
+++ b/kernel/power/gemm_kernel_hummer.S
@@ -46,7 +46,7 @@
 #define	N	r4
 #define	K	r5
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #define A	r6
 #define	B	r7
 #define	C	r8

--- a/kernel/power/gemm_kernel_power3.S
+++ b/kernel/power/gemm_kernel_power3.S
@@ -59,7 +59,7 @@
 #define	N	r4
 #define	K	r5
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define A	r6
 #define	B	r7
@@ -187,7 +187,7 @@
 	li	PREC,   4 * SIZE
 #else
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 	mr	PREA,  r10
 	lwz	PREB,  FRAMESLOT(0) + STACKSIZE(SP)

--- a/kernel/power/gemm_kernel_power6.S
+++ b/kernel/power/gemm_kernel_power6.S
@@ -59,7 +59,7 @@
 #define	N	r4
 #define	K	r5
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define A	r6
 #define	B	r7
@@ -183,7 +183,7 @@
 	slwi	LDC, LDC, BASE_SHIFT
 
 #if defined(TRMMKERNEL)
-#if defined(linux) && defined(__64BIT__)
+#if (defined(linux) || defined(__FreeBSD__)) && defined(__64BIT__)
 	ld	OFFSET,  FRAMESLOT(0) + STACKSIZE(SP)
 #endif
 

--- a/kernel/power/gemm_kernel_ppc440.S
+++ b/kernel/power/gemm_kernel_ppc440.S
@@ -59,7 +59,7 @@
 #define	N	r4
 #define	K	r5
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define A	r6
 #define	B	r7
@@ -183,7 +183,7 @@
 	slwi	LDC, LDC, BASE_SHIFT
 
 #if defined(TRMMKERNEL)
-#if defined(linux) && defined(__64BIT__)
+#if (defined(linux) || defined(__FreeBSD__)) && defined(__64BIT__)
 	ld	OFFSET, FRAMESLOT(0) + STACKSIZE(SP)
 #endif
 

--- a/kernel/power/gemv_n.S
+++ b/kernel/power/gemv_n.S
@@ -39,7 +39,7 @@
 #define ASSEMBLER
 #include "common.h"
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define M	r3
 #define	N	r4
@@ -252,7 +252,7 @@
 	stw	r27,   196(SP)
 #endif
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 	lwz	INCY,    FRAMESLOT(0) + STACKSIZE(SP)
 	lwz	BUFFER,  FRAMESLOT(1) + STACKSIZE(SP)

--- a/kernel/power/gemv_n_ppc440.S
+++ b/kernel/power/gemv_n_ppc440.S
@@ -39,7 +39,7 @@
 #define ASSEMBLER
 #include "common.h"
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define M	r3
 #define	N	r4
@@ -199,7 +199,7 @@
 	stw	r23,   180(SP)
 #endif
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 	lwz	INCY,    FRAMESLOT(0) + STACKSIZE(SP)
 	lwz	BUFFER,  FRAMESLOT(1) + STACKSIZE(SP)

--- a/kernel/power/gemv_t.S
+++ b/kernel/power/gemv_t.S
@@ -39,7 +39,7 @@
 #define ASSEMBLER
 #include "common.h"
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define M	r3
 #define	N	r4
@@ -260,7 +260,7 @@
 	stw	r29,   220(SP)
 #endif
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 	lwz	INCY,	 FRAMESLOT(0) + STACKSIZE(SP)
 	lwz	BUFFER,  FRAMESLOT(1) + STACKSIZE(SP)

--- a/kernel/power/gemv_t_ppc440.S
+++ b/kernel/power/gemv_t_ppc440.S
@@ -39,7 +39,7 @@
 #define ASSEMBLER
 #include "common.h"
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define M	r3
 #define	N	r4
@@ -190,7 +190,7 @@
 	stw	r22,   192(SP)
 #endif
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 	lwz	INCY,	 FRAMESLOT(0) + STACKSIZE(SP)
 	lwz	BUFFER,  FRAMESLOT(1) + STACKSIZE(SP)

--- a/kernel/power/ger.S
+++ b/kernel/power/ger.S
@@ -47,7 +47,7 @@
 #endif
 #endif
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define M	r3
 #define	N	r4
@@ -224,7 +224,7 @@
 	stw	r27,   196(SP)
 #endif
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 	lwz	LDA,     FRAMESLOT(0) + STACKSIZE(SP)
 	lwz	BUFFER,  FRAMESLOT(1) + STACKSIZE(SP)

--- a/kernel/power/scal.S
+++ b/kernel/power/scal.S
@@ -43,7 +43,7 @@
 #define XX	r4
 #define PREA	r5
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define X r6
 #define INCX r7

--- a/kernel/power/scal_ppc440.S
+++ b/kernel/power/scal_ppc440.S
@@ -43,7 +43,7 @@
 #define XX	r4
 #define PRE	r5
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define X r6
 #define INCX r7

--- a/kernel/power/sgemm_kernel_16x8_power8.S
+++ b/kernel/power/sgemm_kernel_16x8_power8.S
@@ -95,7 +95,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define	N	r4
 #define	K	r5
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define A	r6
 #define	B	r7
@@ -273,7 +273,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	slwi	LDC, LDC, 2
 
 #if defined(TRMMKERNEL)
-#if defined(linux) && defined(__64BIT__)
+#if (defined(linux) || defined(__FreeBSD__)) && defined(__64BIT__)
 	ld	OFFSET,  FRAMESLOT(0) + 0(FRAMEPOINTER)
 #endif
 

--- a/kernel/power/strmm_kernel_16x8_power8.S
+++ b/kernel/power/strmm_kernel_16x8_power8.S
@@ -96,7 +96,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define	N	r4
 #define	K	r5
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define A	r6
 #define	B	r7
@@ -271,7 +271,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	slwi	LDC, LDC, BASE_SHIFT
 
 #if defined(TRMMKERNEL)
-#if defined(linux) && defined(__64BIT__)
+#if (defined(linux) || defined(__FreeBSD__)) && defined(__64BIT__)
 	ld	OFFSET,  FRAMESLOT(0) + STACKSIZE(SP)
 #endif
 

--- a/kernel/power/swap.S
+++ b/kernel/power/swap.S
@@ -39,7 +39,7 @@
 #define ASSEMBLER
 #include "common.h"
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define N	r3
 #define X	r6

--- a/kernel/power/symv_L.S
+++ b/kernel/power/symv_L.S
@@ -39,7 +39,7 @@
 #define ASSEMBLER
 #include "common.h"
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define M	r3
 #define N	r4
@@ -248,7 +248,7 @@
 	stw	r27,   196(SP)
 #endif
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 	lwz	BUFFER,  FRAMESLOT(0) + STACKSIZE(SP)
 #else

--- a/kernel/power/symv_U.S
+++ b/kernel/power/symv_U.S
@@ -39,7 +39,7 @@
 #define ASSEMBLER
 #include "common.h"
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define M	r3
 #define IS	r4
@@ -247,7 +247,7 @@
 	stw	r27,   196(SP)
 #endif
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 	lwz	BUFFER,  FRAMESLOT(0) + STACKSIZE(SP)
 #else

--- a/kernel/power/trsm_kernel_LN.S
+++ b/kernel/power/trsm_kernel_LN.S
@@ -59,7 +59,7 @@
 #define	N	r4
 #define	K	r5
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define A	r6
 #define	B	r7
@@ -180,7 +180,7 @@
 
 	slwi	LDC, LDC, BASE_SHIFT
 
-#if defined(linux) && defined(__64BIT__)
+#if (defined(linux) || defined(__FreeBSD__)) && defined(__64BIT__)
 	ld	OFFSET,  FRAMESLOT(0) + STACKSIZE(SP)
 #endif
 
@@ -236,7 +236,7 @@
 
 #else
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 	mr	PREA,  r10
 	lwz	PREB,  FRAMESLOT(0) + STACKSIZE(SP)

--- a/kernel/power/trsm_kernel_LT.S
+++ b/kernel/power/trsm_kernel_LT.S
@@ -59,7 +59,7 @@
 #define	N	r4
 #define	K	r5
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define A	r6
 #define	B	r7
@@ -180,7 +180,7 @@
 
 	slwi	LDC, LDC, BASE_SHIFT
 
-#if defined(linux) && defined(__64BIT__)
+#if (defined(linux) || defined(__FreeBSD__)) && defined(__64BIT__)
 	ld	OFFSET,  FRAMESLOT(0) + STACKSIZE(SP)
 #endif
 
@@ -257,7 +257,7 @@
 
 #else
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 	mr	PREA,  r10
 	lwz	PREB,  FRAMESLOT(0) + STACKSIZE(SP)

--- a/kernel/power/trsm_kernel_RT.S
+++ b/kernel/power/trsm_kernel_RT.S
@@ -59,7 +59,7 @@
 #define	N	r4
 #define	K	r5
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define A	r6
 #define	B	r7
@@ -180,7 +180,7 @@
 
 	slwi	LDC, LDC, BASE_SHIFT
 
-#if defined(linux) && defined(__64BIT__)
+#if (defined(linux) || defined(__FreeBSD__)) && defined(__64BIT__)
 	ld	OFFSET,  FRAMESLOT(0) + STACKSIZE(SP)
 #endif
 
@@ -254,7 +254,7 @@
 
 #else
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 	mr	PREA,  r10
 	lwz	PREB,  FRAMESLOT(0) + STACKSIZE(SP)

--- a/kernel/power/trsm_kernel_cell_LN.S
+++ b/kernel/power/trsm_kernel_cell_LN.S
@@ -59,7 +59,7 @@
 #define	N	r4
 #define	K	r5
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define A	r6
 #define	B	r7
@@ -180,7 +180,7 @@
 
 	slwi	LDC, LDC, BASE_SHIFT
 
-#if defined(linux) && defined(__64BIT__)
+#if (defined(linux) || defined(__FreeBSD__)) && defined(__64BIT__)
 	ld	OFFSET,  FRAMESLOT(0) + STACKSIZE(SP)
 #endif
 
@@ -231,7 +231,7 @@
 	li	PREC,  -4 * SIZE
 #else
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 	mr	PREA,  r10
 	lwz	PREB,  FRAMESLOT(0) + STACKSIZE(SP)

--- a/kernel/power/trsm_kernel_cell_LT.S
+++ b/kernel/power/trsm_kernel_cell_LT.S
@@ -59,7 +59,7 @@
 #define	N	r4
 #define	K	r5
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define A	r6
 #define	B	r7
@@ -180,7 +180,7 @@
 
 	slwi	LDC, LDC, BASE_SHIFT
 
-#if defined(linux) && defined(__64BIT__)
+#if (defined(linux) || defined(__FreeBSD__)) && defined(__64BIT__)
 	ld	OFFSET,  FRAMESLOT(0) + STACKSIZE(SP)
 #endif
 
@@ -257,7 +257,7 @@
 
 #else
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 	mr	PREA,  r10
 	lwz	PREB,  FRAMESLOT(0) + STACKSIZE(SP)

--- a/kernel/power/trsm_kernel_cell_RT.S
+++ b/kernel/power/trsm_kernel_cell_RT.S
@@ -59,7 +59,7 @@
 #define	N	r4
 #define	K	r5
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define A	r6
 #define	B	r7
@@ -180,7 +180,7 @@
 
 	slwi	LDC, LDC, BASE_SHIFT
 
-#if defined(linux) && defined(__64BIT__)
+#if (defined(linux) || defined(__FreeBSD__)) && defined(__64BIT__)
 	ld	OFFSET,  FRAMESLOT(0) + STACKSIZE(SP)
 #endif
 
@@ -231,7 +231,7 @@
 	li	PREC,  -4 * SIZE
 #else
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 	mr	PREA,  r10
 	lwz	PREB,  FRAMESLOT(0) + STACKSIZE(SP)

--- a/kernel/power/trsm_kernel_hummer_LN.S
+++ b/kernel/power/trsm_kernel_hummer_LN.S
@@ -46,7 +46,7 @@
 #define	N	r4
 #define	K	r5
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #define A	r6
 #define	B	r7
 #define	C	r8

--- a/kernel/power/trsm_kernel_hummer_LT.S
+++ b/kernel/power/trsm_kernel_hummer_LT.S
@@ -46,7 +46,7 @@
 #define	N	r4
 #define	K	r5
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #define A	r6
 #define	B	r7
 #define	C	r8

--- a/kernel/power/trsm_kernel_hummer_RT.S
+++ b/kernel/power/trsm_kernel_hummer_RT.S
@@ -46,7 +46,7 @@
 #define	N	r4
 #define	K	r5
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #define A	r6
 #define	B	r7
 #define	C	r8

--- a/kernel/power/trsm_kernel_power6_LN.S
+++ b/kernel/power/trsm_kernel_power6_LN.S
@@ -59,7 +59,7 @@
 #define	N	r4
 #define	K	r5
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define A	r6
 #define	B	r7
@@ -179,7 +179,7 @@
 
 	slwi	LDC, LDC, BASE_SHIFT
 
-#if defined(linux) && defined(__64BIT__)
+#if (defined(linux) || defined(__FreeBSD__)) && defined(__64BIT__)
 	ld	OFFSET,  FRAMESLOT(0) + STACKSIZE(SP)
 #endif
 

--- a/kernel/power/trsm_kernel_power6_LT.S
+++ b/kernel/power/trsm_kernel_power6_LT.S
@@ -59,7 +59,7 @@
 #define	N	r4
 #define	K	r5
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define A	r6
 #define	B	r7
@@ -180,7 +180,7 @@
 
 	slwi	LDC, LDC, BASE_SHIFT
 
-#if defined(linux) && defined(__64BIT__)
+#if (defined(linux) || defined(__FreeBSD__)) && defined(__64BIT__)
 	ld	OFFSET,  FRAMESLOT(0) + STACKSIZE(SP)
 #endif
 

--- a/kernel/power/trsm_kernel_power6_RT.S
+++ b/kernel/power/trsm_kernel_power6_RT.S
@@ -59,7 +59,7 @@
 #define	N	r4
 #define	K	r5
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define A	r6
 #define	B	r7
@@ -179,7 +179,7 @@
 
 	slwi	LDC, LDC, BASE_SHIFT
 
-#if defined(linux) && defined(__64BIT__)
+#if (defined(linux) || defined(__FreeBSD__)) && defined(__64BIT__)
 	ld	OFFSET,  FRAMESLOT(0) + STACKSIZE(SP)
 #endif
 

--- a/kernel/power/trsm_kernel_ppc440_LN.S
+++ b/kernel/power/trsm_kernel_ppc440_LN.S
@@ -59,7 +59,7 @@
 #define	N	r4
 #define	K	r5
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define A	r6
 #define	B	r7
@@ -191,7 +191,7 @@
 
 	slwi	LDC, LDC, BASE_SHIFT
 
-#if defined(linux) && defined(__64BIT__)
+#if (defined(linux) || defined(__FreeBSD__)) && defined(__64BIT__)
 	ld	OFFSET,  FRAMESLOT(0) + STACKSIZE(SP)
 #endif
 

--- a/kernel/power/trsm_kernel_ppc440_LT.S
+++ b/kernel/power/trsm_kernel_ppc440_LT.S
@@ -59,7 +59,7 @@
 #define	N	r4
 #define	K	r5
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define A	r6
 #define	B	r7
@@ -176,7 +176,7 @@
 
 	slwi	LDC, LDC, BASE_SHIFT
 
-#if defined(linux) && defined(__64BIT__)
+#if (defined(linux) || defined(__FreeBSD__)) && defined(__64BIT__)
 	ld	OFFSET,  FRAMESLOT(0) + STACKSIZE(SP)
 #endif
 

--- a/kernel/power/trsm_kernel_ppc440_RT.S
+++ b/kernel/power/trsm_kernel_ppc440_RT.S
@@ -59,7 +59,7 @@
 #define	N	r4
 #define	K	r5
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define A	r6
 #define	B	r7
@@ -191,7 +191,7 @@
 
 	slwi	LDC, LDC, BASE_SHIFT
 
-#if defined(linux) && defined(__64BIT__)
+#if (defined(linux) || defined(__FreeBSD__)) && defined(__64BIT__)
 	ld	OFFSET,  FRAMESLOT(0) + STACKSIZE(SP)
 #endif
 

--- a/kernel/power/zaxpy.S
+++ b/kernel/power/zaxpy.S
@@ -39,7 +39,7 @@
 #define ASSEMBLER
 #include "common.h"
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define N	r3
 #define X	r6
@@ -123,7 +123,7 @@
 	stfd	f24,   80(SP)
 	stfd	f25,   88(SP)
 
-#if defined(linux) && defined(__64BIT__)
+#if (defined(linux) || defined(__FreeBSD__)) && defined(__64BIT__)
         ld	INCY, FRAMESLOT(0) + STACKSIZE(SP)
 #endif
 

--- a/kernel/power/zaxpy_ppc440.S
+++ b/kernel/power/zaxpy_ppc440.S
@@ -39,7 +39,7 @@
 #define ASSEMBLER
 #include "common.h"
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define N	r3
 #define X	r6
@@ -112,7 +112,7 @@
 	stfd	f24,   80(SP)
 	stfd	f25,   88(SP)
 
-#if defined(linux) && defined(__64BIT__)
+#if (defined(linux) || defined(__FreeBSD__)) && defined(__64BIT__)
         ld	INCY, FRAMESLOT(0) + STACKSIZE(SP)
 #endif
 

--- a/kernel/power/zgemm_beta.S
+++ b/kernel/power/zgemm_beta.S
@@ -62,7 +62,7 @@
 	stfd	f31,    8(SP)
 	stw	r0,    16(SP)
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 	lwz	LDC,    FRAMESLOT(0) + STACKSIZE(SP)
 #else

--- a/kernel/power/zgemm_kernel.S
+++ b/kernel/power/zgemm_kernel.S
@@ -61,7 +61,7 @@
 #define	N	r4
 #define	K	r5
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define A	r6
 #define	B	r7
@@ -169,7 +169,7 @@
 	stfd	f2,  ALPHA_I
 	stw	r0,  FZERO
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifdef __64BIT__
 	ld	LDC, FRAMESLOT(0) + STACKSIZE(SP)
 #endif
@@ -190,7 +190,7 @@
 #endif
 
 #ifdef TRMMKERNEL
-#if defined(linux) && defined(__64BIT__)
+#if (defined(linux) || defined(__FreeBSD__)) && defined(__64BIT__)
 	ld	OFFSET,  FRAMESLOT(1) + STACKSIZE(SP)
 #endif
 
@@ -231,7 +231,7 @@
 #endif
 #else
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 	lwz	PREA,  FRAMESLOT(2) + STACKSIZE(SP)
 	lwz	PREC,  FRAMESLOT(3) + STACKSIZE(SP)

--- a/kernel/power/zgemm_kernel_8x2_power8.S
+++ b/kernel/power/zgemm_kernel_8x2_power8.S
@@ -132,7 +132,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define	N	r4
 #define	K	r5
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define A	r6
 #define	B	r7
@@ -296,7 +296,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	stfd	f2,  ALPHA_I_SP
 	stw	r0,  FZERO
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifdef __64BIT__
 	ld	LDC, FRAMESLOT(0) + 0(FRAMEPOINTER)
 #endif
@@ -317,7 +317,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endif
 
 #ifdef TRMMKERNEL
-#if defined(linux) && defined(__64BIT__)
+#if (defined(linux) || defined(__FreeBSD__)) && defined(__64BIT__)
 	ld	OFFSET,  FRAMESLOT(1) + 0(FRAMEPOINTER)
 #endif
 

--- a/kernel/power/zgemm_kernel_altivec.S
+++ b/kernel/power/zgemm_kernel_altivec.S
@@ -62,7 +62,7 @@
 #define	N	r4
 #define	K	r5
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define A	r6
 #define	B	r7
@@ -238,7 +238,7 @@
 #endif
 
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifdef __64BIT__
 	ld	LDC,   FRAMESLOT(0) + STACKSIZE(SP)
 #endif
@@ -264,7 +264,7 @@
 #endif
 #else
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 	lwz	PREB,  FRAMESLOT(2) + STACKSIZE(SP)
 	lwz	PREC,  FRAMESLOT(3) + STACKSIZE(SP)

--- a/kernel/power/zgemm_kernel_altivec_cell.S
+++ b/kernel/power/zgemm_kernel_altivec_cell.S
@@ -62,7 +62,7 @@
 #define	N	r4
 #define	K	r5
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define A	r6
 #define	B	r7
@@ -244,7 +244,7 @@
 #endif
 
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifdef __64BIT__
 	ld	LDC,    FRAMESLOT(0) + STACKSIZE(SP)
 #endif
@@ -270,7 +270,7 @@
 #endif
 #else
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 	lwz	PREB,  FRAMESLOT(2) + STACKSIZE(SP)
 	lwz	PREC,  FRAMESLOT(3) + STACKSIZE(SP)

--- a/kernel/power/zgemm_kernel_altivec_g4.S
+++ b/kernel/power/zgemm_kernel_altivec_g4.S
@@ -62,7 +62,7 @@
 #define	N	r4
 #define	K	r5
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define A	r6
 #define	B	r7
@@ -238,7 +238,7 @@
 #endif
 
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifdef __64BIT__
 	ld	LDC,  FRAMESLOT(0) + STACKSIZE(SP)
 #endif

--- a/kernel/power/zgemm_kernel_cell.S
+++ b/kernel/power/zgemm_kernel_cell.S
@@ -61,7 +61,7 @@
 #define	N	r4
 #define	K	r5
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define A	r6
 #define	B	r7
@@ -175,7 +175,7 @@
 	stfd	f2,  ALPHA_I
 	stw	r0,  FZERO
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifdef __64BIT__
 	ld	LDC, FRAMESLOT(0) + STACKSIZE(SP)
 #endif
@@ -196,7 +196,7 @@
 #endif
 
 #ifdef TRMMKERNEL
-#if defined(linux) && defined(__64BIT__)
+#if (defined(linux) || defined(__FreeBSD__)) && defined(__64BIT__)
 	ld	OFFSET,  FRAMESLOT(1) + STACKSIZE(SP)
 #endif
 
@@ -230,7 +230,7 @@
 	li	PREA,   16 * 12 * SIZE
 #else
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 	lwz	PREA,  FRAMESLOT(2) + STACKSIZE(SP)
 	lwz	PREC,  FRAMESLOT(3) + STACKSIZE(SP)

--- a/kernel/power/zgemm_kernel_g4.S
+++ b/kernel/power/zgemm_kernel_g4.S
@@ -61,7 +61,7 @@
 #define	N	r4
 #define	K	r5
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define A	r6
 #define	B	r7
@@ -185,7 +185,7 @@
 	stfd	f2,  ALPHA_I
 	stw	r0,  FZERO
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifdef __64BIT__
 	ld	LDC, FRAMESLOT(0) + STACKSIZE(SP)
 #endif
@@ -206,7 +206,7 @@
 #endif
 
 #ifdef TRMMKERNEL
-#if defined(linux) && defined(__64BIT__)
+#if (defined(linux) || defined(__FreeBSD__)) && defined(__64BIT__)
 	ld	OFFSET,  FRAMESLOT(1) + STACKSIZE(SP)
 #endif
 

--- a/kernel/power/zgemm_kernel_hummer.S
+++ b/kernel/power/zgemm_kernel_hummer.S
@@ -48,7 +48,7 @@
 #define	N	r4
 #define	K	r5
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #define A	r6
 #define	B	r7
 #define	C	r8

--- a/kernel/power/zgemm_kernel_power3.S
+++ b/kernel/power/zgemm_kernel_power3.S
@@ -61,7 +61,7 @@
 #define	N	r4
 #define	K	r5
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define A	r6
 #define	B	r7
@@ -161,7 +161,7 @@
 	stfd	f2,  ALPHA_I
 	stw	r0,  FZERO
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifdef __64BIT__
 	ld	LDC, FRAMESLOT(0) + STACKSIZE(SP)
 #endif
@@ -202,7 +202,7 @@
 #endif
 #else
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 	lwz	PREA,  FRAMESLOT(2) + STACKSIZE(SP)
 	lwz	PREC,  FRAMESLOT(3) + STACKSIZE(SP)

--- a/kernel/power/zgemm_kernel_power6.S
+++ b/kernel/power/zgemm_kernel_power6.S
@@ -61,7 +61,7 @@
 #define	N	r4
 #define	K	r5
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define A	r6
 #define	B	r7
@@ -199,7 +199,7 @@
 	stfd	f2,  ALPHA_I
 	stw	r0,  FZERO
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifdef __64BIT__
 	ld	LDC, FRAMESLOT(0) + STACKSIZE(SP)
 #endif
@@ -220,7 +220,7 @@
 #endif
 
 #ifdef TRMMKERNEL
-#if defined(linux) && defined(__64BIT__)
+#if (defined(linux) || defined(__FreeBSD__)) && defined(__64BIT__)
 	ld	OFFSET,  FRAMESLOT(1) + STACKSIZE(SP)
 #endif
 

--- a/kernel/power/zgemm_kernel_power9.S
+++ b/kernel/power/zgemm_kernel_power9.S
@@ -147,13 +147,13 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     std    r0, FLINK_SAVE(SP)
  
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 	ld	LDC, FRAMESLOT(0) + 0(FRAMEPOINTER)
 #endif
 
 
 #ifdef TRMMKERNEL
-#if defined(linux) && defined(__64BIT__)
+#if (defined(linux) || defined(__FreeBSD__)) && defined(__64BIT__)
 	ld	OFFSET,  FRAMESLOT(1) + 0(FRAMEPOINTER)
 #endif 
 #endif

--- a/kernel/power/zgemm_kernel_ppc440.S
+++ b/kernel/power/zgemm_kernel_ppc440.S
@@ -61,7 +61,7 @@
 #define	N	r4
 #define	K	r5
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define A	r6
 #define	B	r7
@@ -182,7 +182,7 @@
 	stfd	f2,  ALPHA_I
 	stw	r0,  FZERO
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifdef __64BIT__
 	ld	LDC, FRAMESLOT(0) + STACKSIZE(SP)
 #endif
@@ -203,7 +203,7 @@
 #endif
 
 #ifdef TRMMKERNEL
-#if defined(linux) && defined(__64BIT__)
+#if (defined(linux) || defined(__FreeBSD__)) && defined(__64BIT__)
 	ld	OFFSET,  FRAMESLOT(1) + STACKSIZE(SP)
 #endif
 

--- a/kernel/power/zgemv_n.S
+++ b/kernel/power/zgemv_n.S
@@ -39,7 +39,7 @@
 #define ASSEMBLER
 #include "common.h"
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define M	r3
 #define	N	r4
@@ -250,7 +250,7 @@
 	stw	r22,   176(SP)
 #endif
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 	lwz	INCY,  FRAMESLOT(0) + STACKSIZE(SP)
 #else

--- a/kernel/power/zgemv_n_ppc440.S
+++ b/kernel/power/zgemv_n_ppc440.S
@@ -39,7 +39,7 @@
 #define ASSEMBLER
 #include "common.h"
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define M	r3
 #define	N	r4
@@ -223,7 +223,7 @@
 	stw	r22,   176(SP)
 #endif
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 	lwz	INCY,	 FRAMESLOT(0) + STACKSIZE(SP)
 	lwz	BUFFER,  FRAMESLOT(1) + STACKSIZE(SP)

--- a/kernel/power/zgemv_t.S
+++ b/kernel/power/zgemv_t.S
@@ -47,7 +47,7 @@
 #define STACKSIZE 304
 #endif
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define M	r3
 #define	N	r4
@@ -226,7 +226,7 @@
 	stw	r0,    4 + FZERO
 #endif
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 	lwz	INCY,	 FRAMESLOT(0) + STACKSIZE(SP)
 	lwz	BUFFER,  FRAMESLOT(1) + STACKSIZE(SP)

--- a/kernel/power/zgemv_t_ppc440.S
+++ b/kernel/power/zgemv_t_ppc440.S
@@ -47,7 +47,7 @@
 #define STACKSIZE 304
 #endif
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define M	r3
 #define	N	r4
@@ -179,7 +179,7 @@
 	stw	r0,    4 + FZERO
 #endif
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 	lwz	INCY,	 FRAMESLOT(0) + STACKSIZE(SP)
 	lwz	BUFFER,  FRAMESLOT(1) + STACKSIZE(SP)

--- a/kernel/power/zger.S
+++ b/kernel/power/zger.S
@@ -47,7 +47,7 @@
 #endif
 #endif
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define M	r3
 #define	N	r4
@@ -235,7 +235,7 @@
 	stw	r27,   196(SP)
 #endif
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 	lwz	LDA,     FRAMESLOT(0) + STACKSIZE(SP)
 	lwz	BUFFER,  FRAMESLOT(1) + STACKSIZE(SP)

--- a/kernel/power/zscal.S
+++ b/kernel/power/zscal.S
@@ -43,7 +43,7 @@
 #define XX	r4
 #define PREA	r5
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define X r6
 #define INCX r7

--- a/kernel/power/zscal_ppc440.S
+++ b/kernel/power/zscal_ppc440.S
@@ -43,7 +43,7 @@
 #define XX	r4
 #define PRE	r5
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define X r6
 #define INCX r7

--- a/kernel/power/zswap.S
+++ b/kernel/power/zswap.S
@@ -39,7 +39,7 @@
 #define ASSEMBLER
 #include "common.h"
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define N	r3
 #define X	r6
@@ -117,7 +117,7 @@
 	stfd	f30,  128(SP)
 	stfd	f31,  136(SP)
 
-#if defined(linux) && defined(__64BIT__)
+#if (defined(linux) || defined(__FreeBSD__)) && defined(__64BIT__)
 	ld	INCY, FRAMESLOT(0) + STACKSIZE(SP)
 #endif
 

--- a/kernel/power/zsymv_L.S
+++ b/kernel/power/zsymv_L.S
@@ -39,7 +39,7 @@
 #define ASSEMBLER
 #include "common.h"
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define M	r3
 #define N	r4
@@ -259,7 +259,7 @@
 	stw	r27,   196(SP)
 #endif
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 	lwz	BUFFER,  FRAMESLOT(0) + STACKSIZE(SP)
 #else

--- a/kernel/power/zsymv_U.S
+++ b/kernel/power/zsymv_U.S
@@ -39,7 +39,7 @@
 #define ASSEMBLER
 #include "common.h"
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define M	r3
 #define IS	r4
@@ -256,7 +256,7 @@
 	stw	r27,   196(SP)
 #endif
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 	lwz	BUFFER,  FRAMESLOT(0) + STACKSIZE(SP)
 #else

--- a/kernel/power/ztrmm_kernel_8x2_power8.S
+++ b/kernel/power/ztrmm_kernel_8x2_power8.S
@@ -98,7 +98,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define	N	r4
 #define	K	r5
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define A	r6
 #define	B	r7
@@ -259,7 +259,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	stfd	f2,  ALPHA_I_SP
 	stw	r0,  FZERO
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifdef __64BIT__
 	ld	LDC, FRAMESLOT(0) + STACKSIZE(SP)
 #endif
@@ -280,7 +280,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endif
 
 #ifdef TRMMKERNEL
-#if defined(linux) && defined(__64BIT__)
+#if (defined(linux) || defined(__FreeBSD__)) && defined(__64BIT__)
 	ld	OFFSET,  FRAMESLOT(1) + STACKSIZE(SP)
 #endif
 

--- a/kernel/power/ztrsm_kernel_LN.S
+++ b/kernel/power/ztrsm_kernel_LN.S
@@ -61,7 +61,7 @@
 #define	N	r4
 #define	K	r5
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define A	r6
 #define	B	r7
@@ -166,7 +166,7 @@
 
 	stw	r0,  FZERO
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifdef __64BIT__
 	ld	LDC, FRAMESLOT(0) + STACKSIZE(SP)
 #endif
@@ -186,7 +186,7 @@
 #endif
 #endif
 
-#if defined(linux) && defined(__64BIT__)
+#if (defined(linux) || defined(__FreeBSD__)) && defined(__64BIT__)
 	ld	OFFSET,  FRAMESLOT(1) + STACKSIZE(SP)
 #endif
 
@@ -244,7 +244,7 @@
 #endif
 #else
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 	lwz	PREA,  FRAMESLOT(2) + STACKSIZE(SP)
 	lwz	PREC,  FRAMESLOT(3) + STACKSIZE(SP)

--- a/kernel/power/ztrsm_kernel_LT.S
+++ b/kernel/power/ztrsm_kernel_LT.S
@@ -61,7 +61,7 @@
 #define	N	r4
 #define	K	r5
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define A	r6
 #define	B	r7
@@ -166,7 +166,7 @@
 
 	stw	r0,  FZERO
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifdef __64BIT__
 	ld	LDC, FRAMESLOT(0) + STACKSIZE(SP)
 #endif
@@ -186,7 +186,7 @@
 #endif
 #endif
 
-#if defined(linux) && defined(__64BIT__)
+#if (defined(linux) || defined(__FreeBSD__)) && defined(__64BIT__)
 	ld	OFFSET,  FRAMESLOT(1) + STACKSIZE(SP)
 #endif
 
@@ -247,7 +247,7 @@
 #endif
 #else
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 	lwz	PREA,  FRAMESLOT(2) + STACKSIZE(SP)
 	lwz	PREC,  FRAMESLOT(3) + STACKSIZE(SP)

--- a/kernel/power/ztrsm_kernel_RT.S
+++ b/kernel/power/ztrsm_kernel_RT.S
@@ -61,7 +61,7 @@
 #define	N	r4
 #define	K	r5
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define A	r6
 #define	B	r7
@@ -166,7 +166,7 @@
 
 	stw	r0,  FZERO
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifdef __64BIT__
 	ld	LDC, FRAMESLOT(0) + STACKSIZE(SP)
 #endif
@@ -186,7 +186,7 @@
 #endif
 #endif
 
-#if defined(linux) && defined(__64BIT__)
+#if (defined(linux) || defined(__FreeBSD__)) && defined(__64BIT__)
 	ld	OFFSET,  FRAMESLOT(1) + STACKSIZE(SP)
 #endif
 
@@ -247,7 +247,7 @@
 #endif
 #else
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 	lwz	PREA,  FRAMESLOT(2) + STACKSIZE(SP)
 	lwz	PREC,  FRAMESLOT(3) + STACKSIZE(SP)

--- a/kernel/power/ztrsm_kernel_cell_LN.S
+++ b/kernel/power/ztrsm_kernel_cell_LN.S
@@ -61,7 +61,7 @@
 #define	N	r4
 #define	K	r5
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define A	r6
 #define	B	r7
@@ -172,7 +172,7 @@
 
 	stw	r0,  FZERO
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifdef __64BIT__
 	ld	LDC, FRAMESLOT(0) + STACKSIZE(SP)
 #endif
@@ -192,7 +192,7 @@
 #endif
 #endif
 
-#if defined(linux) && defined(__64BIT__)
+#if (defined(linux) || defined(__FreeBSD__)) && defined(__64BIT__)
 	ld	OFFSET,  FRAMESLOT(1) + STACKSIZE(SP)
 #endif
 

--- a/kernel/power/ztrsm_kernel_cell_LT.S
+++ b/kernel/power/ztrsm_kernel_cell_LT.S
@@ -61,7 +61,7 @@
 #define	N	r4
 #define	K	r5
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define A	r6
 #define	B	r7
@@ -172,7 +172,7 @@
 
 	stw	r0,  FZERO
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifdef __64BIT__
 	ld	LDC, FRAMESLOT(0) + STACKSIZE(SP)
 #endif
@@ -192,7 +192,7 @@
 #endif
 #endif
 
-#if defined(linux) && defined(__64BIT__)
+#if (defined(linux) || defined(__FreeBSD__)) && defined(__64BIT__)
 	ld	OFFSET,  FRAMESLOT(1) + STACKSIZE(SP)
 #endif
 
@@ -246,7 +246,7 @@
 	li	PREA,   16 * 12 * SIZE
 #else
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 	lwz	PREA,  FRAMESLOT(2) + STACKSIZE(SP)
 	lwz	PREC,  FRAMESLOT(3) + STACKSIZE(SP)

--- a/kernel/power/ztrsm_kernel_cell_RT.S
+++ b/kernel/power/ztrsm_kernel_cell_RT.S
@@ -61,7 +61,7 @@
 #define	N	r4
 #define	K	r5
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define A	r6
 #define	B	r7
@@ -172,7 +172,7 @@
 
 	stw	r0,  FZERO
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifdef __64BIT__
 	ld	LDC, FRAMESLOT(0) + STACKSIZE(SP)
 #endif
@@ -192,7 +192,7 @@
 #endif
 #endif
 
-#if defined(linux) && defined(__64BIT__)
+#if (defined(linux) || defined(__FreeBSD__)) && defined(__64BIT__)
 	ld	OFFSET,  FRAMESLOT(1) + STACKSIZE(SP)
 #endif
 

--- a/kernel/power/ztrsm_kernel_hummer_LN.S
+++ b/kernel/power/ztrsm_kernel_hummer_LN.S
@@ -48,7 +48,7 @@
 #define	N	r4
 #define	K	r5
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #define A	r6
 #define	B	r7
 #define	C	r8

--- a/kernel/power/ztrsm_kernel_hummer_LT.S
+++ b/kernel/power/ztrsm_kernel_hummer_LT.S
@@ -48,7 +48,7 @@
 #define	N	r4
 #define	K	r5
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #define A	r6
 #define	B	r7
 #define	C	r8

--- a/kernel/power/ztrsm_kernel_hummer_RT.S
+++ b/kernel/power/ztrsm_kernel_hummer_RT.S
@@ -48,7 +48,7 @@
 #define	N	r4
 #define	K	r5
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #define A	r6
 #define	B	r7
 #define	C	r8

--- a/kernel/power/ztrsm_kernel_power6_LN.S
+++ b/kernel/power/ztrsm_kernel_power6_LN.S
@@ -57,7 +57,7 @@
 #define	N	r4
 #define	K	r5
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define A	r6
 #define	B	r7
@@ -184,7 +184,7 @@
 
 	stw	r0,  FZERO
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifdef __64BIT__
 	ld	LDC, FRAMESLOT(0) + STACKSIZE(SP)
 #endif
@@ -204,7 +204,7 @@
 #endif
 #endif
 
-#if defined(linux) && defined(__64BIT__)
+#if (defined(linux) || defined(__FreeBSD__)) && defined(__64BIT__)
 	ld	OFFSET,  FRAMESLOT(1) + STACKSIZE(SP)
 #endif
 

--- a/kernel/power/ztrsm_kernel_power6_LT.S
+++ b/kernel/power/ztrsm_kernel_power6_LT.S
@@ -57,7 +57,7 @@
 #define	N	r4
 #define	K	r5
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define A	r6
 #define	B	r7
@@ -184,7 +184,7 @@
 
 	stw	r0,  FZERO
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifdef __64BIT__
 	ld	LDC, FRAMESLOT(0) + STACKSIZE(SP)
 #endif
@@ -204,7 +204,7 @@
 #endif
 #endif
 
-#if defined(linux) && defined(__64BIT__)
+#if (defined(linux) || defined(__FreeBSD__)) && defined(__64BIT__)
 	ld	OFFSET,  FRAMESLOT(1) + STACKSIZE(SP)
 #endif
 

--- a/kernel/power/ztrsm_kernel_power6_RT.S
+++ b/kernel/power/ztrsm_kernel_power6_RT.S
@@ -57,7 +57,7 @@
 #define	N	r4
 #define	K	r5
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define A	r6
 #define	B	r7
@@ -184,7 +184,7 @@
 
 	stw	r0,  FZERO
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifdef __64BIT__
 	ld	LDC, FRAMESLOT(0) + STACKSIZE(SP)
 #endif
@@ -204,7 +204,7 @@
 #endif
 #endif
 
-#if defined(linux) && defined(__64BIT__)
+#if (defined(linux) || defined(__FreeBSD__)) && defined(__64BIT__)
 	ld	OFFSET,  FRAMESLOT(1) + STACKSIZE(SP)
 #endif
 

--- a/kernel/power/ztrsm_kernel_ppc440_LN.S
+++ b/kernel/power/ztrsm_kernel_ppc440_LN.S
@@ -61,7 +61,7 @@
 #define	N	r4
 #define	K	r5
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define A	r6
 #define	B	r7
@@ -177,7 +177,7 @@
 
 	stw	r0,  FZERO
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifdef __64BIT__
 	ld	LDC, FRAMESLOT(0) + STACKSIZE(SP)
 #endif
@@ -197,7 +197,7 @@
 #endif
 #endif
 
-#if defined(linux) && defined(__64BIT__)
+#if (defined(linux) || defined(__FreeBSD__)) && defined(__64BIT__)
 	ld	OFFSET,  FRAMESLOT(1) + STACKSIZE(SP)
 #endif
 

--- a/kernel/power/ztrsm_kernel_ppc440_LT.S
+++ b/kernel/power/ztrsm_kernel_ppc440_LT.S
@@ -61,7 +61,7 @@
 #define	N	r4
 #define	K	r5
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define A	r6
 #define	B	r7
@@ -177,7 +177,7 @@
 
 	stw	r0,  FZERO
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifdef __64BIT__
 	ld	LDC, FRAMESLOT(0) + STACKSIZE(SP)
 #endif
@@ -197,7 +197,7 @@
 #endif
 #endif
 
-#if defined(linux) && defined(__64BIT__)
+#if (defined(linux) || defined(__FreeBSD__)) && defined(__64BIT__)
 	ld	OFFSET,  FRAMESLOT(1) + STACKSIZE(SP)
 #endif
 

--- a/kernel/power/ztrsm_kernel_ppc440_RT.S
+++ b/kernel/power/ztrsm_kernel_ppc440_RT.S
@@ -61,7 +61,7 @@
 #define	N	r4
 #define	K	r5
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifndef __64BIT__
 #define A	r6
 #define	B	r7
@@ -177,7 +177,7 @@
 
 	stw	r0,  FZERO
 
-#ifdef linux
+#if defined(linux) || defined(__FreeBSD__)
 #ifdef __64BIT__
 	ld	LDC, FRAMESLOT(0) + STACKSIZE(SP)
 #endif
@@ -197,7 +197,7 @@
 #endif
 #endif
 
-#if defined(linux) && defined(__64BIT__)
+#if (defined(linux) || defined(__FreeBSD__)) && defined(__64BIT__)
 	ld	OFFSET,  FRAMESLOT(1) + STACKSIZE(SP)
 #endif
 


### PR DESCRIPTION
Building on FreeBSD/powerpc64 requires the same macros as Linux/ppc64.