### PR TITLE
Apply fix for LAPACK issue 394 (fixed-form code beyond column 72)

### DIFF
--- a/lapack-netlib/SRC/sorhr_col.f
+++ b/lapack-netlib/SRC/sorhr_col.f
@@ -282,7 +282,8 @@
      $                   NPLUSONE
 *     ..
 *     .. External Subroutines ..
-      EXTERNAL           SCOPY, SLAORHR_COL_GETRFNP, SSCAL, STRSM, XERBLA
+      EXTERNAL           SCOPY, SLAORHR_COL_GETRFNP, SSCAL, STRSM,
+     $XERBLA
 *     ..
 *     .. Intrinsic Functions ..
       INTRINSIC          MAX, MIN


### PR DESCRIPTION
https://github.com/Reference-LAPACK/lapack/issues/394 , Intel fortran (and possibly others) failing to build LAPACK due to spurious XERBL symbol