### PR TITLE
driver: more reasonable thread wait timeout on Windows.

### DIFF
--- a/driver/others/blas_server_win32.c
+++ b/driver/others/blas_server_win32.c
@@ -462,7 +462,7 @@ int BLASFUNC(blas_thread_shutdown)(void){
 
     for(i = 0; i < blas_num_threads - 1; i++){
       // Could also just use WaitForMultipleObjects
-      DWORD wait_thread_value = WaitForSingleObject(blas_threads[i], 5000);
+      DWORD wait_thread_value = WaitForSingleObject(blas_threads[i], 50);
 
 #ifndef OS_WINDOWSSTORE
       // TerminateThread is only available with WINAPI_DESKTOP and WINAPI_SYSTEM not WINAPI_APP in UWP


### PR DESCRIPTION
It used to be 5ms, which might not be long enough in some cases for the
thread to exit well, but then when set to 5000 (5s), it would slow down
any program depending on OpenBlas.

Let's just set it to 50ms, which is at least 10 times longer than
originally, but still reasonable in case of failed thread termination.

------------------

This is a followup of #2314. After providing a test installer of GIMP with patched OpenBLAS, reporters could confirm crashes were gone. On the other hand, it seems GIMP got extra slower on startup on Windows (worse reports were telling of GIMP startup hanging for more than 10 minutes!). I am unsure when this code in `blas_server_win32.c` is called exactly, and how many threads it creates and it awaits for termination (and I'd like to not have to spend too long on this! 😛), but I figured the timeout we passed to 5 seconds is the culprit. After testing, lowering it down to 50ms (which is still 10 times longer than the original 5ms, but at least reasonable wait in case of failure), people confirmed GIMP startup is good again and crash is still gone.

Anyway I think that the other part of the previous patch (not terminating a thread which was successfully terminated by itself) was the most important part of the fix.