### PR TITLE
Correct ifort options

### DIFF
--- a/Makefile.system
+++ b/Makefile.system
@@ -855,7 +855,7 @@ ifneq ($(INTERFACE64), 0)
 FCOMMON_OPT += -i8
 endif
 endif
-FCOMMON_OPT += -recursive
+FCOMMON_OPT += -recursive -fp-model strict -assume protect-parens
 ifeq ($(USE_OPENMP), 1)
 FCOMMON_OPT += -fopenmp
 endif


### PR DESCRIPTION
to same as suggested by reference-lapack
second part of fix for #2552 (missed in #2603)