### PR TITLE
Support QEMU virtual cpu in 64bit mode as CORE2 or BARCELONA

### DIFF
--- a/cpuid_x86.c
+++ b/cpuid_x86.c
@@ -1197,7 +1197,11 @@ int get_cpuname(void){
 	case  3:
 	case  5:
 	case  6:
+#ifdef __64BIT__
+	  return CPUTYPE_CORE2;
+#else			
 	  return CPUTYPE_PENTIUM2;
+#endif
 	case  7:
 	case  8:
 	case 10:

--- a/cpuid_x86.c
+++ b/cpuid_x86.c
@@ -1197,11 +1197,7 @@ int get_cpuname(void){
 	case  3:
 	case  5:
 	case  6:
-#ifdef __64BIT__
-	  return CPUTYPE_CORE2;
-#else			
 	  return CPUTYPE_PENTIUM2;
-#endif
 	case  7:
 	case  8:
 	case 10:
@@ -1383,8 +1379,6 @@ int get_cpuname(void){
       break;
       case 7: // family 6 exmodel 7
         switch (model) {
-        case 10: // Goldmont Plus
-          return CPUTYPE_NEHALEM;
         case 14: // Ice Lake
           if(support_avx512())
             return CPUTYPE_SKYLAKEX;
@@ -1431,7 +1425,11 @@ int get_cpuname(void){
     case 0x5:
       return CPUTYPE_AMDK6;
     case 0x6:
+#if defined(__x86_64__) || defined(__amd64__)
+      return CPUTYPE_BARCELONA;
+#else
       return CPUTYPE_ATHLON;
+#endif
     case 0xf:
       switch (exfamily) {
       case  0:
@@ -1814,7 +1812,11 @@ int get_coretype(void){
 	case  4:
 	case  5:
 	case  6:
+#if defined(__x86_64__) || defined(__amd64__)
+	  return CORE_CORE2;
+#else
 	  return CORE_P6;
+#endif
 	case  7:
 	  return CORE_KATMAI;
 	case  8:
@@ -2021,7 +2023,11 @@ int get_coretype(void){
 
   if (vendor == VENDOR_AMD){
     if (family <= 0x5) return CORE_80486;
+#if defined(__x86_64__) || defined(__amd64__)
+    if (family <= 0xe) return CORE_BARCELONA;
+#else
     if (family <= 0xe) return CORE_ATHLON;
+#endif
     if (family == 0xf){
       if ((exfamily == 0) || (exfamily == 2)) return CORE_OPTERON;
       else if (exfamily == 5) return CORE_BOBCAT;


### PR DESCRIPTION
qemu itself claims it is a 64bit P6, which of course does not exist in the wild. (In some circumstances, probably depending on qemu/libvirt software version or availability of kvm acceleration, the virtual cpu identifies as an AMD processor of the  same family and model id - a 64bit Athlon that does not exist as real hardware either. I believe the 32bit case of this was taken care of by #288 several years ago.)
Fixes #2176