### PR TITLE
Minor CMAKE fixes

### DIFF
--- a/cmake/arch.cmake
+++ b/cmake/arch.cmake
@@ -79,7 +79,7 @@ if (DYNAMIC_ARCH)
       string(REGEX REPLACE "-march=native" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
     endif ()
     if (DYNAMIC_LIST)
-	set(DYNAMIC_CORE ${DYNAMIC_LIST})
+      set(DYNAMIC_CORE PRESCOTT ${DYNAMIC_LIST})
     endif ()
   endif ()
 

--- a/cmake/arch.cmake
+++ b/cmake/arch.cmake
@@ -1,4 +1,3 @@
-##
 ## Author: Hank Anderson <hank@statease.com>
 ## Description: Ported from portion of OpenBLAS/Makefile.system
 ##              Sets various variables based on architecture.
@@ -80,8 +79,13 @@ if (DYNAMIC_ARCH)
       string(REGEX REPLACE "-march=native" "" CMAKE_C_FLAGS "${CMAKE_C_FLAGS}")
     endif ()
     if (DYNAMIC_LIST)
-	set(DYNAMIC_CORE PRESCOTT ${DYNAMIC_LIST})
+	set(DYNAMIC_CORE ${DYNAMIC_LIST})
     endif ()
+  endif ()
+
+  CHECK_INCLUDE_FILE ("${PROJECT_SOURCE_DIR}/config_kernel.h" TRAP)
+  if (TRAP)
+	  message (FATAL_ERROR "Your build directory contains a file config_kernel.h, probably from a previous compilation with make. This will conflict with the cmake compilation and cause strange compiler errors - please remove the file before trying again")
   endif ()
 
   if (NOT DYNAMIC_CORE)

--- a/cmake/system_check.cmake
+++ b/cmake/system_check.cmake
@@ -121,7 +121,6 @@ endif()
 
 include(CheckIncludeFile)
 CHECK_INCLUDE_FILE("stdatomic.h" HAVE_C11)
-if (HAVE_C11 EQUAL 1)
-message (STATUS found stdatomic.h)
+if (HAVE_C11)
 set (CCOMMON_OPT "${CCOMMON_OPT} -DHAVE_C11")
 endif()


### PR DESCRIPTION
1. remove extra verbosity in check for stdatomic.h (fixes #2872)
2. Abort the configuration step for a DYNAMIC_ARCH build if the toplevel source directory already contains a file config_kernel.h
(from a preceding build attempt with gmake, and source of weird errors as some assembler files would be missing crucial defines if this stale file would get included instead of the dynamically generated one specific to each TARGET_CORE)