### PR TITLE
Lazyly reinit threads after a fork in OMP mode

### DIFF
--- a/driver/others/blas_server_omp.c
+++ b/driver/others/blas_server_omp.c
@@ -48,6 +48,21 @@
 
 #else
 
+#ifndef likely
+#ifdef __GNUC__
+#define likely(x) __builtin_expect(!!(x), 1)
+#else
+#define likely(x) (x)
+#endif
+#endif
+#ifndef unlikely
+#ifdef __GNUC__
+#define unlikely(x) __builtin_expect(!!(x), 0)
+#else
+#define unlikely(x) (x)
+#endif
+#endif
+
 #ifndef OMP_SCHED
 #define OMP_SCHED static
 #endif
@@ -349,6 +364,9 @@ static void exec_threads(blas_queue_t *queue, int buf_index){
 }
 
 int exec_blas(BLASLONG num, blas_queue_t *queue){
+
+  // Handle lazy re-init of the thread-pool after a POSIX fork
+  if (unlikely(blas_server_avail == 0)) blas_thread_init();
 
   BLASLONG i, buf_index;
 


### PR DESCRIPTION
This initializes the per-thread memory buffers which get cleared/released on a fork via pthread_at_fork. Not doing so leads to
each thread calling blas_memory_alloc on almost every execution which slows down the code significantly as the threads race for the memory allocation using locks to serialize that.

See https://github.com/xianyi/OpenBLAS/blob/d3c0d6811b3b87df0ea0cded56090b9ba0a3f5e3/driver/others/blas_server_omp.c#L281-L285 for the thread-race-alloc

Note that e.g. the non-OMP blas_server.c does this already so this seems to be forgotten by https://github.com/xianyi/OpenBLAS/commit/138a8413903776242cb3c184df9838ba54d04044

I tested a simple example from https://github.com/xianyi/OpenBLAS/issues/2869#issuecomment-701478442 and noticed that with the fork there were 136296 calls to the alloc function and without the fork there were only 2676

To provide some more information on the seriousness of the issue: On ALL platforms/architectures where the application runs a `fork` after loading OpenBLAS into the process space (`dlopen`, linking, ...) the performance of OpenBLAS will be degraded. A `fork` happens e.g. when querying system information in Python by using `platform.system()` (which boils down to running `uname -s` in the child process which is safe to do even with OpenMP active). There are other "safe" usages of `fork` (basically everything which just `execve` another binary, including C/C++ `system()` calls IIRC) that can trigger this, although using OpenMP in the child process when it has been used before is still "unsafe" due to GNU libgomp.

On a 24 core x86 system I see a 11-25% slowdown after a fork using 0.3.7 (using numpy to do some qr and matmul)
On a 44 core (4x HT => 176 threads) POWER I have seen a 19% **decrease** in runtime after fork with default settings. When using `OMP_NUM_THREADS=44` the same code runs about twice as fast and has a ~35% increase in runtime after fork. After this patch I see an increase at 176 Threads of 1-13% and with 44 threads an increase of about 7%. Not sure why there is one now at all... Anyway the time after fork when using 1 thread/core is now much better