### PR TITLE
Restore -march flag for Android builds

### DIFF
--- a/Makefile.arm
+++ b/Makefile.arm
@@ -1,7 +1,7 @@
 ifeq ($(CORE), $(filter $(CORE),ARMV7 CORTEXA9 CORTEXA15))
 ifeq ($(OSNAME), Android)
-CCOMMON_OPT += -mfpu=neon
-FCOMMON_OPT += -mfpu=neon
+CCOMMON_OPT += -mfpu=neon -march=armv7-a
+FCOMMON_OPT += -mfpu=neon -march=armv7-a
 else
 CCOMMON_OPT += -mfpu=vfpv3 -march=armv7-a
 FCOMMON_OPT += -mfpu=vfpv3 -march=armv7-a


### PR DESCRIPTION
fixes #2419 - renewed discussion in #2112 suggests removal of the option was primarily aimed at non-Android builds