### PR TITLE
Update benchmark statistical time function

### DIFF
--- a/benchmark/axpy.c
+++ b/benchmark/axpy.c
@@ -128,7 +128,7 @@ int main(int argc, char *argv[]){
   int to   = 200;
   int step =   1;
 
-  struct timeval start, stop;
+  struct timespec start, stop;
   double time1,timeg;
 
   argc--;argv++;
@@ -175,13 +175,13 @@ int main(int argc, char *argv[]){
    	for(i = 0; i < m * COMPSIZE * abs(inc_y); i++){
 			y[i] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
    	}
-    	gettimeofday( &start, (struct timezone *)0);
+    	clock_gettime( CLOCK_REALTIME, &start);
 
     	AXPY (&m, alpha, x, &inc_x, y, &inc_y );
 
-    	gettimeofday( &stop, (struct timezone *)0);
+    	clock_gettime( CLOCK_REALTIME, &stop);
 
-    	time1 = (double)(stop.tv_sec - start.tv_sec) + (double)((stop.tv_usec - start.tv_usec)) * 1.e-6;
+    	time1 = (double)(stop.tv_sec - start.tv_sec) + (double)((stop.tv_nsec - start.tv_nsec)) * 1.e-9;
 
 	timeg += time1;
 
@@ -190,7 +190,7 @@ int main(int argc, char *argv[]){
     timeg /= loops;
 
     fprintf(stderr,
-	    " %10.2f MFlops %10.6f sec\n",
+	    " %10.2f MFlops %10.9f sec\n",
 	    COMPSIZE * COMPSIZE * 2. * (double)m / timeg * 1.e-6, timeg);
 
   }


### PR DESCRIPTION
The function gettimeofday does not count the time，when testing the small data volume usecase of axpy.
![old](https://user-images.githubusercontent.com/58972037/75651638-ef1fad80-5c93-11ea-8e64-a8929200e216.PNG)

Use the function clock_gettime to replace the gettimeofday function to count the time.

![new](https://user-images.githubusercontent.com/58972037/75651646-f777e880-5c93-11ea-92b9-e6c7747bf4eb.PNG)
