### PR TITLE
add fninit to reset fpu registers before assembler routines

### DIFF
--- a/kernel/x86_64/amax.S
+++ b/kernel/x86_64/amax.S
@@ -54,6 +54,8 @@
 
 	PROLOGUE
 	PROFCODE
+	
+	fninit
 
 	salq	$BASE_SHIFT, INCX
 

--- a/kernel/x86_64/amax.S
+++ b/kernel/x86_64/amax.S
@@ -55,7 +55,9 @@
 	PROLOGUE
 	PROFCODE
 	
-	fninit
+#ifdef WINDOWS_ABI
+	emms
+#endif
 
 	salq	$BASE_SHIFT, INCX
 

--- a/kernel/x86_64/asum.S
+++ b/kernel/x86_64/asum.S
@@ -49,7 +49,8 @@
 
 	PROLOGUE
 	PROFCODE
-
+	
+	fninit
 	fldz
 	testq	M, M
 	jle	.L999

--- a/kernel/x86_64/asum.S
+++ b/kernel/x86_64/asum.S
@@ -50,7 +50,10 @@
 	PROLOGUE
 	PROFCODE
 	
-	fninit
+#ifdef WINDOWS_ABI
+	emms
+#endif
+
 	fldz
 	testq	M, M
 	jle	.L999

--- a/kernel/x86_64/dot.S
+++ b/kernel/x86_64/dot.S
@@ -49,6 +49,7 @@
 
 	PROLOGUE
 	PROFCODE
+	fninit
 
 	salq	$BASE_SHIFT, INCX
 	salq	$BASE_SHIFT, INCY

--- a/kernel/x86_64/dot.S
+++ b/kernel/x86_64/dot.S
@@ -49,7 +49,10 @@
 
 	PROLOGUE
 	PROFCODE
-	fninit
+
+#ifdef WINDOWS_ABI
+	emms
+#endif
 
 	salq	$BASE_SHIFT, INCX
 	salq	$BASE_SHIFT, INCY

--- a/kernel/x86_64/iamax.S
+++ b/kernel/x86_64/iamax.S
@@ -59,6 +59,7 @@
 
 	PROLOGUE
 	PROFCODE
+	fninit
 
 	salq	$BASE_SHIFT, INCX
 

--- a/kernel/x86_64/iamax.S
+++ b/kernel/x86_64/iamax.S
@@ -59,7 +59,10 @@
 
 	PROLOGUE
 	PROFCODE
-	fninit
+
+#ifdef WINDOWS_ABI
+	emms
+#endif
 
 	salq	$BASE_SHIFT, INCX
 

--- a/kernel/x86_64/izamax.S
+++ b/kernel/x86_64/izamax.S
@@ -59,6 +59,7 @@
 
 	PROLOGUE
 	PROFCODE
+	fninit
 
 	salq	$ZBASE_SHIFT, INCX
 

--- a/kernel/x86_64/izamax.S
+++ b/kernel/x86_64/izamax.S
@@ -59,7 +59,10 @@
 
 	PROLOGUE
 	PROFCODE
-	fninit
+
+#ifdef WINDOWS_ABI
+	emms
+#endif
 
 	salq	$ZBASE_SHIFT, INCX
 

--- a/kernel/x86_64/nrm2.S
+++ b/kernel/x86_64/nrm2.S
@@ -50,6 +50,7 @@
 	PROLOGUE
 	PROFCODE
 
+	fninit
 	fldz
 	testq	M, M
 	jle	.L999

--- a/kernel/x86_64/nrm2.S
+++ b/kernel/x86_64/nrm2.S
@@ -50,7 +50,10 @@
 	PROLOGUE
 	PROFCODE
 
-	fninit
+#ifdef WINDOWS_ABI
+	emms
+#endif
+
 	fldz
 	testq	M, M
 	jle	.L999

--- a/kernel/x86_64/qconjg.S
+++ b/kernel/x86_64/qconjg.S
@@ -41,7 +41,10 @@
 
 	PROLOGUE
 	PROFCODE
-	fninit
+
+#ifdef WINDOWS_ABI
+	emms
+#endif
 
 	fldz
 	FLD	1 * SIZE(ARG1)

--- a/kernel/x86_64/qconjg.S
+++ b/kernel/x86_64/qconjg.S
@@ -41,6 +41,7 @@
 
 	PROLOGUE
 	PROFCODE
+	fninit
 
 	fldz
 	FLD	1 * SIZE(ARG1)

--- a/kernel/x86_64/qdot.S
+++ b/kernel/x86_64/qdot.S
@@ -58,7 +58,9 @@
 
 	PROLOGUE
 
-	fninit
+#ifdef WINDOWS_ABI
+	emms
+#endif
 
 	pushl	%edi
 	pushl	%esi

