### PR TITLE
Nightly homebrew check

### DIFF
--- a/.github/workflows/nightly-Homebrew-build.yml
+++ b/.github/workflows/nightly-Homebrew-build.yml
@@ -3,7 +3,7 @@
 on:
   push:
     paths:
-      - '**/nightlyHomebrew-build.yml'
+      - '**/nightly-Homebrew-build.yml'
   pull_request:
     branches:
       - develop
@@ -51,13 +51,16 @@ jobs:
         # the HEAD flags tell Homebrew to build the develop branch fetch via git
 
       - name: Create bottle
-        run: brew bottle -v openblas
+        run: |
+          brew bottle -v openblas
+          mkdir bottles
+          mv *.bottle.tar.gz bottles
 
       - name: Upload bottle
         uses: actions/upload-artifact@v1
         with:
           name: openblas--HEAD.catalina.bottle.tar.gz
-          paht: ./*.bottle.*
+          path: bottles
 
       - name: Show linkage
         run: brew linkage -v openblas

--- a/.github/workflows/nightly-Homebrew-build.yml
+++ b/.github/workflows/nightly-Homebrew-build.yml
@@ -1,0 +1,63 @@
+on:
+  push:
+  pull_request:
+    branches:
+      - develop
+  schedule:
+    - cron: 45 7 * * *
+
+name: Nightly-Homebrew-Build
+jobs:
+  build-OpenBLAS-with-Homebrew:
+    runs-on: macos-latest
+    env:
+      HOMEBREW_DEVELOPER: "ON"
+      HOMEBREW_DISPLAY_INSTALL_TIMES: "ON"
+      HOMEBREW_NO_ANALYTICS: "ON"
+      HOMEBREW_NO_AUTO_UPDATE: "ON"
+      HOMEBREW_NO_BOTTLE_SOURCE_FALLBACK: "ON"
+      HOMEBREW_NO_INSTALL_CLEANUP: "ON"
+
+    steps:
+      - name: Random delay for cron job
+        run: |
+          delay=$(( RANDOM % 600 ))
+          printf 'Delaying for %s seconds on event %s' ${delay} "${{ github.event_name }}"
+          sleep ${delay}
+        if: github.event_name == 'schedule'
+
+      - uses: actions/checkout@v2
+
+      - name: Update Homebrew
+        if: github.event_name != 'pull_request'
+        run: brew update || true
+
+      - name: Install prerequisites
+        run: brew install --fetch-HEAD --HEAD --only-dependencies --keep-tmp openblas
+
+      - name: Install and bottle OpenBLAS
+        run: brew install --fetch-HEAD --HEAD --build-bottle --keep-tmp openblas
+
+      - name: Create bottle
+        run: brew bottle -v openblas
+
+      - name: Upload bottle
+        uses: actions/upload-artifact@v1
+        with:
+          name: openblas--HEAD.catalina.bottle.tar.gz
+          paht: ./*.bottle.*
+
+      - name: Show linkage
+        run: brew linkage -v openblas
+
+      - name: Test openblas
+        run: brew test --HEAD --verbose openblas
+
+      - name: Audit openblas formula
+        run: |
+          brew audit --strict openblas
+          brew cat openblas
+
+      - name: Post logs on failure
+        if: failure()
+        run: brew gist-logs --with-hostname -v openblas

--- a/.github/workflows/nightly-Homebrew-build.yml
+++ b/.github/workflows/nightly-Homebrew-build.yml
@@ -1,10 +1,20 @@
+# Only the "head" branch of the OpenBLAS package is tested
+
 on:
   push:
+    paths:
+      - '**/nightlyHomebrew-build.yml'
   pull_request:
     branches:
       - develop
+    paths:
+      - '**/nightly-Homebrew-build.yml'
   schedule:
     - cron: 45 7 * * *
+# This is 7:45 AM UTC daily, late at night in the USA
+
+# Since push and pull_request will still always be building and testing the `develop` branch,
+# it only makes sense to test if this file has been changed
 
 name: Nightly-Homebrew-Build
 jobs:
@@ -27,6 +37,7 @@ jobs:
         if: github.event_name == 'schedule'
 
       - uses: actions/checkout@v2
+        # This isn't even needed, technically. Homebrew will get `develop` via git
 
       - name: Update Homebrew
         if: github.event_name != 'pull_request'
@@ -37,6 +48,7 @@ jobs:
 
       - name: Install and bottle OpenBLAS
         run: brew install --fetch-HEAD --HEAD --build-bottle --keep-tmp openblas
+        # the HEAD flags tell Homebrew to build the develop branch fetch via git
 
       - name: Create bottle
         run: brew bottle -v openblas


### PR DESCRIPTION
~~Test PRs into develop and nightly test of develop built using the Homebrew formula.~~

Nightly tests of develop built on macOS using Homebrew's build "formula" for OpenBLAS. This emulates the Homebrew binary build and distribution process so you will know if changes in Homebrew adversely impact OpenBLAS, and if changes in OpenBLAS will impede a quick release in Homebrew before minting a new release.