### PR TITLE
Fix  pr #2487 error

### DIFF
--- a/benchmark/spr.c
+++ b/benchmark/spr.c
@@ -187,7 +187,7 @@ int main(int argc, char *argv[]){
 	timeg /= loops;
 	 
     fprintf(stderr,
-	    " %10.2f MBytes %10.6f sec\n",
+	    " %10.2f MFlops %10.6f sec\n",
 	    COMPSIZE * COMPSIZE * 1. * (double)m * (double)m  / timeg * 1.e-6, timeg);
 
   }

--- a/benchmark/spr2.c
+++ b/benchmark/spr2.c
@@ -196,7 +196,7 @@ int main(int argc, char *argv[]){
     timeg /= loops;
 	 
     fprintf(stderr,
-	    " %10.2f MBytes %10.6f sec\n",
+	    " %10.2f MFlops %10.6f sec\n",
 	    COMPSIZE * COMPSIZE * 2. * (double)m * (double)m  / timeg * 1.e-6, timeg);
 
   }


### PR DESCRIPTION
In pr #2487,add benchmark for spr/spr2.
Wrong measurement unit used.
This pr fixed the error.