--- a/kernel/x86_64/qdot.S
+++ b/kernel/x86_64/qdot.S
@@ -58,6 +58,8 @@
 
 	PROLOGUE
 
+	fninit
+
 	pushl	%edi
 	pushl	%esi
 	pushl	%ebx

--- a/kernel/x86_64/qgemm_kernel_2x2.S
+++ b/kernel/x86_64/qgemm_kernel_2x2.S
@@ -74,7 +74,9 @@
 	PROLOGUE
 	PROFCODE
 
-	fninit
+#ifdef WINDOWS_ABI
+	emms
+#endif
 
 	subq	$STACKSIZE, %rsp
 	movq	%rbx,  0(%rsp)

--- a/kernel/x86_64/qgemm_kernel_2x2.S
+++ b/kernel/x86_64/qgemm_kernel_2x2.S
@@ -74,6 +74,8 @@
 	PROLOGUE
 	PROFCODE
 
+	fninit
+
 	subq	$STACKSIZE, %rsp
 	movq	%rbx,  0(%rsp)
 	movq	%rbp,  8(%rsp)

--- a/kernel/x86_64/qgemv_n.S
+++ b/kernel/x86_64/qgemv_n.S
@@ -76,7 +76,9 @@
 	PROLOGUE
 	PROFCODE
 
-	fninit
+#ifdef WINDOWS_ABI
+	emms
+#endif
 
 	subq	$STACKSIZE, %rsp
 	movq	%rbx,  0(%rsp)

--- a/kernel/x86_64/qgemv_n.S
+++ b/kernel/x86_64/qgemv_n.S
@@ -76,6 +76,8 @@
 	PROLOGUE
 	PROFCODE
 
+	fninit
+
 	subq	$STACKSIZE, %rsp
 	movq	%rbx,  0(%rsp)
 	movq	%rbp,  8(%rsp)

--- a/kernel/x86_64/qgemv_t.S
+++ b/kernel/x86_64/qgemv_t.S
@@ -75,6 +75,7 @@
 	PROLOGUE
 	PROFCODE
 
+	fninit
 	subq	$STACKSIZE, %rsp
 	movq	%rbx,  0(%rsp)
 	movq	%rbp,  8(%rsp)

--- a/kernel/x86_64/qgemv_t.S
+++ b/kernel/x86_64/qgemv_t.S
@@ -75,7 +75,10 @@
 	PROLOGUE
 	PROFCODE
 
-	fninit
+#ifdef WINDOWS_ABI
+	emms
+#endif
+
 	subq	$STACKSIZE, %rsp
 	movq	%rbx,  0(%rsp)
 	movq	%rbp,  8(%rsp)

--- a/kernel/x86_64/qtrsm_kernel_LN_2x2.S
+++ b/kernel/x86_64/qtrsm_kernel_LN_2x2.S
@@ -74,7 +74,9 @@
 	PROLOGUE
 	PROFCODE
 
-	fninit
+#ifdef WINDOWS_ABI
+	emms
+#endif
 
 	subq	$STACKSIZE, %rsp
 	movq	%rbx,  0(%rsp)

--- a/kernel/x86_64/qtrsm_kernel_LN_2x2.S
+++ b/kernel/x86_64/qtrsm_kernel_LN_2x2.S
@@ -74,6 +74,8 @@
 	PROLOGUE
 	PROFCODE
 
+	fninit
+
 	subq	$STACKSIZE, %rsp
 	movq	%rbx,  0(%rsp)
 	movq	%rbp,  8(%rsp)

--- a/kernel/x86_64/qtrsm_kernel_LT_2x2.S
+++ b/kernel/x86_64/qtrsm_kernel_LT_2x2.S
@@ -74,7 +74,9 @@
 	PROLOGUE
 	PROFCODE
 
-	fninit
+#ifdef WINDOWS_ABI
+	emms
+#endif
 
 	subq	$STACKSIZE, %rsp
 	movq	%rbx,  0(%rsp)

--- a/kernel/x86_64/qtrsm_kernel_LT_2x2.S
+++ b/kernel/x86_64/qtrsm_kernel_LT_2x2.S
@@ -74,6 +74,8 @@
 	PROLOGUE
 	PROFCODE
 
+	fninit
+
 	subq	$STACKSIZE, %rsp
 	movq	%rbx,  0(%rsp)
 	movq	%rbp,  8(%rsp)

--- a/kernel/x86_64/qtrsm_kernel_RT_2x2.S
+++ b/kernel/x86_64/qtrsm_kernel_RT_2x2.S
@@ -74,6 +74,9 @@
 	PROLOGUE
 	PROFCODE
 
+	fninit
+
+
 	subq	$STACKSIZE, %rsp
 	movq	%rbx,  0(%rsp)
 	movq	%rbp,  8(%rsp)

