### PR TITLE
BUG: Fix the loop range in ZHEEQUB.f

### DIFF
--- a/lapack-netlib/SRC/zheequb.f
+++ b/lapack-netlib/SRC/zheequb.f
@@ -271,7 +271,7 @@
          AVG = AVG / N
 
          STD = 0.0D0
-         DO I = N+1, N
+         DO I = N+1, 2*N
             WORK( I ) = S( I-N ) * WORK( I-N ) - AVG
          END DO
          CALL ZLASSQ( N, WORK( N+1 ), 1, SCALE, SUMSQ )


### PR DESCRIPTION
Closes #2633 

This is an early OpenBLAS fix for the LAPACK v3.9.0 bug reported in https://github.com/Reference-LAPACK/lapack/pull/408 