### PR TITLE
Do not deploy import libraries on Windows when NO_STATIC=1

### DIFF
--- a/Makefile.install
+++ b/Makefile.install
@@ -89,11 +89,17 @@ ifeq ($(OSNAME), Darwin)
 endif
 ifeq ($(OSNAME), WINNT)
 	@-cp $(LIBDLLNAME) "$(DESTDIR)$(OPENBLAS_BINARY_DIR)"
-	@-cp $(IMPLIBNAME) "$(DESTDIR)$(OPENBLAS_LIBRARY_DIR)"
 endif
 ifeq ($(OSNAME), CYGWIN_NT)
 	@-cp $(LIBDLLNAME) "$(DESTDIR)$(OPENBLAS_BINARY_DIR)"
+endif
+ifneq ($(NO_STATIC),1)
+ifeq ($(OSNAME), WINNT)
 	@-cp $(IMPLIBNAME) "$(DESTDIR)$(OPENBLAS_LIBRARY_DIR)"
+endif
+ifeq ($(OSNAME), CYGWIN_NT)
+	@-cp $(IMPLIBNAME) "$(DESTDIR)$(OPENBLAS_LIBRARY_DIR)"
+endif
 endif
 endif
 


### PR DESCRIPTION
Currently with NO_STATIC=1 and shared libs on, still a `dll.a` file is installed in `lib/`, which seems like an oversight.