### PR TITLE
Leave all thread cleanup to Windows when DLL_PROCESS_DETACH occurs

### DIFF
--- a/driver/others/memory.c
+++ b/driver/others/memory.c
@@ -3146,7 +3146,7 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD  ul_reason_for_call, LPVOID lpReser
     case DLL_THREAD_DETACH:
       break;
     case DLL_PROCESS_DETACH:
-      gotoblas_quit();
+      /* gotoblas_quit(); */
       break;
     default:
       break;


### PR DESCRIPTION
trying to do an orderly shutdown of threads here is likely to cause a deadlock - DllMain is called while the loader lock is held, also event handling is serialized in this situation so thread exit signals cannot get delivered until DllMain itself returns. (see PR #2350 for background)