### PR TITLE
Optimize the performance of sum by using universal intrinsics

### DIFF
--- a/kernel/arm/sum.c
+++ b/kernel/arm/sum.c
@@ -29,23 +29,55 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 * trivial copy of asum.c with the ABS() removed                                       *
 **************************************************************************************/
 
-
 #include "common.h"
+#include "../simd/intrin.h"
 #include <math.h>
 
 FLOAT CNAME(BLASLONG n, FLOAT *x, BLASLONG inc_x)
 {
-	BLASLONG i=0;
+	BLASLONG i = 0;
 	FLOAT sumf = 0.0;
-	if (n <= 0 || inc_x <= 0) return(sumf);
-
+	if (n <= 0 || inc_x <= 0)
+		return (sumf);
 	n *= inc_x;
-	while(i < n)
+	if (inc_x == 1)
+	{
+#if V_SIMD
+		const int vstep = v_nlanes_f32;
+		const int unrollx4 = n & (-vstep * 4);
+		const int unrollx = n & -vstep;
+		v_f32 vsum0 = v_zero_f32();
+		v_f32 vsum1 = v_zero_f32();
+		v_f32 vsum2 = v_zero_f32();
+		v_f32 vsum3 = v_zero_f32();
+		while (i < unrollx4)
+		{
+			vsum0 = v_add_f32(vsum0, v_loadu_f32(x));
+			vsum1 = v_add_f32(vsum1, v_loadu_f32(x + vstep));
+			vsum2 = v_add_f32(vsum2, v_loadu_f32(x + vstep * 2));
+			vsum3 = v_add_f32(vsum3, v_loadu_f32(x + vstep * 3));
+			i += vstep * 4;
+		}
+		vsum0 = v_add_f32(
+			v_add_f32(vsum0, vsum1), v_add_f32(vsum2, vsum3));
+		while (i < unrollx)
+		{
+			vsum0 = v_add_f32(vsum0, v_loadu_f32(x + i));
+			i += vstep;
+		}
+		sumf = v_sum_f32(vsum0);
+#else
+		int n1 = n & -4;
+		for (; i < n1; i += 4)
+		{
+			sumf += x[i] + x[i + 1] + x[i + 2] + x[i + 3];
+		}
+#endif
+	}
+	while (i < n)
 	{
 		sumf += x[i];
 		i += inc_x;
 	}
-	return(sumf);
+	return (sumf);
 }
-
-


### PR DESCRIPTION
## Introduction

Inspired by #2887, we can take advantage of universal intrinsics, Compare with develop branch,  the new implementation has about 13x faster in AVX2, about 4x faster in SSE2, about 6x faster in NEON. 

## Benchmark

  Each test has run for 10 loops and then take the average result, The radio is the MFlops division of Baseline and optimized branch(*The bigger* the radio is, the *better* performance is achieved).

- X86 BaseLine

| data size(10^3) | develop(float)               |
| --------------- | ---------------------------- |
| 4000            | 568.87 MFlops   0.014063 sec |
| 8000            | 564.95 MFlops   0.028321 sec |

- X86 loop unrolling

| data size(10^3) | develop(float)                | ratio |
| --------------- | ----------------------------- | ----- |
| 4000            | 1820.37 MFlops   0.004395 sec | 3.19  |
| 8000            | 1883.19 MFlops   0.008496 sec | 3.33  |

- X86-SSE2 enabled

  | data size(10^3) | usimd-sum(float)              | ratio |
  | --------------- | ----------------------------- | ----- |
  | 4000            | 2642.44 MFlops   0.003027 sec | 4.64  |
  | 8000            | 2642.40 MFlops   0.006055 sec | 4.67  |
  
- X86-AVX2 enabled

  | data size(10^3) | usimd-sum(float)              | ratio |
  | --------------- | ----------------------------- | ----- |
  | 4000            | 7447.40 MFlops   0.001074 sec | 13.09 |
  | 8000            | 5649.32 MFlops   0.002832 sec | 9.99  |
  
- ARM BaseLine

  | data size(10^3) | develop(float)               |
  | --------------- | ---------------------------- |
  | 4000            | 338.97 MFlops   0.023601 sec |
  | 8000            | 338.20 MFlops   0.047309 sec |
  
- ARM loop unrolling

| data size | usimd-sum(float)              | ratio |
| --------- | ----------------------------- | ----- |
| 4000      | 1007.34 MFlops   0.007942 sec | 2.97  |
| 8000      | 1009.55 MFlops   0.015849 sec | 2.98  |

- ARM-Neon enabled

  | data size | usimd-sum(float)              | ratio |
  | --------- | ----------------------------- | ----- |
  | 4000      | 2151.17 MFlops   0.003719 sec | 6.34  |
  | 8000      | 2154.59 MFlops   0.007426 sec | 6.37  |

## System Info

|           | Arm                                                          | x86                                      |
| --------- | ------------------------------------------------------------ | ---------------------------------------- |
| Hardware  | KunPeng                                                      |                                          |
| Processor | ARMv8 2.6GMHZ 8 processors                                   | Intel(R) Xeon(R) Gold 6161 CPU @ 2.20GHz |
| OS        | Linux ecs-9d50 4.19.36-vhulk1905.1.0.h276.eulerosv2r8.aarch64 | Windows Server 2008 R2 Enterprise        |
| Compiler  | gcc (GCC) 7.3.0                                              | MSVC14.06                                |
