### PR TITLE
Solve the problem of core dumped when using large-scale data in bench…

### DIFF
--- a/benchmark/hemv.c
+++ b/benchmark/hemv.c
@@ -167,7 +167,7 @@ int main(int argc, char *argv[]){
 
    for(j = 0; j < m; j++){
       		for(i = 0; i < m * COMPSIZE; i++){
-			a[i + j * m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
+			a[(long)i + (long)j * (long)m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
       		}
    }
 


### PR DESCRIPTION
…mark test

E.g ：  when running test calse such as below in benchmark:
./chemv.goto 100000 100000 100000
From : 100000  To : 100000 Step = 100000 Uplo = 'L' Inc_x = 1 Inc_y = 1 Loops = 1
   SIZE       Flops
 100000x100000 : Segmentation fault (core dumped)
Because i+j*m has exceeded the maximum range of int
![image](https://user-images.githubusercontent.com/32100330/75448621-7fb17180-59a6-11ea-84bb-17f90097bd14.png)
