### PR TITLE
Override special make variables

### DIFF
--- a/ctest/Makefile
+++ b/ctest/Makefile
@@ -6,6 +6,8 @@ TOPDIR = ..
 include $(TOPDIR)/Makefile.system
 
 override CFLAGS += -DADD$(BU) -DCBLAS
+override TARGET_ARCH=
+override TARGET_MACH=
 
 LIB = $(TOPDIR)/$(LIBNAME)
 

--- a/utest/Makefile
+++ b/utest/Makefile
@@ -1,6 +1,9 @@
 UTEST_CHECK = 1
 TOPDIR	= ..
 
+override TARGET_ARCH=
+override TARGET_MACH=
+
 UTESTBIN=openblas_utest
 
 .PHONY : all


### PR DESCRIPTION
as seen in https://github.com/xianyi/OpenBLAS/issues/1912#issuecomment-514183900 , any external setting of TARGET_ARCH (which could result from building OpenBLAS as part of a larger project that actually uses this variable) would cause the utest build to fail. 
(Other subtargets appear to be unaffected as they do not use implicit make rules)