### PR TITLE
MAINT: remove legacy CMake endif()

### DIFF
--- a/cmake/system_check.cmake
+++ b/cmake/system_check.cmake
@@ -15,7 +15,7 @@ if (${HOST_OS} STREQUAL "LINUX")
     EXECUTE_PROCESS( COMMAND uname -o COMMAND tr -d '\n' OUTPUT_VARIABLE OPERATING_SYSTEM)
       if(${OPERATING_SYSTEM} MATCHES "Android")
         set(HOST_OS ANDROID)
-      endif(${OPERATING_SYSTEM} MATCHES "Android")
+      endif()
 endif()
 
 


### PR DESCRIPTION
* clean up a case where CMake endif()
contained the conditional used in the
if(), which is no longer needed /
discouraged since our minimum required
CMake version supports the modern syntax

Ok, so pretty small PR :)