### PR TITLE
Fix array overruns in the LIN part of the LAPACK testsuite

### DIFF
--- a/lapack-netlib/TESTING/LIN/cdrvls.f
+++ b/lapack-netlib/TESTING/LIN/cdrvls.f
@@ -372,13 +372,13 @@
                         END IF
 *                       Compute workspace needed for CGELSY
                         CALL CGELSY( M, N, NRHS, A, LDA, B, LDB,
-     $                               IWQ, RCOND, CRANK, WQ, -1, RWORK,
+     $                               IWQ, RCOND, CRANK, WQ, -1, RWQ,
      $                               INFO )
                         LWORK_CGELSY = INT( WQ( 1 ) )
                         LRWORK_CGELSY = 2*N
 *                       Compute workspace needed for CGELSS
                         CALL CGELSS( M, N, NRHS, A, LDA, B, LDB, S,
-     $                               RCOND, CRANK, WQ, -1, RWORK, INFO )
+     $                               RCOND, CRANK, WQ, -1, RWQ, INFO )
                         LWORK_CGELSS = INT( WQ( 1 ) )
                         LRWORK_CGELSS = 5*MNMIN
 *                       Compute workspace needed for CGELSD
@@ -564,7 +564,7 @@
                                  CALL CLARNV( 2, ISEED, NCOLS*NRHS,
      $                                        WORK )
                                  CALL CSCAL( NCOLS*NRHS,
-     $                                       ONE / REAL( NCOLS ), WORK,
+     $                                       CONE / REAL( NCOLS ), WORK,
      $                                       1 )
                               END IF
                               CALL CGEMM( TRANS, 'No transpose', NROWS,

--- a/lapack-netlib/TESTING/LIN/derrtsqr.f
+++ b/lapack-netlib/TESTING/LIN/derrtsqr.f
@@ -77,7 +77,7 @@
 *     ..
 *     .. Local Arrays ..
       DOUBLE PRECISION   A( NMAX, NMAX ), T( NMAX, NMAX ), W( NMAX ),
-     $                   C( NMAX, NMAX ), TAU(NMAX)
+     $                   C( NMAX, NMAX ), TAU(NMAX*2)
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           ALAESM, CHKXER, DGEQR,
@@ -137,6 +137,8 @@
 *
       TAU(1)=1
       TAU(2)=1
+      TAU(3)=1
+      TAU(4)=1
       SRNAMT = 'DGEMQR'
       NB=1
       INFOT = 1

--- a/lapack-netlib/TESTING/LIN/serrtsqr.f
+++ b/lapack-netlib/TESTING/LIN/serrtsqr.f
@@ -77,7 +77,7 @@
 *     ..
 *     .. Local Arrays ..
       REAL               A( NMAX, NMAX ), T( NMAX, NMAX ), W( NMAX ),
-     $                   C( NMAX, NMAX ), TAU(NMAX)
+     $                   C( NMAX, NMAX ), TAU(NMAX*2)
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           ALAESM, CHKXER, SGEQR,
@@ -137,6 +137,8 @@
 *
       TAU(1)=1
       TAU(2)=1
+      TAU(3)=1
+      TAU(4)=1
       SRNAMT = 'SGEMQR'
       NB=1
       INFOT = 1

--- a/lapack-netlib/TESTING/LIN/zdrvls.f
+++ b/lapack-netlib/TESTING/LIN/zdrvls.f
@@ -372,12 +372,12 @@
                         END IF
 *                       Compute workspace needed for ZGELSY
                         CALL ZGELSY( M, N, NRHS, A, LDA, B, LDB, IWQ,
-     $                               RCOND, CRANK, WQ, -1, RWORK, INFO )
+     $                               RCOND, CRANK, WQ, -1, RWQ, INFO )
                         LWORK_ZGELSY = INT( WQ( 1 ) )
                         LRWORK_ZGELSY = 2*N
 *                       Compute workspace needed for ZGELSS
                         CALL ZGELSS( M, N, NRHS, A, LDA, B, LDB, S,
-     $                               RCOND, CRANK, WQ, -1 , RWORK,
+     $                               RCOND, CRANK, WQ, -1 , RWQ,
      $                               INFO )
                         LWORK_ZGELSS = INT( WQ( 1 ) )
                         LRWORK_ZGELSS = 5*MNMIN
@@ -564,7 +564,7 @@
                                  CALL ZLARNV( 2, ISEED, NCOLS*NRHS,
      $                                        WORK )
                                  CALL ZSCAL( NCOLS*NRHS,
-     $                                       ONE / DBLE( NCOLS ), WORK,
+     $                                       CONE / DBLE( NCOLS ), WORK,
      $                                       1 )
                               END IF
                               CALL ZGEMM( TRANS, 'No transpose', NROWS,


### PR DESCRIPTION
https://github.com/Reference-LAPACK/lapack/pull/427 SGEMQR/DGEMQR try to read TAU(2) and TAU(3) as their MB and NB, so make TAU large enough (found by gcc asan)
https://github.com/Reference-LAPACK/lapack/pull/431 Correct arguments used in workspace queries and (C,Z)SCAL call