### PR TITLE
Fix potential index overflows at large matrix sizes in the benchmark codes

### DIFF
--- a/benchmark/cholesky.c
+++ b/benchmark/cholesky.c
@@ -173,46 +173,46 @@ int main(int argc, char *argv[]){
 #ifndef COMPLEX
       if (uplos & 1) {
 	for (j = 0; j < m; j++) {
-	  for(i = 0; i < j; i++)     a[i + j * m] = 0.;
-	                             a[j + j * m] = ((double) rand() / (double) RAND_MAX) + 8.;
-	  for(i = j + 1; i < m; i++) a[i + j * m] = ((double) rand() / (double) RAND_MAX) - 0.5;
+	  for(i = 0; i < j; i++)     a[(long)i + (long)j * (long)m] = 0.;
+	                             a[(long)j + (long)j * (long)m] = ((double) rand() / (double) RAND_MAX) + 8.;
+	  for(i = j + 1; i < m; i++) a[(long)i + (long)j * (long)m] = ((double) rand() / (double) RAND_MAX) - 0.5;
 	}
       } else {
 	for (j = 0; j < m; j++) {
-	  for(i = 0; i < j; i++)     a[i + j * m] = ((double) rand() / (double) RAND_MAX) - 0.5;
-	                             a[j + j * m] = ((double) rand() / (double) RAND_MAX) + 8.;
-	  for(i = j + 1; i < m; i++) a[i + j * m] = 0.;
+	  for(i = 0; i < j; i++)     a[(long)i + (long)j * (long)m] = ((double) rand() / (double) RAND_MAX) - 0.5;
+	                             a[(long)j + (long)j * (long)m] = ((double) rand() / (double) RAND_MAX) + 8.;
+	  for(i = j + 1; i < m; i++) a[(long)i + (long)j * (long)m] = 0.;
 	}
       }
 #else
       if (uplos & 1) {
 	for (j = 0; j < m; j++) {
 	  for(i = 0; i < j; i++) {
-	    a[(i + j * m) * 2 + 0] = 0.;
-	    a[(i + j * m) * 2 + 1] = 0.;
+	    a[((long)i + (long)j * (long)m) * 2 + 0] = 0.;
+	    a[((long)i + (long)j * (long)m) * 2 + 1] = 0.;
 	  }
 
-	  a[(j + j * m) * 2 + 0] = ((double) rand() / (double) RAND_MAX) + 8.;
-	  a[(j + j * m) * 2 + 1] = 0.;
+	  a[((long)j + (long)j * (long)m) * 2 + 0] = ((double) rand() / (double) RAND_MAX) + 8.;
+	  a[((long)j + (long)j * (long)m) * 2 + 1] = 0.;
 
 	  for(i = j + 1; i < m; i++) {
-	    a[(i + j * m) * 2 + 0] = ((double) rand() / (double) RAND_MAX) - 0.5;
-	    a[(i + j * m) * 2 + 1] = ((double) rand() / (double) RAND_MAX) - 0.5;
+	    a[((long)i + (long)j * (long)m) * 2 + 0] = ((double) rand() / (double) RAND_MAX) - 0.5;
+	    a[((long)i + (long)j * (long)m) * 2 + 1] = ((double) rand() / (double) RAND_MAX) - 0.5;
 	  }
 	}
       } else {
 	for (j = 0; j < m; j++) {
 	  for(i = 0; i < j; i++) {
-	    a[(i + j * m) * 2 + 0] = ((double) rand() / (double) RAND_MAX) - 0.5;
-	    a[(i + j * m) * 2 + 1] = ((double) rand() / (double) RAND_MAX) - 0.5;
+	    a[((long)i + (long)j * (long)m) * 2 + 0] = ((double) rand() / (double) RAND_MAX) - 0.5;
+	    a[((long)i + (long)j * (long)m) * 2 + 1] = ((double) rand() / (double) RAND_MAX) - 0.5;
 	  }
 
-	  a[(j + j * m) * 2 + 0] = ((double) rand() / (double) RAND_MAX) + 8.;
-	  a[(j + j * m) * 2 + 1] = 0.;
+	  a[((long)j + (long)j * (long)m) * 2 + 0] = ((double) rand() / (double) RAND_MAX) + 8.;
+	  a[((long)j + (long)j * (long)m) * 2 + 1] = 0.;
 
 	  for(i = j + 1; i < m; i++) {
-	    a[(i + j * m) * 2 + 0] = 0.;
-	    a[(i + j * m) * 2 + 1] = 0.;
+	    a[((long)i + (long)j * (long)m) * 2 + 0] = 0.;
+	    a[((long)i + (long)j * (long)m) * 2 + 1] = 0.;
 	  }
 	}
       }
@@ -239,10 +239,13 @@ int main(int argc, char *argv[]){
 	for (j = 0; j < m; j++) {
 	  for(i = 0; i <= j; i++) {
 #ifndef COMPLEX
-	    if (maxerr < fabs(a[i + j * m] - b[i + j * m])) maxerr = fabs(a[i + j * m] - b[i + j * m]);
+	    if (maxerr < fabs(a[(long)i + (long)j * (long)m] - b[(long)i + (long)j * (long)m]))
+	        maxerr = fabs(a[(long)i + (long)j * (long)m] - b[(long)i + (long)j * (long)m]);
 #else
-	    if (maxerr < fabs(a[(i + j * m) * 2 + 0] - b[(i + j * m) * 2 + 0])) maxerr = fabs(a[(i + j * m) * 2 + 0] - b[(i + j * m) * 2 + 0]);
-	    if (maxerr < fabs(a[(i + j * m) * 2 + 1] - b[(i + j * m) * 2 + 1])) maxerr = fabs(a[(i + j * m) * 2 + 1] - b[(i + j * m) * 2 + 1]);
+	    if (maxerr < fabs(a[((long)i + (long)j * (long)m) * 2 + 0] - b[((long)i + (long)j * (long)m) * 2 + 0]))
+	        maxerr = fabs(a[((long)i + (long)j * (long)m) * 2 + 0] - b[((long)i + (long)j * (long)m) * 2 + 0]);
+	    if (maxerr < fabs(a[((long)i + (long)j * (long)m) * 2 + 1] - b[((long)i + (long)j * (long)m) * 2 + 1]))
+	        maxerr = fabs(a[((long)i + (long)j * (long)m) * 2 + 1] - b[((long)i + (long)j * (long)m) * 2 + 1]);
 #endif
 	  }
 	}
@@ -250,10 +253,13 @@ int main(int argc, char *argv[]){
 	for (j = 0; j < m; j++) {
 	  for(i = j; i < m; i++) {
 #ifndef COMPLEX
-	    if (maxerr < fabs(a[i + j * m] - b[i + j * m])) maxerr = fabs(a[i + j * m] - b[i + j * m]);
+	    if (maxerr < fabs(a[(long)i + (long)j * (long)m] - b[(long)i + (long)j * (long)m]))
+	        maxerr = fabs(a[(long)i + (long)j * (long)m] - b[(long)i + (long)j * (long)m]);
 #else
-	    if (maxerr < fabs(a[(i + j * m) * 2 + 0] - b[(i + j * m) * 2 + 0])) maxerr = fabs(a[(i + j * m) * 2 + 0] - b[(i + j * m) * 2 + 0]);
-	    if (maxerr < fabs(a[(i + j * m) * 2 + 1] - b[(i + j * m) * 2 + 1])) maxerr = fabs(a[(i + j * m) * 2 + 1] - b[(i + j * m) * 2 + 1]);
+	    if (maxerr < fabs(a[((long)i + (long)j * (long)m) * 2 + 0] - b[((long)i + (long)j * (long)m) * 2 + 0]))
+	        maxerr = fabs(a[((long)i + (long)j * (long)m) * 2 + 0] - b[((long)i + (long)j * (long)m) * 2 + 0]);
+	    if (maxerr < fabs(a[((long)i + (long)j * (long)m) * 2 + 1] - b[((long)i + (long)j * (long)m) * 2 + 1]))
+	        maxerr = fabs(a[((long)i + (long)j * (long)m) * 2 + 1] - b[((long)i + (long)j * (long)m) * 2 + 1]);
 #endif
 	  }
 	}

--- a/benchmark/geev.c
+++ b/benchmark/geev.c
@@ -195,7 +195,7 @@ int main(int argc, char *argv[]){
 
     for(j = 0; j < to; j++){
       for(i = 0; i < to * COMPSIZE; i++){
-	a[i + j * to * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
+	a[(long)i + (long)j * (long)to * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
       }
     }
 

--- a/benchmark/gemm3m.c
+++ b/benchmark/gemm3m.c
@@ -181,9 +181,9 @@ int main(int argc, char *argv[]){
   
     	for(j = 0; j < m; j++){
       		for(i = 0; i < m * COMPSIZE; i++){
-			a[i + j * m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
-			b[i + j * m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
-			c[i + j * m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
+			a[(long)i + (long)j * (long)m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
+			b[(long)i + (long)j * (long)m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
+			c[(long)i + (long)j * (long)m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
       		}
     	}
 

--- a/benchmark/gemv.c
+++ b/benchmark/gemv.c
@@ -197,7 +197,7 @@ int main(int argc, char *argv[]){
    		fprintf(stderr, " %6dx%d : ", (int)m,(int)n);
    		for(j = 0; j < m; j++){
       			for(i = 0; i < n * COMPSIZE; i++){
-				a[j + i * m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
+				a[(long)j + (long)i * (long)m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
       			}
    		}
 
@@ -234,7 +234,7 @@ int main(int argc, char *argv[]){
    		fprintf(stderr, " %6dx%d : ", (int)m,(int)n);
    		for(j = 0; j < m; j++){
       			for(i = 0; i < n * COMPSIZE; i++){
-				a[j + i * m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
+				a[(long)j + (long)i * (long)m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
       			}
    		}
 

--- a/benchmark/ger.c
+++ b/benchmark/ger.c
@@ -182,7 +182,7 @@ int main(int argc, char *argv[]){
 
    for(j = 0; j < m; j++){
       		for(i = 0; i < n * COMPSIZE; i++){
-			a[i + j * m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
+			a[(long)i + (long)j * (long)m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
       		}
    }
 

--- a/benchmark/gesv.c
+++ b/benchmark/gesv.c
@@ -177,20 +177,20 @@ int main(int argc, char *argv[]){
 
     for(j = 0; j < m; j++){
       for(i = 0; i < m * COMPSIZE; i++){
-	a[i + j * m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
+	a[(long)i + (long)j * (long)m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
       }
     }
 
     for(j = 0; j < m; j++){
       for(i = 0; i < m * COMPSIZE; i++){
-	b[i + j * m * COMPSIZE] = 0.0;
+	b[(long)i + (long)j * (long)m * COMPSIZE] = 0.0;
       }
     }
 
 
     for (j = 0; j < m; ++j) {
       for (i = 0; i < m * COMPSIZE; ++i) {
-	b[i] += a[i + j * m * COMPSIZE];
+	b[i] += a[(long)i + (long)j * (long)m * COMPSIZE];
       }
     }
 

--- a/benchmark/getri.c
+++ b/benchmark/getri.c
@@ -172,7 +172,7 @@ int main(int argc, char *argv[]){
 
     for(j = 0; j < to; j++){
       for(i = 0; i < to * COMPSIZE; i++){
-	a[i + j * to * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
+	a[(long)i + (long)j * (long)to * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
       }
     }
 

--- a/benchmark/hemm.c
+++ b/benchmark/hemm.c
@@ -164,9 +164,9 @@ int main(int argc, char *argv[]){
 
     for(j = 0; j < m; j++){
       for(i = 0; i < m * COMPSIZE; i++){
-	a[i + j * m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
-	b[i + j * m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
-	c[i + j * m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
+	a[(long)i + (long)j * (long)m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
+	b[(long)i + (long)j * (long)m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
+	c[(long)i + (long)j * (long)m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
       }
     }
 

--- a/benchmark/hemv.c
+++ b/benchmark/hemv.c
@@ -167,7 +167,7 @@ int main(int argc, char *argv[]){
 
    for(j = 0; j < m; j++){
       		for(i = 0; i < m * COMPSIZE; i++){
-			a[i + j * m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
+			a[(long)i + (long)j * (long)m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
       		}
    }
 

--- a/benchmark/her2k.c
+++ b/benchmark/her2k.c
@@ -163,9 +163,9 @@ int main(int argc, char *argv[]){
 
     for(j = 0; j < m; j++){
       for(i = 0; i < m * COMPSIZE; i++){
-	a[i + j * m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
-	b[i + j * m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
-	c[i + j * m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
+	a[(long)i + (long)j * (long)m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
+	b[(long)i + (long)j * (long)m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
+	c[(long)i + (long)j * (long)m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
       }
     }
 

--- a/benchmark/herk.c
+++ b/benchmark/herk.c
@@ -162,8 +162,8 @@ int main(int argc, char *argv[]){
 
     for(j = 0; j < m; j++){
       for(i = 0; i < m * COMPSIZE; i++){
-	a[i + j * m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
-	c[i + j * m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
+	a[(long)i + (long)j * (long)m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
+	c[(long)i + (long)j * (long)m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
       }
     }
 

--- a/benchmark/linpack.c
+++ b/benchmark/linpack.c
@@ -186,7 +186,7 @@ int main(int argc, char *argv[]){
 
     for(j = 0; j < m; j++){
       for(i = 0; i < m * COMPSIZE; i++){
-	a[i + j * m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
+	a[(long)i + (long)j * (long)m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
       }
     }
 
@@ -194,7 +194,7 @@ int main(int argc, char *argv[]){
 
     for (j = 0; j < m; ++j) {
       for (i = 0; i < m * COMPSIZE; ++i) {
-	b[i] += a[i + j * m * COMPSIZE];
+	b[i] += a[(long)i + (long)j * (long)m * COMPSIZE];
       }
     }
 

--- a/benchmark/potrf.c
+++ b/benchmark/potrf.c
@@ -170,46 +170,46 @@ int main(int argc, char *argv[]){
 #ifndef COMPLEX
       if (uplos & 1) {
 	for (j = 0; j < m; j++) {
-	  for(i = 0; i < j; i++)     a[i + j * m] = 0.;
-	                             a[j + j * m] = ((double) rand() / (double) RAND_MAX) + 8.;
-	  for(i = j + 1; i < m; i++) a[i + j * m] = ((double) rand() / (double) RAND_MAX) - 0.5;
+	  for(i = 0; i < j; i++)     a[(long)i + (long)j * (long)m] = 0.;
+	                             a[(long)j + (long)j * (long)m] = ((double) rand() / (double) RAND_MAX) + 8.;
+	  for(i = j + 1; i < m; i++) a[(long)i + (long)j * (long)m] = ((double) rand() / (double) RAND_MAX) - 0.5;
 	}
       } else {
 	for (j = 0; j < m; j++) {
-	  for(i = 0; i < j; i++)     a[i + j * m] = ((double) rand() / (double) RAND_MAX) - 0.5;
-	                             a[j + j * m] = ((double) rand() / (double) RAND_MAX) + 8.;
-	  for(i = j + 1; i < m; i++) a[i + j * m] = 0.;
+	  for(i = 0; i < j; i++)     a[(long)i + (long)j * (long)m] = ((double) rand() / (double) RAND_MAX) - 0.5;
+	                             a[(long)j + (long)j * (long)m] = ((double) rand() / (double) RAND_MAX) + 8.;
+	  for(i = j + 1; i < m; i++) a[(long)i + (long)j * (long)m] = 0.;
 	}
       }
 #else
       if (uplos & 1) {
 	for (j = 0; j < m; j++) {
 	  for(i = 0; i < j; i++) {
-	    a[(i + j * m) * 2 + 0] = 0.;
-	    a[(i + j * m) * 2 + 1] = 0.;
+	    a[((long)i + (long)j * (long)m) * 2 + 0] = 0.;
+	    a[((long)i + (long)j * (long)m) * 2 + 1] = 0.;
 	  }
 
-	  a[(j + j * m) * 2 + 0] = ((double) rand() / (double) RAND_MAX) + 8.;
-	  a[(j + j * m) * 2 + 1] = 0.;
+	  a[((long)j + (long)j * (long)m) * 2 + 0] = ((double) rand() / (double) RAND_MAX) + 8.;
+	  a[((long)j + (long)j * (long)m) * 2 + 1] = 0.;
 
 	  for(i = j + 1; i < m; i++) {
-	    a[(i + j * m) * 2 + 0] = ((double) rand() / (double) RAND_MAX) - 0.5;
-	    a[(i + j * m) * 2 + 1] = ((double) rand() / (double) RAND_MAX) - 0.5;
+	    a[((long)i + (long)j * (long)m) * 2 + 0] = ((double) rand() / (double) RAND_MAX) - 0.5;
+	    a[((long)i + (long)j * (long)m) * 2 + 1] = ((double) rand() / (double) RAND_MAX) - 0.5;
 	  }
 	}
       } else {
 	for (j = 0; j < m; j++) {
 	  for(i = 0; i < j; i++) {
-	    a[(i + j * m) * 2 + 0] = ((double) rand() / (double) RAND_MAX) - 0.5;
-	    a[(i + j * m) * 2 + 1] = ((double) rand() / (double) RAND_MAX) - 0.5;
+	    a[((long)i + (long)j * (long)m) * 2 + 0] = ((double) rand() / (double) RAND_MAX) - 0.5;
+	    a[((long)i + (long)j * (long)m) * 2 + 1] = ((double) rand() / (double) RAND_MAX) - 0.5;
 	  }
 
-	  a[(j + j * m) * 2 + 0] = ((double) rand() / (double) RAND_MAX) + 8.;
-	  a[(j + j * m) * 2 + 1] = 0.;
+	  a[((long)j + (long)j * (long)m) * 2 + 0] = ((double) rand() / (double) RAND_MAX) + 8.;
+	  a[((long)j + (long)j * (long)m) * 2 + 1] = 0.;
 
 	  for(i = j + 1; i < m; i++) {
-	    a[(i + j * m) * 2 + 0] = 0.;
-	    a[(i + j * m) * 2 + 1] = 0.;
+	    a[((long)i + (long)j * (long)m) * 2 + 0] = 0.;
+	    a[((long)i + (long)j * (long)m) * 2 + 1] = 0.;
 	  }
 	}
       }

--- a/benchmark/symm.c
+++ b/benchmark/symm.c
@@ -175,9 +175,9 @@ int main(int argc, char *argv[]){
 
     for(j = 0; j < m; j++){
       for(i = 0; i < m * COMPSIZE; i++){
-	a[i + j * m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
-	b[i + j * m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
-	c[i + j * m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
+	a[(long)i + (long)j * (long)m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
+	b[(long)i + (long)j * (long)m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
+	c[(long)i + (long)j * (long)m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
       }
     }
 

--- a/benchmark/symv.c
+++ b/benchmark/symv.c
@@ -177,7 +177,7 @@ int main(int argc, char *argv[]){
 
    for(j = 0; j < m; j++){
       		for(i = 0; i < m * COMPSIZE; i++){
-			a[i + j * m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
+			a[(long)i + (long)j * (long)m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
       		}
    }
 

--- a/benchmark/syr2k.c
+++ b/benchmark/syr2k.c
@@ -175,9 +175,9 @@ int main(int argc, char *argv[]){
 
     for(j = 0; j < m; j++){
       for(i = 0; i < m * COMPSIZE; i++){
-	a[i + j * m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
-	b[i + j * m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
-	c[i + j * m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
+	a[(long)i + (long)j * (long)m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
+	b[(long)i + (long)j * (long)m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
+	c[(long)i + (long)j * (long)m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
       }
     }
 

--- a/benchmark/syrk.c
+++ b/benchmark/syrk.c
@@ -172,8 +172,8 @@ int main(int argc, char *argv[]){
 
     for(j = 0; j < m; j++){
       for(i = 0; i < m * COMPSIZE; i++){
-	a[i + j * m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
-	c[i + j * m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
+	a[(long)i + (long)j * (long)m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
+	c[(long)i + (long)j * (long)m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
       }
     }
 

--- a/benchmark/trmm.c
+++ b/benchmark/trmm.c
@@ -175,8 +175,8 @@ int main(int argc, char *argv[]){
 
     for(j = 0; j < m; j++){
       for(i = 0; i < m * COMPSIZE; i++){
-	a[i + j * m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
-	b[i + j * m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
+	a[(long)i + (long)j * (long)m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
+	b[(long)i + (long)j * (long)m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
       }
     }
 

--- a/benchmark/trsm.c
+++ b/benchmark/trsm.c
@@ -191,8 +191,8 @@ int main(int argc, char *argv[]){
 
    		 for(j = 0; j < m; j++){
       			for(i = 0; i < m * COMPSIZE; i++){
-				a[i + j * m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
-				b[i + j * m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
+				a[(long)i + (long)j * (long)m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
+				b[(long)i + (long)j * (long)m * COMPSIZE] = ((FLOAT) rand() / (FLOAT) RAND_MAX) - 0.5;
       		 	}
     		 }
 


### PR DESCRIPTION
Hello!
First of all, i tried the way as you said before with DINTERFACE64=1 when i am building the Openblas,but it doesn't work in my Arm server (the core dumped error as the same before,it is still exits)，i have no ideal about that. secondly, it seems a bit inconvenient when users building the Openblas must be added the arg every time. so, all of the files have be modified and tested by ctest, the result show all passed. BTW, thanks for your suggestion bundle them as one PR. please review these changes , thanks.