### PR TITLE
Add proper defaults for the IxMIN/IxMAX kernels on mips64 and power

### DIFF
--- a/kernel/mips64/KERNEL
+++ b/kernel/mips64/KERNEL
@@ -167,3 +167,27 @@ endif
 
 CGEMM3MKERNEL    =  zgemm3m_kernel.S
 ZGEMM3MKERNEL    =  zgemm3m_kernel.S
+
+ifndef ISMINKERNEL
+ISMINKERNEL = imin.S
+endif
+
+ifndef IDMINKERNEL
+IDMINKERNEL = imin.S
+endif
+
+ifndef IQMINKERNEL
+IQMINKERNEL = imin.S
+endif
+
+ifndef ISMAXKERNEL
+ISMAXKERNEL = imax.S
+endif
+
+ifndef IDMAXKERNEL
+IDMAXKERNEL = imax.S
+endif
+
+ifndef IQMAXKERNEL
+IQMAXKERNEL = imax.S
+endif

--- a/kernel/power/KERNEL
+++ b/kernel/power/KERNEL
@@ -50,3 +50,26 @@ ifndef DSDOTKERNEL
 DSDOTKERNEL = ../generic/dot.c
 endif
 
+ifndef ISMINKERNEL
+ISMINKERNEL = imin.S
+endif
+
+ifndef IDMINKERNEL
+IDMINKERNEL = imin.S
+endif
+
+ifndef IQMINKERNEL
+IQMINKERNEL = imin.S
+endif
+
+ifndef ISMAXKERNEL
+ISMAXKERNEL = imax.S
+endif
+
+ifndef IDMAXKERNEL
+IDMAXKERNEL = imax.S
+endif
+
+ifndef IQMAXKERNEL
+IQMAXKERNEL = imax.S
+endif


### PR DESCRIPTION
The default entries for these functions in Makefile.L1 assume a combined source file with appropriate conditionals for USE_ABS, while power and mips64 have separate implementations for imin/iamin and imax/iamax.
fixes #2433