### PR TITLE
add openbsd 68+ gfortran name

### DIFF
--- a/f_check
+++ b/f_check
@@ -33,7 +33,7 @@ if ($compiler eq "") {
               "ppuf77", "ppuf95", "ppuf90", "ppuxlf",
 	      "pathf90", "pathf95",
 	      "pgf95", "pgf90", "pgf77",
-	      "flang",
+	      "flang", "egfortran",
               "ifort");
 
 OUTER:


### PR DESCRIPTION
Avoid custom command in #2958 , in rest of places `/gfortran/` covers the detection correctly