### PR TITLE
Fix surprising behaviour of NO_AFFINITY=0

### DIFF
--- a/Makefile.system
+++ b/Makefile.system
@@ -1124,7 +1124,11 @@ endif
 endif
 
 ifdef NO_AFFINITY
+ifeq ($(NO_AFFINITY), 0)
+override undefine NO_AFFINITY
+else
 CCOMMON_OPT	+= -DNO_AFFINITY
+endif
 endif
 
 ifdef FUNCTION_PROFILE


### PR DESCRIPTION
(as noticed in https://github.com/xianyi/OpenBLAS/issues/2173#issuecomment-508562358)