### PR TITLE
Solve the problem of core dumped when using large-scale data in bench…

### DIFF
--- a/benchmark/linpack.c
+++ b/benchmark/linpack.c
@@ -186,7 +186,7 @@ int main(int argc, char *argv[]){
 
     for(j = 0; j < m; j++){
       for(i = 0; i < m * COMPSIZE; i++){
-	a[i + j * m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
+	a[(long)i + (long)j * (long)m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
       }
     }
 
@@ -194,7 +194,7 @@ int main(int argc, char *argv[]){
 
     for (j = 0; j < m; ++j) {
       for (i = 0; i < m * COMPSIZE; ++i) {
-	b[i] += a[i + j * m * COMPSIZE];
+	b[i] += a[(long)i + (long)j * (long)m * COMPSIZE];
       }
     }
 


### PR DESCRIPTION
…mark test


Segmentation fault (core dumped)
Because i+j*m has exceeded the maximum range of int