### PR TITLE
Fix various source comment typos

### DIFF
--- a/driver/others/init.c
+++ b/driver/others/init.c
@@ -563,7 +563,7 @@ static void disable_affinity(void) {
 #endif
 
   /* if(common->final_num_procs > 64){ */
-  /*   fprintf(stderr, "\nOpenBLAS Warining : The number of CPU/Cores(%d) is beyond the limit(64). Terminated.\n", common->final_num_procs); */
+  /*   fprintf(stderr, "\nOpenBLAS Warning : The number of CPU/Cores(%d) is beyond the limit(64). Terminated.\n", common->final_num_procs); */
   /*   exit(1); */
   /* }else if(common->final_num_procs == 64){ */
   /*   lprocmask = 0xFFFFFFFFFFFFFFFFUL; */

--- a/kernel/mips64/trsm_kernel_RN_loongson3a.S
+++ b/kernel/mips64/trsm_kernel_RN_loongson3a.S
@@ -188,7 +188,7 @@
 	MADD	t14, t14, a1, b4
 	MADD	t24, t24, a2, b4
 	MADD	t34, t34, a3, b4
-	MADD	t44, t44, a4, b4			#	fisrt
+	MADD	t44, t44, a4, b4			#	first
 
 	LD	a1,  8 * SIZE(AO)
 	LD	a2,  9 * SIZE(AO)
@@ -281,7 +281,7 @@
 	MADD	t14, t14, a5, b8
 	MADD	t24, t24, a6, b8
 	MADD	t34, t34, a7, b8
-	MADD	t44, t44, a8, b8			#	fouth
+	MADD	t44, t44, a8, b8			#	fourth
 
 	daddiu	L, L, -1
 	bgtz	L, .L12

--- a/kernel/mips64/trsm_kernel_RT_loongson3a.S
+++ b/kernel/mips64/trsm_kernel_RT_loongson3a.S
@@ -107,10 +107,10 @@
 
 	dsll	TEMP, TEMP, BASE_SHIFT			#	B Representative triangle matrix!!!
 	daddu	B, B, TEMP						#	B point to the end of sb
-											#	Be carefull B has no effeck of mc!!
+											#	Be careful B has no effect of mc!!
 	mult	N, LDC
 	mflo	TEMP
-	daddu	C, C, TEMP						#	C point to the last colum of blockB
+	daddu	C, C, TEMP						#	C point to the last column of blockB
 
 	dsubu	KK, K, OFFSET					#	KC-KK is the length of rectangular data part of Bj
 
@@ -1164,7 +1164,7 @@
 	MADD	t14, t14, a1, b4
 	MADD	t24, t24, a2, b4
 	MADD	t34, t34, a3, b4
-	MADD	t44, t44, a4, b4			#	fisrt
+	MADD	t44, t44, a4, b4			#	first
 
 	LD	a1,  8 * SIZE(AO)
 	LD	a2,  9 * SIZE(AO)
@@ -1257,7 +1257,7 @@
 	MADD	t14, t14, a5, b8
 	MADD	t24, t24, a6, b8
 	MADD	t34, t34, a7, b8
-	MADD	t44, t44, a8, b8			#	fouth
+	MADD	t44, t44, a8, b8			#	fourth
 
 	daddiu	L, L, -1
 	bgtz	L, .L12

--- a/kernel/power/cgemm_macros_power9.S
+++ b/kernel/power/cgemm_macros_power9.S
@@ -31,7 +31,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 * BLASTEST 	     	: OK
 *  CTEST		    	: OK
 *  TEST			      : OK
-*	 LAPACK-TEST		: OK
+*  LAPACK-TEST		: OK
 **************************************************************************************/
 #define unit_size 8
 #define DISP32(ind,disp) (ind*unit_size*32+disp)
@@ -2907,7 +2907,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  
  
 
-/****************************TRMM POINTER REFRESH MACROSES*************************/
+/****************************TRMM POINTER REFRESH MACROS*************************/
 
 
 .macro SHIFT_REG  REG1,REG2,SHIFT_VAL

--- a/kernel/power/dgemm_macros_power9.S
+++ b/kernel/power/dgemm_macros_power9.S
@@ -3512,7 +3512,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 
-/****************************TRMM POINTER REFRESH MACROSES*************************/
+/****************************TRMM POINTER REFRESH MACROS*************************/
 
 .macro SHIFT_REG  REG1,REG2,SHIFT_VAL
 		.if \SHIFT_VAL==16 

--- a/kernel/power/icamax.c
+++ b/kernel/power/icamax.c
@@ -211,7 +211,7 @@ static BLASLONG   ciamax_kernel_32(BLASLONG n, FLOAT *x, FLOAT *maxf) {
        r2=vec_cmpgt(vv0,vf0);
        ind2 = vec_sel( indf0,indv0,r2);
        vv0= vec_sel(vf0,vv0,r2);       
-       //get asbolute index
+       //get absolute index
        ind2+=temp0;
        //compare with old quadruple and update 
        r1=vec_cmpgt(vv0,quadruple_values);

--- a/kernel/power/icamin.c
+++ b/kernel/power/icamin.c
@@ -145,7 +145,7 @@ static BLASLONG   ciamin_kernel_32(BLASLONG n, FLOAT *x, FLOAT *minf) {
        r2=vec_cmpgt(vf0,vv0);
        ind2 = vec_sel( indf0,indv0,r2);
        vv0= vec_sel(vf0,vv0,r2);       
-       //get asbolute index
+       //get absolute index
        ind2+=temp0;
        //compare with old quadruple and update 
        r1=vec_cmpgt(quadruple_values,vv0);

--- a/kernel/power/sgemm_macros_power9.S
+++ b/kernel/power/sgemm_macros_power9.S
@@ -5464,7 +5464,7 @@ KERNEL8x16_2  \AREG,\BREG,\OffsetA,\OffsetB, (\Index*2+1),\IsLast ,\Complete
 
 
 
-/****************************TRMM POINTER REFRESH MACROSES*************************/
+/****************************TRMM POINTER REFRESH MACROS*************************/
 
 .macro SHIFT_REG  REG1,REG2,SHIFT_VAL
 		.if \SHIFT_VAL==16 

--- a/kernel/power/zgemm_macros_power9.S
+++ b/kernel/power/zgemm_macros_power9.S
@@ -1717,7 +1717,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 /****************************TRMM POINTER REFRESH
 
-.macroSES*************************/
+.macros***************************/
 
 
 .macro SHIFT_REG  REG1,REG2,SHIFT_VAL

--- a/kernel/x86_64/cgemm_kernel_4x8_sandy.S
+++ b/kernel/x86_64/cgemm_kernel_4x8_sandy.S
@@ -2709,7 +2709,7 @@ SHUF_SX $0xb1, xvec10, xvec10;
 SHUF_SX $0xb1, xvec9, xvec9;
 SHUF_SX	$0xb1, xvec8, xvec8;
 #endif
-#### Mulitply Alpha ####
+#### Multiply Alpha ####
 BROAD_SX MEMALPHA_R, xvec7;
 BROAD_SX MEMALPHA_I, xvec6;
 #### Writng back ####
@@ -3155,7 +3155,7 @@ SHUF_SX $0xb1, xvec14, xvec14;
 SHUF_SX $0xb1, xvec11, xvec11;
 SHUF_SX $0xb1, xvec10, xvec10;
 #endif
-#### Mulitply Alpha ####
+#### Multiply Alpha ####
 BROAD_SX MEMALPHA_R, xvec7;
 BROAD_SX MEMALPHA_I, xvec6;
 #### Writng back ####
@@ -3439,7 +3439,7 @@ MOV_SX		xvec7, xvec11;
 SHUF_SX $0xb1, xvec15, xvec15;
 SHUF_SX $0xb1, xvec11, xvec11;
 #endif
-#### Mulitply Alpha ####
+#### Multiply Alpha ####
 BROAD_SX MEMALPHA_R, xvec7;
 BROAD_SX MEMALPHA_I, xvec6;
 #### Writng back ####
@@ -4249,7 +4249,7 @@ ADDSUB_SX xvec15, xvec7, xvec7;
 MOV_SX		xvec7, xvec15;
 SHUF_SX $0xb1, xvec15, xvec15;
 #endif
-#### Mulitply Alpha ####
+#### Multiply Alpha ####
 BROAD_SX MEMALPHA_R, xvec7;
 BROAD_SX MEMALPHA_I, xvec6;
 #### Writng back ####

--- a/kernel/x86_64/cgemv_t_microk_bulldozer-4.c
+++ b/kernel/x86_64/cgemv_t_microk_bulldozer-4.c
@@ -1,7 +1,7 @@
 /***************************************************************************
 Copyright (c) 2014, The OpenBLAS Project
 All rights reserved.
-Redistribution and use in source and binary froms, with or without
+Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
 met:
 1. Redistributions of source code must retain the above copyright

--- a/kernel/x86_64/cgemv_t_microk_haswell-4.c
+++ b/kernel/x86_64/cgemv_t_microk_haswell-4.c
@@ -1,7 +1,7 @@
 /***************************************************************************
 Copyright (c) 2014, The OpenBLAS Project
 All rights reserved.
-Redistribution and use in source and binary froms, with or without
+Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
 met:
 1. Redistributions of source code must retain the above copyright

--- a/kernel/x86_64/sgemm_kernel_8x8_sandy.S
+++ b/kernel/x86_64/sgemm_kernel_8x8_sandy.S
@@ -1427,7 +1427,7 @@ LEAQ (,%rax, SIZE), %rax;
 ADDQ	%rax, ptrba;
 LEAQ (ptrbb, %rax, 8), ptrbb;
 #endif
-#### intitial ####
+#### initial ####
 XOR_SY	yvec15, yvec15, yvec15;
 XOR_SY	yvec14, yvec14, yvec14;
 MOVQ bk, k;

--- a/kernel/x86_64/zgemv_t_microk_bulldozer-4.c
+++ b/kernel/x86_64/zgemv_t_microk_bulldozer-4.c
@@ -1,7 +1,7 @@
 /***************************************************************************
 Copyright (c) 2014, The OpenBLAS Project
 All rights reserved.
-Redistribution and use in source and binary froms, with or without
+Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
 met:
 1. Redistributions of source code must retain the above copyright

--- a/kernel/x86_64/zgemv_t_microk_haswell-4.c
+++ b/kernel/x86_64/zgemv_t_microk_haswell-4.c
@@ -1,7 +1,7 @@
 /***************************************************************************
 Copyright (c) 2014, The OpenBLAS Project
 All rights reserved.
-Redistribution and use in source and binary froms, with or without
+Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
 met:
 1. Redistributions of source code must retain the above copyright

--- a/kernel/zarch/ckernelMacrosV.S
+++ b/kernel/zarch/ckernelMacrosV.S
@@ -1368,7 +1368,7 @@
     la \CIJ_REG,8(\CIJ_REG)
 .endm
 
-/****************************TRMM POINTER REFRESH MACROSES*************************/
+/****************************TRMM POINTER REFRESH MACROS*************************/
 
 .macro RefreshPointers  PTR_A,PTR_B,OFF_VAL,B_VAL,C_A,C_B
   #if (defined(LEFT) &&  defined(TRANSA)) ||  (!defined(LEFT) && !defined(TRANSA))

--- a/kernel/zarch/kernelMacros.S
+++ b/kernel/zarch/kernelMacros.S
@@ -1342,7 +1342,7 @@
 .endm
 
 
-/****************************TRMM POINTER REFRESH MACROSES*************************/
+/****************************TRMM POINTER REFRESH MACROS*************************/
 
 .macro RefreshPointers  PTR_A,PTR_B,OFF_VAL,B_VAL,C_A,C_B
     #if (defined(LEFT) &&  defined(TRANSA)) ||  (!defined(LEFT) && !defined(TRANSA))

--- a/kernel/zarch/skernelMacros.S
+++ b/kernel/zarch/skernelMacros.S
@@ -1008,7 +1008,7 @@
 
 
 
-/****************************TRMM POINTER REFRESH MACROSES*************************/
+/****************************TRMM POINTER REFRESH MACROS*************************/
 
 .macro RefreshPointers  PTR_A,PTR_B,OFF_VAL,B_VAL,C_A,C_B
     #if (defined(LEFT) &&  defined(TRANSA)) ||  (!defined(LEFT) && !defined(TRANSA))

--- a/kernel/zarch/zkernelMacrosV.S
+++ b/kernel/zarch/zkernelMacrosV.S
@@ -1219,7 +1219,7 @@
     la \CIJ_REG,16(\CIJ_REG)
 .endm
 
-/****************************TRMM POINTER REFRESH MACROSES*************************/
+/****************************TRMM POINTER REFRESH MACROS*************************/
 
 .macro RefreshPointers  PTR_A,PTR_B,OFF_VAL,B_VAL,C_A,C_B
   #if (defined(LEFT) &&  defined(TRANSA)) ||  (!defined(LEFT) && !defined(TRANSA))

--- a/reference/ctbmvf.f
+++ b/reference/ctbmvf.f
@@ -117,7 +117,7 @@
 *           ( 1 + ( n - 1 )*abs( INCX ) ).
 *           Before entry, the incremented array X must contain the n
 *           element vector x. On exit, X is overwritten with the
-*           tranformed vector x.
+*           transformed vector x.
 *
 *  INCX   - INTEGER.
 *           On entry, INCX specifies the increment for the elements of

--- a/reference/ctpmvf.f
+++ b/reference/ctpmvf.f
@@ -77,7 +77,7 @@
 *           ( 1 + ( n - 1 )*abs( INCX ) ).
 *           Before entry, the incremented array X must contain the n
 *           element vector x. On exit, X is overwritten with the
-*           tranformed vector x.
+*           transformed vector x.
 *
 *  INCX   - INTEGER.
 *           On entry, INCX specifies the increment for the elements of

--- a/reference/ctrmvf.f
+++ b/reference/ctrmvf.f
@@ -80,7 +80,7 @@
 *           ( 1 + ( n - 1 )*abs( INCX ) ).
 *           Before entry, the incremented array X must contain the n
 *           element vector x. On exit, X is overwritten with the
-*           tranformed vector x.
+*           transformed vector x.
 *
 *  INCX   - INTEGER.
 *           On entry, INCX specifies the increment for the elements of

--- a/reference/dtbmvf.f
+++ b/reference/dtbmvf.f
@@ -117,7 +117,7 @@
 *           ( 1 + ( n - 1 )*abs( INCX ) ).
 *           Before entry, the incremented array X must contain the n
 *           element vector x. On exit, X is overwritten with the
-*           tranformed vector x.
+*           transformed vector x.
 *
 *  INCX   - INTEGER.
 *           On entry, INCX specifies the increment for the elements of

--- a/reference/dtpmvf.f
+++ b/reference/dtpmvf.f
@@ -77,7 +77,7 @@
 *           ( 1 + ( n - 1 )*abs( INCX ) ).
 *           Before entry, the incremented array X must contain the n
 *           element vector x. On exit, X is overwritten with the
-*           tranformed vector x.
+*           transformed vector x.
 *
 *  INCX   - INTEGER.
 *           On entry, INCX specifies the increment for the elements of

--- a/reference/dtrmvf.f
+++ b/reference/dtrmvf.f
@@ -80,7 +80,7 @@
 *           ( 1 + ( n - 1 )*abs( INCX ) ).
 *           Before entry, the incremented array X must contain the n
 *           element vector x. On exit, X is overwritten with the
-*           tranformed vector x.
+*           transformed vector x.
 *
 *  INCX   - INTEGER.
 *           On entry, INCX specifies the increment for the elements of

--- a/reference/stbmvf.f
+++ b/reference/stbmvf.f
@@ -117,7 +117,7 @@
 *           ( 1 + ( n - 1 )*abs( INCX ) ).
 *           Before entry, the incremented array X must contain the n
 *           element vector x. On exit, X is overwritten with the
-*           tranformed vector x.
+*           transformed vector x.
 *
 *  INCX   - INTEGER.
 *           On entry, INCX specifies the increment for the elements of

--- a/reference/stpmvf.f
+++ b/reference/stpmvf.f
@@ -77,7 +77,7 @@
 *           ( 1 + ( n - 1 )*abs( INCX ) ).
 *           Before entry, the incremented array X must contain the n
 *           element vector x. On exit, X is overwritten with the
-*           tranformed vector x.
+*           transformed vector x.
 *
 *  INCX   - INTEGER.
 *           On entry, INCX specifies the increment for the elements of

--- a/reference/strmvf.f
+++ b/reference/strmvf.f
@@ -80,7 +80,7 @@
 *           ( 1 + ( n - 1 )*abs( INCX ) ).
 *           Before entry, the incremented array X must contain the n
 *           element vector x. On exit, X is overwritten with the
-*           tranformed vector x.
+*           transformed vector x.
 *
 *  INCX   - INTEGER.
 *           On entry, INCX specifies the increment for the elements of

--- a/reference/ztbmvf.f
+++ b/reference/ztbmvf.f
@@ -117,7 +117,7 @@
 *           ( 1 + ( n - 1 )*abs( INCX ) ).
 *           Before entry, the incremented array X must contain the n
 *           element vector x. On exit, X is overwritten with the
-*           tranformed vector x.
+*           transformed vector x.
 *
 *  INCX   - INTEGER.
 *           On entry, INCX specifies the increment for the elements of

--- a/reference/ztpmvf.f
+++ b/reference/ztpmvf.f
@@ -77,7 +77,7 @@
 *           ( 1 + ( n - 1 )*abs( INCX ) ).
 *           Before entry, the incremented array X must contain the n
 *           element vector x. On exit, X is overwritten with the
-*           tranformed vector x.
+*           transformed vector x.
 *
 *  INCX   - INTEGER.
 *           On entry, INCX specifies the increment for the elements of

--- a/reference/ztrmvf.f
+++ b/reference/ztrmvf.f
@@ -80,7 +80,7 @@
 *           ( 1 + ( n - 1 )*abs( INCX ) ).
 *           Before entry, the incremented array X must contain the n
 *           element vector x. On exit, X is overwritten with the
-*           tranformed vector x.
+*           transformed vector x.
 *
 *  INCX   - INTEGER.
 *           On entry, INCX specifies the increment for the elements of


### PR DESCRIPTION
Found via `codespell -q 3 -L amin,als,ba,dum,mone,nd,nto,orign -S Changelog.txt,./lapack*`