### PR TITLE
Remove case-sensitivity in x86 LSAME on (AMD) cpus without CMOV

### DIFF
--- a/kernel/x86/lsame.S
+++ b/kernel/x86/lsame.S
@@ -56,13 +56,13 @@
 #ifndef HAVE_CMOV
 	movl	%eax, %ecx
 	subl	$32,  %ecx
-	jle	.L1
+	jl	.L1
 	movl	%ecx, %eax
 .L1:
 
 	movl	%edx, %ecx
 	subl	$32,  %ecx
-	jle	.L2
+	jl	.L2
 	movl	%ecx, %edx
 .L2:
 	subl	%eax, %edx


### PR DESCRIPTION
Problem was already noticed some years ago in #238, but back then the problem was only corrected in one of the #ifdef branches.
Fixes #2214