### PR TITLE
WIP, Testing: Reduce the default BUFFERSIZE for x86_64 to its 0.3.9 value

### DIFF
--- a/common_x86_64.h
+++ b/common_x86_64.h
@@ -251,7 +251,7 @@ static __inline unsigned int blas_quickdivide(unsigned int x, unsigned int y){
 #define HUGE_PAGESIZE	( 2 << 20)
 
 #ifndef BUFFERSIZE
-#define BUFFER_SIZE	(32 << 22)
+#define BUFFER_SIZE	(32 << 20)
 #else
 #define BUFFER_SIZE	(32 << BUFFERSIZE)
 #endif


### PR DESCRIPTION
possibly fixes #2970 at the cost of reintroducing the earlier overflows at bigger matrix sizes