--- a/kernel/x86_64/qtrsm_kernel_RT_2x2.S
+++ b/kernel/x86_64/qtrsm_kernel_RT_2x2.S
@@ -74,8 +74,9 @@
 	PROLOGUE
 	PROFCODE
 
-	fninit
-
+#ifdef WINDOWS_ABI
+	emms
+#endif
 
 	subq	$STACKSIZE, %rsp
 	movq	%rbx,  0(%rsp)

--- a/kernel/x86_64/sum.S
+++ b/kernel/x86_64/sum.S
@@ -50,7 +50,9 @@
 	PROLOGUE
 	PROFCODE
 
-	fninit
+#ifdef WINDOWS_ABI
+	emms
+#endif
 
 	fldz
 	testq	M, M

--- a/kernel/x86_64/sum.S
+++ b/kernel/x86_64/sum.S
@@ -50,6 +50,8 @@
 	PROLOGUE
 	PROFCODE
 
+	fninit
+
 	fldz
 	testq	M, M
 	jle	.L999

--- a/kernel/x86_64/xdot.S
+++ b/kernel/x86_64/xdot.S
@@ -59,7 +59,9 @@
 
 	PROFCODE
 
-	fninit
+#ifdef WINDOWS_ABI
+	emms
+#endif
 
 
 #define N	%ebx

--- a/kernel/x86_64/xdot.S
+++ b/kernel/x86_64/xdot.S
@@ -59,6 +59,9 @@
 
 	PROFCODE
 
+	fninit
+
+
 #define N	%ebx
 #define X	%esi
 #define INCX	%ecx

--- a/kernel/x86_64/xgemm3m_kernel_2x2.S
+++ b/kernel/x86_64/xgemm3m_kernel_2x2.S
@@ -78,7 +78,9 @@
 	PROLOGUE
 	PROFCODE
 
-	fninit
+#ifdef WINDOWS_ABI
+	emms
+#endif
 
 	subq	$STACKSIZE, %rsp
 	movq	%rbx,  0(%rsp)

--- a/kernel/x86_64/xgemm3m_kernel_2x2.S
+++ b/kernel/x86_64/xgemm3m_kernel_2x2.S
@@ -78,6 +78,8 @@
 	PROLOGUE
 	PROFCODE
 
+	fninit
+
 	subq	$STACKSIZE, %rsp
 	movq	%rbx,  0(%rsp)
 	movq	%rbp,  8(%rsp)

--- a/kernel/x86_64/xgemm_kernel_1x1.S
+++ b/kernel/x86_64/xgemm_kernel_1x1.S
@@ -97,6 +97,8 @@
 	PROLOGUE
 	PROFCODE
 
+	fninit
+
 	subq	$STACKSIZE, %rsp
 	movq	%rbx,  0(%rsp)
 	movq	%rbp,  8(%rsp)

--- a/kernel/x86_64/xgemm_kernel_1x1.S
+++ b/kernel/x86_64/xgemm_kernel_1x1.S
@@ -97,7 +97,9 @@
 	PROLOGUE
 	PROFCODE
 
-	fninit
+#ifdef WINDOWS_ABI
+	emms
+#endif
 
 	subq	$STACKSIZE, %rsp
 	movq	%rbx,  0(%rsp)

--- a/kernel/x86_64/xgemv_n.S
+++ b/kernel/x86_64/xgemv_n.S
@@ -76,7 +76,9 @@
 	PROLOGUE
 	PROFCODE
 
-	fninit
+#ifdef WINDOWS_ABI
+	emms
+#endif
 
 	subq	$STACKSIZE, %rsp
 	movq	%rbx,  0(%rsp)

--- a/kernel/x86_64/xgemv_n.S
+++ b/kernel/x86_64/xgemv_n.S
@@ -76,6 +76,8 @@
 	PROLOGUE
 	PROFCODE
 
+	fninit
+
 	subq	$STACKSIZE, %rsp
 	movq	%rbx,  0(%rsp)
 	movq	%rbp,  8(%rsp)

--- a/kernel/x86_64/xgemv_t.S
+++ b/kernel/x86_64/xgemv_t.S
@@ -75,6 +75,8 @@
 	PROLOGUE
 	PROFCODE
 
+	fninit
+
 	subq	$STACKSIZE, %rsp
 	movq	%rbx,  0(%rsp)
 	movq	%rbp,  8(%rsp)

--- a/kernel/x86_64/xgemv_t.S
+++ b/kernel/x86_64/xgemv_t.S
@@ -75,7 +75,9 @@
 	PROLOGUE
 	PROFCODE
 
-	fninit
+#ifdef WINDOWS_ABI
+	emms
+#endif
 
 	subq	$STACKSIZE, %rsp
 	movq	%rbx,  0(%rsp)

