### PR TITLE
Improve fix for lapack-test EIG/cchkhb2stg from PR 2778

### DIFF
--- a/lapack-netlib/TESTING/EIG/cchkhb2stg.f
+++ b/lapack-netlib/TESTING/EIG/cchkhb2stg.f
@@ -680,8 +680,8 @@
 *              the one from above. Compare it with D1 computed 
 *              using the DSBTRD.
 *            
-               CALL SLASET( 'Full', N, 1, ZERO, ZERO, SD, 1 )
-               CALL SLASET( 'Full', N, 1, ZERO, ZERO, SE, 1 )
+               CALL SLASET( 'Full', N, 1, ZERO, ZERO, SD, N )
+               CALL SLASET( 'Full', N, 1, ZERO, ZERO, SE, N )
                CALL CLACPY( ' ', K+1, N, A, LDA, U, LDU )
                LH = MAX(1, 4*N)
                LW = LWORK - LH
@@ -753,8 +753,8 @@
 *              the one from above. Compare it with D1 computed 
 *              using the DSBTRD. 
 *           
-               CALL SLASET( 'Full', N, 1, ZERO, ZERO, SD, 1 )
-               CALL SLASET( 'Full', N, 1, ZERO, ZERO, SE, 1 )
+               CALL SLASET( 'Full', N, 1, ZERO, ZERO, SD, N )
+               CALL SLASET( 'Full', N, 1, ZERO, ZERO, SE, N )
                CALL CLACPY( ' ', K+1, N, A, LDA, U, LDU )
                LH = MAX(1, 4*N)
                LW = LWORK - LH


### PR DESCRIPTION
as explained by serguei-patchkovskii in Reference-LAPACK/lapack#438 (comment) , passing in an index of 1 instead of N will probably appear to work in practice but actually leads to a standards violation accessing matrix A in SLASET, i.e. undefined behavior