### PR TITLE
fix error messages

### DIFF
--- a/interface/lapack/gesv.c
+++ b/interface/lapack/gesv.c
@@ -44,19 +44,19 @@
 
 #ifndef COMPLEX
 #ifdef XDOUBLE
-#define ERROR_NAME "QGESV  "
+#define ERROR_NAME "QGESV"
 #elif defined(DOUBLE)
-#define ERROR_NAME "DGESV  "
+#define ERROR_NAME "DGESV"
 #else
-#define ERROR_NAME "SGESV  "
+#define ERROR_NAME "SGESV"
 #endif
 #else
 #ifdef XDOUBLE
-#define ERROR_NAME "XGESV  "
+#define ERROR_NAME "XGESV"
 #elif defined(DOUBLE)
-#define ERROR_NAME "ZGESV  "
+#define ERROR_NAME "ZGESV"
 #else
-#define ERROR_NAME "CGESV  "
+#define ERROR_NAME "CGESV"
 #endif
 #endif
 
@@ -89,7 +89,7 @@ int NAME(blasint *N, blasint *NRHS, FLOAT *a, blasint *ldA, blasint *ipiv,
   if (args.m   < 0)             info = 1;
 
   if (info) {
-    BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME));
+    BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME) - 1);
     *Info = - info;
     return 0;
   }

--- a/interface/lapack/getf2.c
+++ b/interface/lapack/getf2.c
@@ -74,7 +74,7 @@ int NAME(blasint *M, blasint *N, FLOAT *a, blasint *ldA, blasint *ipiv, blasint 
   if (args.n   < 0)             info = 2;
   if (args.m   < 0)             info = 1;
   if (info) {
-    BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME));
+    BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME) - 1);
     *Info = - info;
     return 0;
   }

--- a/interface/lapack/getrf.c
+++ b/interface/lapack/getrf.c
@@ -74,7 +74,7 @@ int NAME(blasint *M, blasint *N, FLOAT *a, blasint *ldA, blasint *ipiv, blasint 
   if (args.n   < 0)             info = 2;
   if (args.m   < 0)             info = 1;
   if (info) {
-    BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME));
+    BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME) - 1);
     *Info = - info;
     return 0;
   }

--- a/interface/lapack/getrs.c
+++ b/interface/lapack/getrs.c
@@ -102,7 +102,7 @@ int NAME(char *TRANS, blasint *N, blasint *NRHS, FLOAT *a, blasint *ldA,
   if (trans     < 0) info = 1;
 
   if (info != 0) {
-    BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME));
+    BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME) - 1);
     return 0;
   }
 

--- a/interface/lapack/lauu2.c
+++ b/interface/lapack/lauu2.c
@@ -90,7 +90,7 @@ int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
   if (args.n   < 0)             info = 2;
   if (uplo     < 0)             info = 1;
   if (info) {
-    BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME));
+    BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME) - 1);
     *Info = - info;
     return 0;
   }

--- a/interface/lapack/lauum.c
+++ b/interface/lapack/lauum.c
@@ -90,7 +90,7 @@ int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
   if (args.n   < 0)             info = 2;
   if (uplo     < 0)             info = 1;
   if (info) {
-    BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME));
+    BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME) - 1);
     *Info = - info;
     return 0;
   }

--- a/interface/lapack/potf2.c
+++ b/interface/lapack/potf2.c
@@ -90,7 +90,7 @@ int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
   if (args.n   < 0)             info = 2;
   if (uplo     < 0)             info = 1;
   if (info) {
-    BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME));
+    BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME) - 1);
     *Info = - info;
     return 0;
   }

--- a/interface/lapack/potrf.c
+++ b/interface/lapack/potrf.c
@@ -90,7 +90,7 @@ int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
   if (args.n   < 0)             info = 2;
   if (uplo     < 0)             info = 1;
   if (info) {
-    BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME));
+    BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME) - 1);
     *Info = - info;
     return 0;
   }

--- a/interface/lapack/potri.c
+++ b/interface/lapack/potri.c
@@ -99,7 +99,7 @@ int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
   if (uplo < 0)                  info = 1;
 
   if (info) {
-    BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME));
+    BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME) - 1);
     *Info = - info;
     return 0;
   }

--- a/interface/lapack/trti2.c
+++ b/interface/lapack/trti2.c
@@ -96,7 +96,7 @@ int NAME(char *UPLO, char *DIAG, blasint *N, FLOAT *a, blasint *ldA, blasint *In
   if (diag < 0)                  info = 2;
   if (uplo < 0)                  info = 1;
   if (info) {
-    BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME));
+    BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME) - 1);
     *Info = - info;
     return 0;
   }

