### PR TITLE
fix a few performance drop in some matrix size per data type

### DIFF
--- a/param.h
+++ b/param.h
@@ -1507,8 +1507,13 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #define SYMV_P  8
 
-#define SWITCH_RATIO	32
-#define GEMM_PREFERED_SIZE	16
+#if defined(XDOUBLE) || defined(DOUBLE)
+#define SWITCH_RATIO            4
+#define GEMM_PREFERED_SIZE      4
+#else
+#define SWITCH_RATIO            8
+#define GEMM_PREFERED_SIZE      8
+#endif
 
 #ifdef ARCH_X86
 
@@ -1627,8 +1632,13 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #define SYMV_P  8
 
-#define SWITCH_RATIO	32
-#define GEMM_PREFERED_SIZE	32
+#if defined(XDOUBLE) || defined(DOUBLE)
+#define SWITCH_RATIO           8
+#define GEMM_PREFERED_SIZE     8
+#else
+#define SWITCH_RATIO           16
+#define GEMM_PREFERED_SIZE     16
+#endif
 #define USE_SGEMM_KERNEL_DIRECT 1
 
 #ifdef ARCH_X86


### PR DESCRIPTION
Signed-off-by: Wang,Long <long1.wang@intel.com>

Add this patch to fix a few performance drop in some matrix size. It was caused by the inappropriate GEMM_PREFERED_SIZE value(=32), which set the imbalance workload split per thread. 
For example 1280x1280 single precision matrix in 16 threads. It was split into 8 threads with 96 width single precision(32 bits)size and 8 threads with 64 width. But for avx512 alignment, the 16 threads with 80 width single precision(32 bits)size is also acceptable and more important in such case is that the workload is also balanced in each thread.