--- a/kernel/x86_64/xtrsm_kernel_LT_1x1.S
+++ b/kernel/x86_64/xtrsm_kernel_LT_1x1.S
@@ -90,7 +90,9 @@
 	PROLOGUE
 	PROFCODE
 
-	fninit
+#ifdef WINDOWS_ABI
+	emms
+#endif
 
 	subq	$STACKSIZE, %rsp
 	movq	%rbx,  0(%rsp)

--- a/kernel/x86_64/xtrsm_kernel_LT_1x1.S
+++ b/kernel/x86_64/xtrsm_kernel_LT_1x1.S
@@ -90,6 +90,8 @@
 	PROLOGUE
 	PROFCODE
 
+	fninit
+
 	subq	$STACKSIZE, %rsp
 	movq	%rbx,  0(%rsp)
 	movq	%rbp,  8(%rsp)

--- a/kernel/x86_64/zamax.S
+++ b/kernel/x86_64/zamax.S
@@ -55,6 +55,8 @@
 	PROLOGUE
 	PROFCODE
 
+	fninit
+
 	salq	$ZBASE_SHIFT, INCX
 
 	fldz

--- a/kernel/x86_64/zamax.S
+++ b/kernel/x86_64/zamax.S
@@ -55,7 +55,9 @@
 	PROLOGUE
 	PROFCODE
 
-	fninit
+#ifdef WINDOWS_ABI
+	emms
+#endif
 
 	salq	$ZBASE_SHIFT, INCX
 

--- a/kernel/x86_64/zasum.S
+++ b/kernel/x86_64/zasum.S
@@ -50,7 +50,9 @@
 	PROLOGUE
 	PROFCODE
 
-	fninit
+#ifdef WINDOWS_ABI
+	emms
+#endif
 
 	fldz
 	testq	M, M

--- a/kernel/x86_64/zasum.S
+++ b/kernel/x86_64/zasum.S
@@ -50,6 +50,8 @@
 	PROLOGUE
 	PROFCODE
 
+	fninit
+
 	fldz
 	testq	M, M
 	jle	.L999

--- a/kernel/x86_64/zdot.S
+++ b/kernel/x86_64/zdot.S
@@ -54,9 +54,9 @@
 	PROLOGUE
 	PROFCODE
 
-	fninit
-
 #ifdef WINDOWS_ABI
+	emms
+
 	movq	40(%rsp), INCY
 #endif
 

--- a/kernel/x86_64/zdot.S
+++ b/kernel/x86_64/zdot.S
@@ -54,6 +54,8 @@
 	PROLOGUE
 	PROFCODE
 
+	fninit
+
 #ifdef WINDOWS_ABI
 	movq	40(%rsp), INCY
 #endif

--- a/kernel/x86_64/znrm2.S
+++ b/kernel/x86_64/znrm2.S
@@ -50,7 +50,9 @@
 	PROLOGUE
 	PROFCODE
 
-	fninit
+#ifdef WINDOWS_ABI
+	emms
+#endif
 
 	fldz
 	testq	M, M

--- a/kernel/x86_64/znrm2.S
+++ b/kernel/x86_64/znrm2.S
@@ -50,6 +50,8 @@
 	PROLOGUE
 	PROFCODE
 
+	fninit
+
 	fldz
 	testq	M, M
 	jle	.L999

--- a/kernel/x86_64/zscal.S
+++ b/kernel/x86_64/zscal.S
@@ -50,7 +50,9 @@
 	PROLOGUE
 	PROFCODE
 
-	fninit
+#ifdef WINDOWS_ABI
+	emms
+#endif
 
 	salq	$ZBASE_SHIFT, INCX
 

--- a/kernel/x86_64/zscal.S
+++ b/kernel/x86_64/zscal.S
@@ -50,6 +50,8 @@
 	PROLOGUE
 	PROFCODE
 
+	fninit
+
 	salq	$ZBASE_SHIFT, INCX
 
 	FLD	 8(%rsp)

--- a/kernel/x86_64/zsum.S
+++ b/kernel/x86_64/zsum.S
@@ -50,7 +50,9 @@
 	PROLOGUE
 	PROFCODE
 
-	fninit
+#ifdef WINDOWS_ABI
+	emms
+#endif
 
 	fldz
 	testq	M, M

--- a/kernel/x86_64/zsum.S
+++ b/kernel/x86_64/zsum.S
@@ -50,6 +50,8 @@
 	PROLOGUE
 	PROFCODE
 
+	fninit
+
 	fldz
 	testq	M, M
 	jle	.L999


### PR DESCRIPTION
closes gh-2709 by adding a call to ~`fninit`~ `emms` to clear the FPU registers.

This seems to be the safe path, unless it can be proven that the kernels will only be called from code that clears the FPU registers and does not set them.

edit: wrong issue number
edit: the original PR had `fninit`, as per review it was changed to `emms`