### PR TITLE
Solve the problem of core dumped when using large-scale data in benchmark tests

### DIFF
--- a/benchmark/gemm3m.c
+++ b/benchmark/gemm3m.c
@@ -181,9 +181,9 @@ int main(int argc, char *argv[]){
   
     	for(j = 0; j < m; j++){
       		for(i = 0; i < m * COMPSIZE; i++){
-			a[i + j * m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
-			b[i + j * m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
-			c[i + j * m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
+			a[(long)i + (long)j * (long)m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
+			b[(long)i + (long)j * (long)m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
+			c[(long)i + (long)j * (long)m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
       		}
     	}
 


### PR DESCRIPTION
E.g ：  when running test calse such as below in benchmark:
./zgemm3m.goto 100000 100000 100000
From : 100000  To : 100000 Step = 100000 Trans = 'N' Inc_x = 1 Inc_y = 1 Loops = 1
   SIZE       Flops
 100000 : Segmentation fault (core dumped)
Because i+j*m has exceeded the maximum range of int

![image](https://user-images.githubusercontent.com/32100330/75446415-5abaff80-59a2-11ea-95a5-2e505e778537.png)
