### PR TITLE
LAPACK: avoid out-of-bound write in ?LANTR

### DIFF
--- a/lapack-netlib/SRC/clantr.f
+++ b/lapack-netlib/SRC/clantr.f
@@ -283,7 +283,7 @@
             END IF
          ELSE
             IF( LSAME( DIAG, 'U' ) ) THEN
-               DO 210 I = 1, N
+               DO 210 I = 1, MIN( M, N )
                   WORK( I ) = ONE
   210          CONTINUE
                DO 220 I = N + 1, M

--- a/lapack-netlib/SRC/dlantr.f
+++ b/lapack-netlib/SRC/dlantr.f
@@ -281,7 +281,7 @@
             END IF
          ELSE
             IF( LSAME( DIAG, 'U' ) ) THEN
-               DO 210 I = 1, N
+               DO 210 I = 1, MIN( M, N )
                   WORK( I ) = ONE
   210          CONTINUE
                DO 220 I = N + 1, M

--- a/lapack-netlib/SRC/slantr.f
+++ b/lapack-netlib/SRC/slantr.f
@@ -281,7 +281,7 @@
             END IF
          ELSE
             IF( LSAME( DIAG, 'U' ) ) THEN
-               DO 210 I = 1, N
+               DO 210 I = 1, MIN( M, N )
                   WORK( I ) = ONE
   210          CONTINUE
                DO 220 I = N + 1, M

--- a/lapack-netlib/SRC/zlantr.f
+++ b/lapack-netlib/SRC/zlantr.f
@@ -283,7 +283,7 @@
             END IF
          ELSE
             IF( LSAME( DIAG, 'U' ) ) THEN
-               DO 210 I = 1, N
+               DO 210 I = 1, MIN( M, N )
                   WORK( I ) = ONE
   210          CONTINUE
                DO 220 I = N + 1, M


### PR DESCRIPTION
See https://github.com/Reference-LAPACK/lapack/pull/378 for background.

Note that there are other differences in LANTR routines that would go away after updating to 3.9.0 (or latest master) of netlib lapack.