### PR TITLE
Fix build with -Werror=return-type

### DIFF
--- a/kernel/x86_64/dgemm_tcopy_16_skylakex.c
+++ b/kernel/x86_64/dgemm_tcopy_16_skylakex.c
@@ -126,4 +126,5 @@ int CNAME(BLASLONG dim_second, BLASLONG dim_first, double *src, BLASLONG lead_di
     }
     src1 += src_inc;
   }
+  return 0;
 }


### PR DESCRIPTION
dgemm_tcopy_16_skylakex.c CNAME function should return an int, add a return 0 similar to other files.