### PR TITLE
Avoid taking root of negative number in symv_thread.c

### DIFF
--- a/driver/level2/symv_thread.c
+++ b/driver/level2/symv_thread.c
@@ -166,7 +166,11 @@ int CNAME(BLASLONG m, FLOAT *alpha, FLOAT *a, BLASLONG lda, FLOAT *x, BLASLONG i
     if (nthreads - num_cpu > 1) {
 
       double di = (double)i;
-      width = ((BLASLONG)(sqrt(di * di + dnum) - di) + mask) & ~mask;
+      if (di * di - dnum > 0) {
+        width = ((BLASLONG)(-sqrt(di * di - dnum) + di) + mask) & ~mask;
+      } else {
+        width = m - i;
+      }
 
       if (width < 4) width = 4;
       if (width > m - i) width = m - i;
@@ -212,9 +216,9 @@ int CNAME(BLASLONG m, FLOAT *alpha, FLOAT *a, BLASLONG lda, FLOAT *x, BLASLONG i
 
       double di = (double)(m - i);
       if (di * di - dnum > 0) {
-	width = ((BLASLONG)(-sqrt(di * di - dnum) + di) + mask) & ~mask;
+        width = ((BLASLONG)(-sqrt(di * di - dnum) + di) + mask) & ~mask;
       } else {
-	width = m - i;
+        width = m - i;
       }
 
       if (width < 4) width = 4;


### PR DESCRIPTION
This is similar to fixes in gh-1929, but there was one remaining
occurance of this type of pattern in the driver/level2/*_thread.c
files.

---

We see a heisenbug with an incorrect warning on windows in NumPy. This would be pretty random if it fixes it (I am not even 100% sure the test uses OpenBLAS), but I noticed that there the pattern was still missing an `if` in this one case.