### PR TITLE
Support two-digit version numbers in gcc version check

### DIFF
--- a/f_check
+++ b/f_check
@@ -71,7 +71,7 @@ if ($compiler eq "") {
 
 	if ($data =~ /GNU/) {
 
-	    $data =~ /(\d)\.(\d).(\d)/;
+	    $data =~ /(\d+)\.(\d+).(\d+)/;
 	    $major = $1;
 	    $minor = $2;
 


### PR DESCRIPTION
fixes #2336 (non-recognition of gcc 10) with patch provided by JeffreyALaw.