### PR TITLE
Fix various wrong calls to SLASET/DLASET in the EIG part of the LAPACK testsuite

### DIFF
--- a/lapack-netlib/TESTING/EIG/cchkhb2stg.f
+++ b/lapack-netlib/TESTING/EIG/cchkhb2stg.f
@@ -680,8 +680,8 @@
 *              the one from above. Compare it with D1 computed 
 *              using the DSBTRD.
 *            
-               CALL DLASET( 'Full', N, 1, ZERO, ZERO, SD, 1 )
-               CALL DLASET( 'Full', N, 1, ZERO, ZERO, SE, 1 )
+               CALL SLASET( 'Full', N, 1, ZERO, ZERO, SD, 1 )
+               CALL SLASET( 'Full', N, 1, ZERO, ZERO, SE, 1 )
                CALL CLACPY( ' ', K+1, N, A, LDA, U, LDU )
                LH = MAX(1, 4*N)
                LW = LWORK - LH
@@ -753,8 +753,8 @@
 *              the one from above. Compare it with D1 computed 
 *              using the DSBTRD. 
 *           
-               CALL DLASET( 'Full', N, 1, ZERO, ZERO, SD, 1 )
-               CALL DLASET( 'Full', N, 1, ZERO, ZERO, SE, 1 )
+               CALL SLASET( 'Full', N, 1, ZERO, ZERO, SD, 1 )
+               CALL SLASET( 'Full', N, 1, ZERO, ZERO, SE, 1 )
                CALL CLACPY( ' ', K+1, N, A, LDA, U, LDU )
                LH = MAX(1, 4*N)
                LW = LWORK - LH

--- a/lapack-netlib/TESTING/EIG/schksb2stg.f
+++ b/lapack-netlib/TESTING/EIG/schksb2stg.f
@@ -670,8 +670,8 @@
 *              the one from above. Compare it with D1 computed 
 *              using the SSBTRD.
 *            
-               CALL SLASET( 'Full', N, 1, ZERO, ZERO, SD, 1 )
-               CALL SLASET( 'Full', N, 1, ZERO, ZERO, SE, 1 )
+               CALL SLASET( 'Full', N, 1, ZERO, ZERO, SD, N )
+               CALL SLASET( 'Full', N, 1, ZERO, ZERO, SE, N )
                CALL SLACPY( ' ', K+1, N, A, LDA, U, LDU )
                LH = MAX(1, 4*N)
                LW = LWORK - LH

--- a/lapack-netlib/TESTING/EIG/schkst2stg.f
+++ b/lapack-netlib/TESTING/EIG/schkst2stg.f
@@ -999,8 +999,8 @@
 *           the one from above. Compare it with D1 computed 
 *           using the 1-stage.
 *
-            CALL SLASET( 'Full', N, 1, ZERO, ZERO, SD, 1 )
-            CALL SLASET( 'Full', N, 1, ZERO, ZERO, SE, 1 )
+            CALL SLASET( 'Full', N, 1, ZERO, ZERO, SD, N )
+            CALL SLASET( 'Full', N, 1, ZERO, ZERO, SE, N )
             CALL SLACPY( "U", N, N, A, LDA, V, LDU )
             LH = MAX(1, 4*N)
             LW = LWORK - LH


### PR DESCRIPTION
copied from Reference-LAPACK issues 425 and 429