### PR TITLE
Fix DYNAMIC_ARCH build for POWER9

### DIFF
--- a/Makefile.system
+++ b/Makefile.system
@@ -327,7 +327,6 @@ ifeq ($(C_COMPILER), GCC)
 #Version tests for supporting specific features (MS_ABI, POWER9 intrinsics)
 GCCVERSIONGTEQ4 := $(shell expr `$(CC) -dumpversion | cut -f1 -d.` \>= 4)
 GCCVERSIONGT4 := $(shell expr `$(CC) -dumpversion | cut -f1 -d.` \> 4)
-GCCVERSIONGT5 := $(shell expr `$(CC) -dumpversion | cut -f1 -d.` \> 5)
 GCCVERSIONGTEQ7 := $(shell expr `$(CC) -dumpversion | cut -f1 -d.` \>= 7)
 GCCVERSIONGTEQ9 := $(shell expr `$(CC) -dumpversion | cut -f1 -d.` \>= 9)
 GCCMINORVERSIONGTEQ7 := $(shell expr `$(CC) -dumpversion | cut -f2 -d.` \>= 7)
@@ -575,6 +574,7 @@ ifneq ($(C_COMPILER), GCC)
 DYNAMIC_CORE += POWER9
 endif
 ifeq ($(C_COMPILER), GCC)
+GCCVERSIONGT5 := $(shell expr `$(CC) -dumpversion | cut -f1 -d.` \> 5)
 ifeq ($(GCCVERSIONGT5), 1)
 DYNAMIC_CORE += POWER9
 else

--- a/driver/others/dynamic_power.c
+++ b/driver/others/dynamic_power.c
@@ -3,7 +3,7 @@
 
 extern gotoblas_t gotoblas_POWER6;
 extern gotoblas_t gotoblas_POWER8;
-#if (!defined C_GCC) || (GCC_VERSION >= 60000)
+#if (!defined __GNUC__) || ( __GNUC__ >= 6)
 extern gotoblas_t gotoblas_POWER9;
 #endif
 
@@ -21,7 +21,7 @@ static char *corename[] = {
 char *gotoblas_corename(void) {
 	if (gotoblas == &gotoblas_POWER6)	return corename[1];
 	if (gotoblas == &gotoblas_POWER8)	return corename[2];
-#if (!defined C_GCC) || (GCC_VERSION >= 60000)
+#if (!defined __GNUC__) || ( __GNUC__ >= 6)
 	if (gotoblas == &gotoblas_POWER9)	return corename[3];
 #endif
 	return corename[0];
@@ -33,7 +33,7 @@ static gotoblas_t *get_coretype(void) {
 		return &gotoblas_POWER6;
 	if (__builtin_cpu_is("power8"))
 		return &gotoblas_POWER8;
-#if (!defined C_GCC) || (GCC_VERSION >= 60000)
+#if (!defined __GNUC__) || ( __GNUC__ >= 6)
 	if (__builtin_cpu_is("power9"))
 		return &gotoblas_POWER9;
 #endif
@@ -59,7 +59,7 @@ static gotoblas_t *force_coretype(char * coretype) {
 	{
 	case  1: return (&gotoblas_POWER6);
 	case  2: return (&gotoblas_POWER8);
-#if (!defined C_GCC) || (GCC_VERSION >= 60000)
+#if (!defined __GNUC__) || ( __GNUC__ >= 6)
 	case  3: return (&gotoblas_POWER9);
 #endif
 	default: return NULL;

--- a/kernel/power/caxpy_power9.S
+++ b/kernel/power/caxpy_power9.S
@@ -13,7 +13,11 @@
 
 	PROLOGUE
 
+#ifdef CONJ
+caxpyc_k:
+#else
 caxpy_k:
+#endif
 .LCF0:
 0:	addis 2,12,.TOC.-.LCF0@ha
 	addi 2,2,.TOC.-.LCF0@l

--- a/kernel/power/icamax_power9.S
+++ b/kernel/power/icamax_power9.S
@@ -1,3 +1,4 @@
+/*
 	.file	"icamax.c"
 	.abiversion 2
 	.section	".text"
@@ -5,6 +6,12 @@
 	.p2align 4,,15
 	.globl icamax_k
 	.type	icamax_k, @function
+*/
+#define ASSEMBLER
+#include "common.h"
+
+        PROLOGUE
+
 icamax_k:
 .LCF0:
 0:	addis 2,12,.TOC.-.LCF0@ha

--- a/kernel/power/icamin_power9.S
+++ b/kernel/power/icamin_power9.S
@@ -1,3 +1,4 @@
+/*
 	.file	"icamin.c"
 	.abiversion 2
 	.section	".text"
@@ -5,6 +6,12 @@
 	.p2align 4,,15
 	.globl icamin_k
 	.type	icamin_k, @function
+*/
+#define ASSEMBLER
+#include "common.h"
+
+        PROLOGUE
+
 icamin_k:
 .LCF0:
 0:	addis 2,12,.TOC.-.LCF0@ha

--- a/kernel/power/isamax_power9.S
+++ b/kernel/power/isamax_power9.S
@@ -1,3 +1,4 @@
+/*
 	.file	"isamax.c"
 	.abiversion 2
 	.section	".text"
@@ -5,6 +6,12 @@
 	.p2align 4,,15
 	.globl isamax_k
 	.type	isamax_k, @function
+*/
+#define ASSEMBLER
+#include "common.h"
+
+        PROLOGUE
+
 isamax_k:
 .LCF0:
 0:	addis 2,12,.TOC.-.LCF0@ha

--- a/kernel/power/isamin_power9.S
+++ b/kernel/power/isamin_power9.S
@@ -1,3 +1,4 @@
+/*
 	.file	"isamin.c"
 	.abiversion 2
 	.section	".text"
@@ -5,6 +6,12 @@
 	.p2align 4,,15
 	.globl isamin_k
 	.type	isamin_k, @function
+*/
+#define ASSEMBLER
+#include "common.h"
+
+        PROLOGUE
+
 isamin_k:
 .LCF0:
 0:	addis 2,12,.TOC.-.LCF0@ha


### PR DESCRIPTION
Setting DYNAMIC_ARCH=1 on POWER9 does not build POWER9 files due to some
compiler version checks.  This patch fixes some of the macros that are used
to check compiler version.  On fixing those checks, there are some new make
failures related to icamin, icamax, isamin, isamax and caxpy files on POWER9.
This patch fixes those failures as well.