### PR TITLE
Fix GCC ubsan warnings in x86_64 complex dot and gemv_t kernels

### DIFF
--- a/kernel/x86_64/cdot.c
+++ b/kernel/x86_64/cdot.c
@@ -141,8 +141,8 @@ OPENBLAS_COMPLEX_FLOAT CNAME(BLASLONG n, FLOAT *x, BLASLONG inc_x, FLOAT *y, BLA
 		i=0;
 		ix=0;
 		iy=0;
-		inc_x <<= 1;
-		inc_y <<= 1;
+		inc_x *= 2;
+		inc_y *= 2;
 		while(i < n)
 		{
 

--- a/kernel/x86_64/cgemv_t_4.c
+++ b/kernel/x86_64/cgemv_t_4.c
@@ -233,9 +233,9 @@ int CNAME(BLASLONG m, BLASLONG n, BLASLONG dummy1, FLOAT alpha_r, FLOAT alpha_i,
         if ( m < 1 ) return(0);
         if ( n < 1 ) return(0);
 
-        inc_x <<= 1;
-        inc_y <<= 1;
-        lda   <<= 1;
+        inc_x *= 2;
+        inc_y *= 2;
+        lda   *= 2;
 	lda4    = lda << 2;
 
 	xbuffer = buffer;

--- a/kernel/x86_64/zdot.c
+++ b/kernel/x86_64/zdot.c
@@ -140,8 +140,8 @@ static void zdot_compute (BLASLONG n, FLOAT *x, BLASLONG inc_x, FLOAT *y, BLASLO
 		i=0;
 		ix=0;
 		iy=0;
-		inc_x <<= 1;
-		inc_y <<= 1;
+		inc_x *= 2;
+		inc_y *= 2;
 		while(i < n)
 		{
 

--- a/kernel/x86_64/zgemv_t_4.c
+++ b/kernel/x86_64/zgemv_t_4.c
@@ -235,9 +235,9 @@ int CNAME(BLASLONG m, BLASLONG n, BLASLONG dummy1, FLOAT alpha_r, FLOAT alpha_i,
         if ( m < 1 ) return(0);
         if ( n < 1 ) return(0);
 
-        inc_x <<= 1;
-        inc_y <<= 1;
-        lda   <<= 1;
+        inc_x *= 2;
+        inc_y *= 2;
+        lda  <<= 1;
 	lda4    = lda << 2;
 
 	xbuffer = buffer;


### PR DESCRIPTION
by replacing a left shift with the equivalent multiplication by 2
(to avoid invoking undefined behavior when the value happens to be less than zero, as seen in the BLAS tests).