### PR TITLE
Fix cooperlake compile issue

### DIFF
--- a/Makefile.system
+++ b/Makefile.system
@@ -319,6 +319,7 @@ ifeq ($(GCCVERSIONGTEQ7),1)
 else
 	GCCDUMPVERSION_PARAM := -dumpversion
 endif
+GCCMINORVERSIONGTEQ1 := $(shell expr `$(CC) $(GCCDUMPVERSION_PARAM) | cut -f2 -d.` \>= 1)
 GCCMINORVERSIONGTEQ2 := $(shell expr `$(CC) $(GCCDUMPVERSION_PARAM) | cut -f2 -d.` \>= 2)
 GCCMINORVERSIONGTEQ7 := $(shell expr `$(CC) $(GCCDUMPVERSION_PARAM) | cut -f2 -d.` \>= 7)
 endif


### PR DESCRIPTION
Add a missing macro which is required in Makefile.x86_64 due to recent clearnup, which causes cooperlake platform build failure.