### PR TITLE
Fix IxMIN/IxMAX defaulting to the IxAMIN/IxAMAX kernels

### DIFF
--- a/kernel/Makefile.L1
+++ b/kernel/Makefile.L1
@@ -133,29 +133,29 @@ endif
 ### IMAX ###
 
 ifndef ISMAXKERNEL
-ISMAXKERNEL = iamax.S
+ISMAXKERNEL = imax.S
 endif
 
 ifndef IDMAXKERNEL
-IDMAXKERNEL = iamax.S
+IDMAXKERNEL = imax.S
 endif
 
 ifndef IQMAXKERNEL
-IQMAXKERNEL = iamax.S
+IQMAXKERNEL = imax.S
 endif
 
 ### IMIN ###
 
 ifndef ISMINKERNEL
-ISMINKERNEL = iamin.S
+ISMINKERNEL = imin.S
 endif
 
 ifndef IDMINKERNEL
-IDMINKERNEL = iamin.S
+IDMINKERNEL = imin.S
 endif
 
 ifndef IQMINKERNEL
-IQMINKERNEL = iamin.S
+IQMINKERNEL = imin.S
 endif
 
 ### ASUM ###


### PR DESCRIPTION
fixes #2433 (ppc and mips64 were affected as they have separate kernels for these tasks, while e.g. x86 uses a combined source with a USE_ABS define).