### PR TITLE
Add reproducer test for crash after fork

### DIFF
--- a/utest/CMakeLists.txt
+++ b/utest/CMakeLists.txt
@@ -27,13 +27,17 @@ endif ()
 
 # known to hang with the native Windows and Android threads
 # FIXME needs checking if this works on any of the other platforms
-if (NOT USE_OPENMP)
 if (OS_CYGWIN_NT OR OS_LINUX)
+if (NOT USE_OPENMP)
 set(OpenBLAS_utest_src
   ${OpenBLAS_utest_src}
   test_fork.c
   )
 endif()
+set(OpenBLAS_utest_src
+  ${OpenBLAS_utest_src}
+  test_post_fork.c
+  )
 endif()
 
 if (NOT NO_LAPACK)

--- a/utest/Makefile
+++ b/utest/Makefile
@@ -25,10 +25,11 @@ endif
 
 #this does not work with OpenMP nor with native Windows or Android threads
 # FIXME TBD if this works on OSX, SunOS, POWER and zarch
-ifndef USE_OPENMP
 ifeq ($(OSNAME), $(filter $(OSNAME),Linux CYGWIN_NT))
+ifneq ($(USE_OPENMP), 1)
 OBJS += test_fork.o
 endif
+OBJS += test_post_fork.o
 endif
 
 ifeq ($(C_COMPILER), PGI)


### PR DESCRIPTION
See #2993 for an analysis

This reproduces the issue in #2993 without resorting to numpy. I confirmed that the test fails prior to applying #2995 and succeeds afterwards independent of the number of threads that OpenBLAS was build with