### PR TITLE
Temporary workaround for excessive LAPACK test failures with COMPLEX on Skylake-X

### DIFF
--- a/kernel/x86_64/KERNEL.SKYLAKEX
+++ b/kernel/x86_64/KERNEL.SKYLAKEX
@@ -24,3 +24,6 @@ DGEMM_BETA = dgemm_beta_skylakex.c
 
 CGEMMKERNEL    =  cgemm_kernel_8x2_skylakex.c
 ZGEMMKERNEL    =  zgemm_kernel_4x2_skylakex.c
+
+CSCALKERNEL    = ../arm/zscal.c
+ZSCALKERNEL    = ../arm/zscal.c


### PR DESCRIPTION
Something in the plain C parts of x86_64 cscal.c and zscal.c appears to be miscompiled by both gfortran9 and ifort when compiling for skylakex-avx512, leading to some 40 (80) errors in the LAPACK testsuite for COMPLEX and COMPLEX16 respectively. The problem persists even when the optimized Haswell microkernel is explicitly disabled in the code, while the same source works fine when compiled for HASWELL.
cf #2552