### PR TITLE
Solve the problem of core dumped when using large-scale data in bench…

### DIFF
--- a/benchmark/trmm.c
+++ b/benchmark/trmm.c
@@ -175,8 +175,8 @@ int main(int argc, char *argv[]){
 
     for(j = 0; j < m; j++){
       for(i = 0; i < m * COMPSIZE; i++){
-	a[i + j * m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
-	b[i + j * m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
+	a[(long)i + (long)j * (long)m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
+	b[(long)i + (long)j * (long)m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
       }
     }
 


### PR DESCRIPTION
…mark test

E.g ：  when running test calse such as below in benchmark:
 ./strmm.goto 100000 100000 100000
From : 100000  To : 100000 Step = 100000 Side = L Uplo = U Trans = N Diag = U
   SIZE       Flops
 100000 : Segmentation fault (core dumped)
Because i+j*m has exceeded the maximum range of int

![image](https://user-images.githubusercontent.com/32100330/75451423-80003b80-59ab-11ea-8017-37796142cccd.png)
