### PR TITLE
Do not require pkg-config to generate the *.pc file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -389,11 +389,9 @@ if(NOT NO_LAPACKE)
 	install (FILES ${CMAKE_BINARY_DIR}/lapacke_mangling.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/openblas${SUFFIX64})
 endif()
 
-include(FindPkgConfig QUIET)
-if(PKG_CONFIG_FOUND)
-	configure_file(${PROJECT_SOURCE_DIR}/cmake/openblas.pc.in ${PROJECT_BINARY_DIR}/openblas${SUFFIX64}.pc @ONLY)
-	install (FILES ${PROJECT_BINARY_DIR}/openblas${SUFFIX64}.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig/)
-endif()
+# Install pkg-config files
+configure_file(${PROJECT_SOURCE_DIR}/cmake/openblas.pc.in ${PROJECT_BINARY_DIR}/openblas${SUFFIX64}.pc @ONLY)
+install (FILES ${PROJECT_BINARY_DIR}/openblas${SUFFIX64}.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig/)
 
 
 # GNUInstallDirs "DATADIR" wrong here; CMake search path wants "share".


### PR DESCRIPTION
Generating the pkg-config file does not actually depend on pkg-config being available, so we can always just generate it.

This has the benefit to make the output of the build process more consistent. The pkg-config files will always be generated, no matter whether I install pkg-config before building OpenBLAS or afterwards.

Additionally it is more consistent with the *.pc files that are generated by LAPACK if it is enabled: Those files are being generated unconditionally.
