### PR TITLE
Solve the problem of core dumped when using large-scale data in bench…

### DIFF
--- a/benchmark/gesv.c
+++ b/benchmark/gesv.c
@@ -177,20 +177,20 @@ int main(int argc, char *argv[]){
 
     for(j = 0; j < m; j++){
       for(i = 0; i < m * COMPSIZE; i++){
-	a[i + j * m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
+	a[(long)i + (long)j * (long)m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
       }
     }
 
     for(j = 0; j < m; j++){
       for(i = 0; i < m * COMPSIZE; i++){
-	b[i + j * m * COMPSIZE] = 0.0;
+	b[(long)i + (long)j * (long)m * COMPSIZE] = 0.0;
       }
     }
 
 
     for (j = 0; j < m; ++j) {
       for (i = 0; i < m * COMPSIZE; ++i) {
-	b[i] += a[i + j * m * COMPSIZE];
+	b[i] += a[(long)i + (long)j * (long)m * COMPSIZE];
       }
     }
 


### PR DESCRIPTION
…mark test

E.g ：  when running test calse such as below in benchmark:
./dgesv.goto 100000 100000 100000
From : 100000  To : 100000 Step = 100000 Trans = 'N' Inc_x = 1 Inc_y = 1 Loops = 1
   SIZE       Flops
 100000 : Segmentation fault (core dumped)
Because i+j*m has exceeded the maximum range of int