### PR TITLE
Avoid spurious dependency on the fortran runtime despite NOFORTRAN=1

### DIFF
--- a/Makefile.system
+++ b/Makefile.system
@@ -267,9 +267,10 @@ OBJCOPY = $(CROSS_SUFFIX)objcopy
 OBJCONV = $(CROSS_SUFFIX)objconv
 
 
-# For detect fortran failed, only build BLAS.
+# When fortran support was either not detected or actively deselected, only build BLAS.
 ifeq ($(NOFORTRAN), 1)
 NO_LAPACK = 1
+override FEXTRALIB = 
 endif
 
 #


### PR DESCRIPTION
for cases where a fortran compiler is present but not wanted (e.g. not fully functional)