### PR TITLE
[OpenBLAS]:fix the iamax benchmark error

### DIFF
--- a/benchmark/iamax.c
+++ b/benchmark/iamax.c
@@ -181,7 +181,7 @@ int main(int argc, char *argv[]){
     timeg /= loops;
 
     fprintf(stderr,
-	    " %10.2f MFlops %10.6f sec\n",
+	    " %10.2f MBytes %10.6f sec\n",
 	    COMPSIZE * sizeof(FLOAT) * 1. * (double)m / timeg * 1.e-6, timeg);
 
   }


### PR DESCRIPTION
[Description]:the result for i?amax is not MFlops, it is MBytes