### PR TITLE
win32: Don't rely on timeout at all

### DIFF
--- a/driver/others/blas_server_win32.c
+++ b/driver/others/blas_server_win32.c
@@ -462,14 +462,7 @@ int BLASFUNC(blas_thread_shutdown)(void){
 
     for(i = 0; i < blas_num_threads - 1; i++){
       // Could also just use WaitForMultipleObjects
-      DWORD wait_thread_value = WaitForSingleObject(blas_threads[i], 50);
-
-#ifndef OS_WINDOWSSTORE
-      // TerminateThread is only available with WINAPI_DESKTOP and WINAPI_SYSTEM not WINAPI_APP in UWP
-      if (WAIT_OBJECT_0 != wait_thread_value) {
-        TerminateThread(blas_threads[i],0);
-      }
-#endif
+      DWORD wait_thread_value = WaitForSingleObject(blas_threads[i], INFINITE);
 
       CloseHandle(blas_threads[i]);
     }

--- a/exports/dllinit.c
+++ b/exports/dllinit.c
@@ -50,7 +50,10 @@ BOOL APIENTRY DllMain(HINSTANCE hInst, DWORD reason, LPVOID reserved) {
         gotoblas_init();
         break;
       case DLL_PROCESS_DETACH:
-        gotoblas_quit();
+        // If the process is about to exit, don't bother releasing any resources
+        // The kernel is much better at bulk releasing then.
+        if (!reserved)
+          gotoblas_quit();
         break;
       case DLL_THREAD_ATTACH:
         break;


### PR DESCRIPTION
Same issue as #2314, but this time seen in Julia. Having a timeout here is fundamentally unsound. There is no guarantee that the kernel will ever schedule the thread holding the lock. We need to rely on the pool threads to exit eventually (if they don't, that's a different bug that this can't work around - especially since we already don't do the termination for windows store apps). However, to prevent thread pool threads from blocking process exit, don't attempt to shut down BLAS if the process is about to exit - the kernel will kill all our resources anyway. After this patch, the problematic code section is only called if the dll is manually unloaded, which I think is
a) A much rarer use case and
b) even more important that we don't interrupt pool threads in the middle of work that that host application may want to look at later.

cc @Jehan