### PR TITLE
Fix OpenMP builds defaulting to singlethreading with OMP_PLACES or OMP_PROC_BIND set

### DIFF
--- a/common_thread.h
+++ b/common_thread.h
@@ -132,18 +132,18 @@ extern int blas_server_avail;
 static __inline int num_cpu_avail(int level) {
 
 #ifdef USE_OPENMP
-	int openmp_nthreads=0;
+	int openmp_nthreads=omp_get_max_threads();
 #endif
 
+#ifndef USE_OPENMP 
   if (blas_cpu_number == 1
-
-#ifdef USE_OPENMP
-      || omp_in_parallel()
 #endif
-      ) return 1;
+#ifdef USE_OPENMP
+     if (openmp_nthreads == 1 || omp_in_parallel()
+#endif
+      ) return 1;        
 
 #ifdef USE_OPENMP
-  openmp_nthreads=omp_get_max_threads();
   if (blas_cpu_number != openmp_nthreads) {
 	  goto_set_num_threads(openmp_nthreads);
   }


### PR DESCRIPTION
Always obey omp_get_max_threads() when build with USE_OPENMP