### PR TITLE
Modify the main Makefile in OpenBLAS 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,11 +56,21 @@ ifneq ($(INTERFACE64), 0)
 	@echo "  Use 64 bits int    (equivalent to \"-i8\" in Fortran)      "
 endif
 endif
-	@cverinfo=`$(CC) --version | sed -n '1p'`; \
-	echo "  C compiler       ... $(C_COMPILER)  (cmd & version : $${cverinfo})"
+	@$(CC) --version > /dev/null 2>&1;\
+	if [ $$? -eq 0 ]; then \
+	   cverinfo=`$(CC) --version | sed -n '1p'`; \
+	   echo "  C compiler       ... $(C_COMPILER)  (cmd & version : $${cverinfo})";\
+	else  \
+	   echo "  C compiler       ... $(C_COMPILER)  (command line : $(CC))";\
+	fi
 ifeq ($(NOFORTRAN), $(filter 0,$(NOFORTRAN)))
-	@fverinfo=`$(FC) --version | sed -n '1p'`; \
-	echo "  Fortran compiler ... $(F_COMPILER)  (cmd & version : $${fverinfo})"
+	@$(FC) --version > /dev/null 2>&1;\
+	if [ $$? -eq 0 ]; then \
+	   fverinfo=`$(FC) --version | sed -n '1p'`; \
+	   echo "  Fortran compiler ... $(F_COMPILER)  (cmd & version : $${fverinfo})";\
+	else \
+	   echo "  Fortran compiler ... $(F_COMPILER)  (command line : $(FC))";\
+	fi
 endif
 ifneq ($(OSNAME), AIX)
 	@echo -n "  Library Name     ... $(LIBNAME)"

--- a/Makefile
+++ b/Makefile
@@ -56,10 +56,11 @@ ifneq ($(INTERFACE64), 0)
 	@echo "  Use 64 bits int    (equivalent to \"-i8\" in Fortran)      "
 endif
 endif
-
-	@echo "  C compiler       ... $(C_COMPILER)  (command line : $(CC))"
+	@cverinfo=`$(CC) --version | sed -n '1p'`; \
+	echo "  C compiler       ... $(C_COMPILER)  (cmd & version : $${cverinfo})"
 ifeq ($(NOFORTRAN), $(filter 0,$(NOFORTRAN)))
-	@echo "  Fortran compiler ... $(F_COMPILER)  (command line : $(FC))"
+	@fverinfo=`$(FC) --version | sed -n '1p'`; \
+	echo "  Fortran compiler ... $(F_COMPILER)  (cmd & version : $${fverinfo})"
 endif
 ifneq ($(OSNAME), AIX)
 	@echo -n "  Library Name     ... $(LIBNAME)"
@@ -68,9 +69,9 @@ else
 endif
 
 ifndef SMP
-	@echo " (Single threaded)  "
+	@echo " (Single-threading)  "
 else
-	@echo " (Multi threaded; Max num-threads is $(NUM_THREADS))"
+	@echo " (Multi-threading; Max num-threads is $(NUM_THREADS))"
 endif
 
 ifeq ($(USE_OPENMP), 1)


### PR DESCRIPTION
add c/fortran compiler version information in final note.
with these information , the user could know the exact verion for both c and fortran complier version which could avoid version conflict when there are more than two gcc tools in the complier environment.  especially the c complier using the command "cc" may lead to lots confusing actions while it links to the gcc the user don't intend to launch. the changed note the makefile show like this:
 OpenBLAS build complete. (BLAS CBLAS LAPACK LAPACKE)

  OS                       ... Linux
  Architecture        ... arm64
  BINARY               ... 64bit
  C compiler          ... GCC  (cmd & version : cc (GCC) 4.8.5 20150623 (Red Hat 4.8.5-39))
  Fortran compiler ... GFORTRAN  (cmd & version : GNU Fortran (GCC) 4.8.5 20150623 (Red Hat 4.8.5-39))
  Library Name      ... libopenblas_armv8p-r0.3.9.dev.a (Multi-threading; Max num-threads is 96)
