### PR TITLE
Prevent attempts to run ctest or test when fortran is not available

### DIFF
--- a/ctest/Makefile
+++ b/ctest/Makefile
@@ -40,8 +40,11 @@ ztestl3o = c_zblas3.o c_z3chke.o auxiliary.o c_xerbla.o constant.o
 ztestl3o_3m = c_zblas3_3m.o c_z3chke_3m.o auxiliary.o c_xerbla.o constant.o
 
 
-
+ifeq ($(NOFORTRAN),1)
+all ::
+else
 all :: all1 all2 all3
+endif
 
 all1: xscblat1 xdcblat1 xccblat1 xzcblat1
 ifndef CROSS

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,7 +1,12 @@
 TOPDIR	= ..
 include ../Makefile.system
 
+
+ifeq ($(NOFORTRAN),1)
+all ::
+else
 all :: level1 level2 level3
+endif
 
 level1 : sblat1 dblat1 cblat1 zblat1
 ifndef CROSS


### PR DESCRIPTION
The main Makefile already handles this, but users or CI jobs may still try to call the tests directly.
Works around a current build failure on Travis where our ppc64 environment appears to have lost gfortran recently.