### PR TITLE
Avoid calling DIRECT codepath in DYNAMIC_ARCH on non-SKX

### DIFF
--- a/interface/gemm.c
+++ b/interface/gemm.c
@@ -272,6 +272,9 @@ void CNAME(enum CBLAS_ORDER order, enum CBLAS_TRANSPOSE TransA, enum CBLAS_TRANS
   PRINT_DEBUG_CNAME;
 
 #if !defined(COMPLEX) && !defined(DOUBLE) && defined(USE_SGEMM_KERNEL_DIRECT)
+#ifdef DYNAMIC_ARCH
+ if (gotoblas == &gotoblas_SKYLAKEX)
+#endif  
   if (beta == 0 && alpha == 1.0 && order == CblasRowMajor && TransA == CblasNoTrans && TransB == CblasNoTrans && sgemm_kernel_direct_performant(m,n,k)) {
 	sgemm_kernel_direct(m, n, k, a, lda, b, ldb, c, ldc);
 	return;


### PR DESCRIPTION
#2526 (possibly #2524 as well)