### PR TITLE
Protect against inadvertent activation of USE_CUDA

### DIFF
--- a/driver/others/Makefile
+++ b/driver/others/Makefile
@@ -47,7 +47,9 @@ endif
 endif
 
 ifdef USE_CUDA
+ifeq ($(USE_CUDA), 1)
 COMMONOBJS	+= cuda_init.$(SUFFIX)
+endif
 endif
 
 ifdef FUNCTION_PROFILE


### PR DESCRIPTION
this is old GotoBLAS code, probably not even useful in its present form...
fixes #2755