### PR TITLE
Fix gfortran detection by vendor matching

### DIFF
--- a/f_check
+++ b/f_check
@@ -69,7 +69,7 @@ if ($compiler eq "") {
 	    $bu       = "_";
 	}
 
-	if ($data =~ /GNU/) {
+	if ($data =~ /GNU/ || $data =~ /GCC/ ) {
 
 	    $data =~ /(\d+)\.(\d+).(\d+)/;
 	    $major = $1;


### PR DESCRIPTION
fixes #2831 where use of the mpi wrapper thwarts the fallback solution of matching the compiler name against gfortran.