### PR TITLE
Add new linker option for POWER10

### DIFF
--- a/Makefile.system
+++ b/Makefile.system
@@ -617,6 +617,7 @@ DYNAMIC_CORE += POWER8
 ifneq ($(C_COMPILER), GCC)
 DYNAMIC_CORE += POWER9
 DYNAMIC_CORE += POWER10
+override LDFLAGS += -Wl,-no-power10-stubs
 endif
 ifeq ($(C_COMPILER), GCC)
 ifeq ($(GCCVERSIONGT5), 1)
@@ -626,9 +627,11 @@ $(info, OpenBLAS: Your gcc version is too old to build the POWER9 kernels.)
 endif
 ifeq ($(GCCVERSIONGTEQ11), 1)
 DYNAMIC_CORE += POWER10
-else ifeq ($(GCCVERSIONEQ10), 1)
+override LDFLAGS += -Wl,-no-power10-stubs
+else ifeq ($(GCCVERSIONGTEQ10), 1)
 ifeq ($(GCCMINORVERSIONGTEQ2), 1)
 DYNAMIC_CORE += POWER10
+override LDFLAGS += -Wl,-no-power10-stubs
 endif
 else
 $(info, OpenBLAS: Your gcc version is too old to build the POWER10 kernels.)


### PR DESCRIPTION
While building with DYNAMIC_ARCH on POWER9 with POWER10
aware toolchain, new LDFLAG is needed to avoid POWER10
instructions on PLT calls .