### PR TITLE
fix clang std=c18 compilation on aarch64

### DIFF
--- a/common.h
+++ b/common.h
@@ -352,7 +352,7 @@ typedef int blasint;
 #endif
 
 #if defined(ARMV7) || defined(ARMV6) || defined(ARMV8) || defined(ARMV5)
-#define YIELDING        asm volatile ("nop;nop;nop;nop;nop;nop;nop;nop; \n");
+#define YIELDING        __asm__ __volatile__ ("nop;nop;nop;nop;nop;nop;nop;nop; \n");
 #endif
 
 #ifdef BULLDOZER

--- a/driver/others/dynamic_arm64.c
+++ b/driver/others/dynamic_arm64.c
@@ -68,7 +68,7 @@ extern void openblas_warning(int verbose, const char * msg);
 #endif
 
 #define get_cpu_ftr(id, var) ({					\
-		asm("mrs %0, "#id : "=r" (var));		\
+		__asm__("mrs %0, "#id : "=r" (var));		\
 	})
 
 static char *corename[] = {

--- a/kernel/arm64/daxpy_thunderx.c
+++ b/kernel/arm64/daxpy_thunderx.c
@@ -62,7 +62,7 @@ static void daxpy_kernel_8(BLASLONG n, FLOAT *x, FLOAT *y, FLOAT *alpha)
               y5 = a * x[5] + y[5];
               y6 = a * x[6] + y[6];
               y7 = a * x[7] + y[7];
-	      asm("":"+w"(y0),"+w"(y1),"+w"(y2),"+w"(y3),"+w"(y4),"+w"(y5),"+w"(y6),"+w"(y7));
+	      __asm__("":"+w"(y0),"+w"(y1),"+w"(y2),"+w"(y3),"+w"(y4),"+w"(y5),"+w"(y6),"+w"(y7));
 	      y[0] = y0;
 	      y[1] = y1;
 	      y[2] = y2;
@@ -74,7 +74,7 @@ static void daxpy_kernel_8(BLASLONG n, FLOAT *x, FLOAT *y, FLOAT *alpha)
 
               xx = (x + 4*128/sizeof(*x));
               yy = (y + 4*128/sizeof(*y));
-	      asm("":"+r"(yy)::"memory");
+	      __asm__("":"+r"(yy)::"memory");
 	      prefetch(xx);
 	      prefetch(yy);
 


### PR DESCRIPTION
Also dynamic arch revealed 2 more past initial finding in #2871

I cannot fix because cannot test all actively developed code:
```
./kernel/power/shgemm_kernel_power10.c:1
./kernel/power/dgemm_kernel_power10.c:1
./kernel/zarch/gemm_vec.c:5
```
Assuming ia64 and alpha in deep slumber, each with dozen of similar spots.