### PR TITLE
Change bad usage of "asum" to "sum" in ZARCH versions of ?sum

### DIFF
--- a/kernel/zarch/csum.c
+++ b/kernel/zarch/csum.c
@@ -88,7 +88,7 @@ static FLOAT csum_kernel_32(BLASLONG n, FLOAT *x) {
     "vfasb   %%v24,%%v24,%%v25\n\t"
     "vrepf   %%v25,%%v24,2\n\t"
     "vfasb   %%v24,%%v24,%%v25\n\t"
-    "vstef   %%v24,%[asum],0"
+    "vstef   %%v24,%[sum],0"
     : [sum] "=Q"(sum),[n] "+&r"(n)
     : "m"(*(const struct { FLOAT x[n * 2]; } *) x),[x] "a"(x)
     : "cc", "r1", "v16", "v17", "v18", "v19", "v20", "v21", "v22", "v23",

--- a/kernel/zarch/dsum.c
+++ b/kernel/zarch/dsum.c
@@ -86,7 +86,7 @@ static FLOAT dsum_kernel_32(BLASLONG n, FLOAT *x) {
     "vfadb   %%v24,%%v24,%%v31\n\t"
     "vrepg   %%v25,%%v24,1\n\t"
     "vfadb   %%v24,%%v24,%%v25\n\t"
-    "vsteg   %%v24,%[asum],0"
+    "vsteg   %%v24,%[sum],0"
     : [sum] "=Q"(sum),[n] "+&r"(n)
     : "m"(*(const struct { FLOAT x[n]; } *) x),[x] "a"(x)
     : "cc", "r1", "v16", "v17", "v18", "v19", "v20", "v21", "v22", "v23",

--- a/kernel/zarch/ssum.c
+++ b/kernel/zarch/ssum.c
@@ -89,7 +89,7 @@ static FLOAT ssum_kernel_64(BLASLONG n, FLOAT *x) {
     "vfasb   %%v24,%%v24,%%v25\n\t"
     "vrepf   %%v25,%%v24,2\n\t"
     "vfasb   %%v24,%%v24,%%v25\n\t"
-    "vstef   %%v24,%[asum],0"
+    "vstef   %%v24,%[sum],0"
     : [sum] "=Q"(sum),[n] "+&r"(n)
     : "m"(*(const struct { FLOAT x[n]; } *) x),[x] "a"(x)
     : "cc", "r1", "v16", "v17", "v18", "v19", "v20", "v21", "v22", "v23",

--- a/kernel/zarch/zsum.c
+++ b/kernel/zarch/zsum.c
@@ -87,7 +87,7 @@ static FLOAT zsum_kernel_16(BLASLONG n, FLOAT *x) {
     "vfadb   %%v24,%%v24,%%v31\n\t"
     "vrepg   %%v25,%%v24,1\n\t"
     "vfadb   %%v24,%%v24,%%v25\n\t"
-    "vsteg   %%v24,%[asum],0"
+    "vsteg   %%v24,%[sum],0"
     : [sum] "=Q"(sum),[n] "+&r"(n)
     : "m"(*(const struct { FLOAT x[n * 2]; } *) x),[x] "a"(x)
     : "cc", "r1", "v16", "v17", "v18", "v19", "v20", "v21", "v22", "v23",


### PR DESCRIPTION
The ZARCH implementations of ?sum contain a cut & paste-error: An inline
assembly argument is named "sum", but the assembly references "asum"
instead.  The mismatch causes a build error.  This is fixed.