### PR TITLE
Do not run any cleanup if the program is exiting anyway

### DIFF
--- a/exports/dllinit.c
+++ b/exports/dllinit.c
@@ -50,7 +50,10 @@ BOOL APIENTRY DllMain(HINSTANCE hInst, DWORD reason, LPVOID reserved) {
         gotoblas_init();
         break;
       case DLL_PROCESS_DETACH:
-        gotoblas_quit();
+        // If the process is about to exit, don't bother releasing any resources
+        // The kernel is much better at bulk releasing then.
+        if (!reserved)
+          gotoblas_quit();
         break;
       case DLL_THREAD_ATTACH:
         break;


### PR DESCRIPTION
From keno's PR #2350 - this avoids the potential hang in blas_thread_shutdown where we may wait for threads to exit while they are waiting on the loader lock from DllMain