### PR TITLE
Apply fix from Reference-LAPACK PR 390

### DIFF
--- a/lapack-netlib/SRC/dcombssq.f
+++ b/lapack-netlib/SRC/dcombssq.f
@@ -80,6 +80,8 @@
       IF( V1( 1 ).GE.V2( 1 ) ) THEN
          IF( V1( 1 ).NE.ZERO ) THEN
             V1( 2 ) = V1( 2 ) + ( V2( 1 ) / V1( 1 ) )**2 * V2( 2 )
+         ELSE
+            V1( 2 ) = V1( 2 ) + V2( 2 )   
          END IF
       ELSE
          V1( 2 ) = V2( 2 ) + ( V1( 1 ) / V2( 1 ) )**2 * V1( 2 )

--- a/lapack-netlib/SRC/scombssq.f
+++ b/lapack-netlib/SRC/scombssq.f
@@ -80,6 +80,8 @@
       IF( V1( 1 ).GE.V2( 1 ) ) THEN
          IF( V1( 1 ).NE.ZERO ) THEN
             V1( 2 ) = V1( 2 ) + ( V2( 1 ) / V1( 1 ) )**2 * V2( 2 )
+         ELSE
+            V1( 2 ) = V1( 2 ) + V2( 2 )
          END IF
       ELSE
          V1( 2 ) = V2( 2 ) + ( V1( 1 ) / V2( 1 ) )**2 * V1( 2 )


### PR DESCRIPTION
NaN not propagating in DCOMBSSQ and SCOMBSSQ in some cases (3.9.0 regression reported and fixed in https://github.com/Reference-LAPACK/lapack/pull/390)