--- a/interface/lapack/trtri.c
+++ b/interface/lapack/trtri.c
@@ -99,7 +99,7 @@ int NAME(char *UPLO, char *DIAG, blasint *N, FLOAT *a, blasint *ldA, blasint *In
   if (diag < 0)                  info = 2;
   if (uplo < 0)                  info = 1;
   if (info) {
-    BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME));
+    BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME) - 1);
     *Info = - info;
     return 0;
   }

--- a/interface/lapack/zgetf2.c
+++ b/interface/lapack/zgetf2.c
@@ -74,7 +74,7 @@ int NAME(blasint *M, blasint *N, FLOAT *a, blasint *ldA, blasint *ipiv, blasint 
   if (args.n   < 0)             info = 2;
   if (args.m   < 0)             info = 1;
   if (info) {
-    BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME));
+    BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME) - 1);
     *Info = - info;
     return 0;
   }

--- a/interface/lapack/zgetrf.c
+++ b/interface/lapack/zgetrf.c
@@ -74,7 +74,7 @@ int NAME(blasint *M, blasint *N, FLOAT *a, blasint *ldA, blasint *ipiv, blasint 
   if (args.n   < 0)             info = 2;
   if (args.m   < 0)             info = 1;
   if (info) {
-    BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME));
+    BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME) - 1);
     *Info = - info;
     return 0;
   }

--- a/interface/lapack/zgetrs.c
+++ b/interface/lapack/zgetrs.c
@@ -102,7 +102,7 @@ int NAME(char *TRANS, blasint *N, blasint *NRHS, FLOAT *a, blasint *ldA,
   if (trans     < 0) info = 1;
 
   if (info != 0) {
-    BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME));
+    BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME) - 1);
     return 0;
   }
 

--- a/interface/lapack/zlauu2.c
+++ b/interface/lapack/zlauu2.c
@@ -91,7 +91,7 @@ int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
   if (args.n   < 0)             info = 2;
   if (uplo     < 0)             info = 1;
   if (info) {
-    BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME));
+    BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME) - 1);
     *Info = - info;
     return 0;
   }

--- a/interface/lapack/zpotf2.c
+++ b/interface/lapack/zpotf2.c
@@ -91,7 +91,7 @@ int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
   if (args.n   < 0)             info = 2;
   if (uplo     < 0)             info = 1;
   if (info) {
-    BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME));
+    BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME) - 1);
     *Info = - info;
     return 0;
   }

--- a/interface/lapack/zpotrf.c
+++ b/interface/lapack/zpotrf.c
@@ -90,7 +90,7 @@ int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
   if (args.n   < 0)             info = 2;
   if (uplo     < 0)             info = 1;
   if (info) {
-    BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME));
+    BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME) - 1);
     *Info = - info;
     return 0;
   }

--- a/interface/lapack/zpotri.c
+++ b/interface/lapack/zpotri.c
@@ -99,7 +99,7 @@ int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
   if (uplo < 0)                  info = 1;
 
   if (info) {
-    BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME));
+    BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME) - 1);
     *Info = - info;
     return 0;
   }

--- a/interface/lapack/ztrti2.c
+++ b/interface/lapack/ztrti2.c
@@ -96,7 +96,7 @@ int NAME(char *UPLO, char *DIAG, blasint *N, FLOAT *a, blasint *ldA, blasint *In
   if (diag < 0)                  info = 2;
   if (uplo < 0)                  info = 1;
   if (info) {
-    BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME));
+    BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME) - 1);
     *Info = - info;
     return 0;
   }

--- a/interface/lapack/ztrtri.c
+++ b/interface/lapack/ztrtri.c
@@ -96,7 +96,7 @@ int NAME(char *UPLO, char *DIAG, blasint *N, FLOAT *a, blasint *ldA, blasint *In
   if (diag < 0)                  info = 2;
   if (uplo < 0)                  info = 1;
   if (info) {
-    BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME));
+    BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME) - 1);
     *Info = - info;
     return 0;
   }


### PR DESCRIPTION
I noticed that the error messages in the reimplemented lapack funcions are null terminated. For instance, if you run make lapack-test, you'll see a lot of lines similar to this:
 *** XERBLA was called with SRNAME = SGETRF^@ instead      of    SGETRF ***
sizeof("SGETRF") is 1 + strlen("SGETRF"), so  the fix is to remove 1.