### PR TITLE
Solve the problem of core dumped when using large-scale data in bench…

### DIFF
--- a/benchmark/syr2k.c
+++ b/benchmark/syr2k.c
@@ -175,9 +175,9 @@ int main(int argc, char *argv[]){
 
     for(j = 0; j < m; j++){
       for(i = 0; i < m * COMPSIZE; i++){
-	a[i + j * m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
-	b[i + j * m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
-	c[i + j * m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
+	a[(long)i + (long)j * (long)m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
+	b[(long)i + (long)j * (long)m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
+	c[(long)i + (long)j * (long)m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
       }
     }
 


### PR DESCRIPTION
…mark test

E.g ：  when running test calse such as below in benchmark:
 ./ssyr2k.goto 100000 100000 100000
From : 100000  To : 100000 Step = 100000 Uplo = U Trans = N
   SIZE       Flops
 100000 : Segmentation fault (core dumped)
Because i+j*m has exceeded the maximum range of int

![image](https://user-images.githubusercontent.com/32100330/75450762-5b579400-59aa-11ea-9ba4-b959d041dd15.png)