### PR TITLE
Unify BUFFER_SIZE settings for x86_64 again to fix DYNAMIC_ARCH crashes

### DIFF
--- a/common_x86_64.h
+++ b/common_x86_64.h
@@ -228,13 +228,7 @@ static __inline unsigned int blas_quickdivide(unsigned int x, unsigned int y){
 #define HUGE_PAGESIZE	( 2 << 20)
 
 #ifndef BUFFERSIZE
-#if defined(SKYLAKEX) 
-#define BUFFER_SIZE	(32 << 21)
-#elif defined(HASWELL) || defined(ZEN)
 #define BUFFER_SIZE	(32 << 22)
-#else
-#define BUFFER_SIZE	(32 << 20)
-#endif
 #else
 #define BUFFER_SIZE	(32 << BUFFERSIZE)
 #endif


### PR DESCRIPTION
DYNAMIC_ARCH builds with a default TARGET of PRESCOTT (or actually anything older than Haswell) would suffer random
crashes in GEMM at larger matrix sizes when run on Haswell, Zen or SkylakeX due to the larger BUFFER_SIZE constant for these targets. Fixes #2728