### PR TITLE
[WIP] Fix compilation with recent PGI compiler

### DIFF
--- a/Makefile.system
+++ b/Makefile.system
@@ -142,9 +142,9 @@ endif
 endif
 
 
-# On x86_64 build getarch with march=native. This is required to detect AVX512 support in getarch.
+# On x86_64 build getarch with march=native unless the compiler is PGI. This is required to detect AVX512 support in getarch.
 ifeq ($(ARCH), x86_64)
-ifneq ($(C_COMPILER), PGI)
+ifeq ($(findstring pgcc,$(HOSTCC)),)
 GETARCH_FLAGS += -march=native
 endif
 endif
@@ -267,10 +267,9 @@ OBJCOPY = $(CROSS_SUFFIX)objcopy
 OBJCONV = $(CROSS_SUFFIX)objconv
 
 
-# When fortran support was either not detected or actively deselected, only build BLAS.
+# For detect fortran failed, only build BLAS.
 ifeq ($(NOFORTRAN), 1)
 NO_LAPACK = 1
-override FEXTRALIB = 
 endif
 
 #
@@ -697,9 +696,9 @@ endif
 
 ifeq ($(C_COMPILER), PGI)
 ifdef BINARY64
-CCOMMON_OPT += -tp p7-64
+CCOMMON_OPT += -m64 -Mnollvm
 else
-CCOMMON_OPT += -tp p7
+CCOMMON_OPT += -m32
 endif
 endif
 
@@ -1125,7 +1124,11 @@ endif
 endif
 
 ifdef NO_AFFINITY
+ifeq ($(NO_AFFINITY), 0)
+override undefine NO_AFFINITY
+else
 CCOMMON_OPT	+= -DNO_AFFINITY
+endif
 endif
 
 ifdef FUNCTION_PROFILE

--- a/cmake/system.cmake
+++ b/cmake/system.cmake
@@ -66,8 +66,15 @@ if (DEFINED TARGET)
 endif ()
 
 # On x86_64 build getarch with march=native. This is required to detect AVX512 support in getarch.
-if (X86_64)
+if (X86_64 AND NOT ${CMAKE_C_COMPILER_ID} STREQUAL "PGI")
   set(GETARCH_FLAGS "${GETARCH_FLAGS} -march=native")
+endif ()
+
+# On x86 no AVX support is available
+if (X86 OR X86_64)
+if ((DEFINED BINARY AND BINARY EQUAL 32) OR ("$CMAKE_SIZEOF_VOID_P}" EQUAL "4"))
+  set(GETARCH_FLAGS "${GETARCH_FLAGS} -DNO_AVX -DNO_AVX2 -DNO_AVX512")
+endif ()
 endif ()
 
 if (INTERFACE64)
@@ -148,7 +155,9 @@ else()
 endif ()
 
 include("${PROJECT_SOURCE_DIR}/cmake/prebuild.cmake")
-
+if (DEFINED BINARY)
+  message(STATUS "Compiling a ${BINARY}-bit binary.")
+endif ()
 if (NOT DEFINED NEED_PIC)
   set(NEED_PIC 1)
 endif ()
@@ -165,6 +174,9 @@ include("${PROJECT_SOURCE_DIR}/cmake/cc.cmake")
 if (NOT NOFORTRAN)
   # Fortran Compiler dependent settings
   include("${PROJECT_SOURCE_DIR}/cmake/fc.cmake")
+else ()
+set(NO_LAPACK 1)
+set(NO_LAPACKE 1)
 endif ()
 
 if (BINARY64)
@@ -190,9 +202,14 @@ if (NEED_PIC)
 endif ()
 
 if (DYNAMIC_ARCH)
-  set(CCOMMON_OPT "${CCOMMON_OPT} -DDYNAMIC_ARCH")
-  if (DYNAMIC_OLDER)
-    set(CCOMMON_OPT "${CCOMMON_OPT} -DDYNAMIC_OLDER")
+  if (X86 OR X86_64 OR ARM64 OR PPC)
+    set(CCOMMON_OPT "${CCOMMON_OPT} -DDYNAMIC_ARCH")
+    if (DYNAMIC_OLDER)
+      set(CCOMMON_OPT "${CCOMMON_OPT} -DDYNAMIC_OLDER")
+    endif ()
+  else ()
+    unset (DYNAMIC_ARCH)
+    message (STATUS "DYNAMIC_ARCH is not supported on the target architecture, removing")
   endif ()
 endif ()
 


### PR DESCRIPTION
for #2217 - my earlier "getarch" compile options fix from #2162 proved to be ineffective as the C_COMPILER variable is only set after getarch has been compiled and run. 
With these fixes, the "no llvm" variant of the compiler suite works but its supposedly newer llvm-based counterpart fails to process some inline assembly files.