### PR TITLE
Revert "Lazyly reinit threads after a fork in OMP mode"

### DIFF
--- a/driver/others/blas_server_omp.c
+++ b/driver/others/blas_server_omp.c
@@ -48,21 +48,6 @@
 
 #else
 
-#ifndef likely
-#ifdef __GNUC__
-#define likely(x) __builtin_expect(!!(x), 1)
-#else
-#define likely(x) (x)
-#endif
-#endif
-#ifndef unlikely
-#ifdef __GNUC__
-#define unlikely(x) __builtin_expect(!!(x), 0)
-#else
-#define unlikely(x) (x)
-#endif
-#endif
-
 #ifndef OMP_SCHED
 #define OMP_SCHED static
 #endif
@@ -375,9 +360,6 @@ fprintf(stderr,"UNHANDLED COMPLEX\n");
 }
 
 int exec_blas(BLASLONG num, blas_queue_t *queue){
-
-  // Handle lazy re-init of the thread-pool after a POSIX fork
-  if (unlikely(blas_server_avail == 0)) blas_thread_init();
 
   BLASLONG i, buf_index;
 


### PR DESCRIPTION
This reverts commit 3094fc6c83c7a623f9a7e7846eb711a8a99ddfff.

Causes seg faults in some scenarios, see https://github.com/xianyi/OpenBLAS/issues/2970#issuecomment-725069635