### PR TITLE
Cast arguments of `_mm512_abs_pd` to `__m512`

### DIFF
--- a/kernel/x86_64/dasum_microk_skylakex-2.c
+++ b/kernel/x86_64/dasum_microk_skylakex-2.c
@@ -39,10 +39,10 @@ static FLOAT dasum_kernel(BLASLONG n, FLOAT *x1)
         accum_2 = _mm512_setzero_pd();
         accum_3 = _mm512_setzero_pd();
         for (i = 0; i < tail_index_AVX512; i += 32) {
-            accum_0 += _mm512_abs_pd(_mm512_load_pd(&x1[i + 0]));
-            accum_1 += _mm512_abs_pd(_mm512_load_pd(&x1[i + 8]));
-            accum_2 += _mm512_abs_pd(_mm512_load_pd(&x1[i +16]));
-            accum_3 += _mm512_abs_pd(_mm512_load_pd(&x1[i +24]));
+            accum_0 += _mm512_abs_pd((__m512)_mm512_load_pd(&x1[i + 0]));
+            accum_1 += _mm512_abs_pd((__m512)_mm512_load_pd(&x1[i + 8]));
+            accum_2 += _mm512_abs_pd((__m512)_mm512_load_pd(&x1[i +16]));
+            accum_3 += _mm512_abs_pd((__m512)_mm512_load_pd(&x1[i +24]));
         }
 
         accum_0 = accum_0 + accum_1 + accum_2 + accum_3;


### PR DESCRIPTION
Argument of `_mm512_abs_pd` must be `__m512`, see
https://software.intel.com/sites/landingpage/IntrinsicsGuide/#techs=KNC&expand=60.
Without the explicit typecast we get
```
In file included from ../kernel/x86_64/dasum.c:8:
../kernel/x86_64/dasum_microk_skylakex-2.c: In function ‘dasum_kernel’:
../kernel/x86_64/dasum_microk_skylakex-2.c:42:38: error: incompatible type for argument 1 of ‘_mm512_abs_pd’
             accum_0 += _mm512_abs_pd(_mm512_load_pd(&x1[i + 0]));
                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /opt/x86_64-linux-gnu/lib/gcc/x86_64-linux-gnu/8.1.0/include/immintrin.h:45,
                 from ../kernel/x86_64/dasum_microk_skylakex-2.c:6,
                 from ../kernel/x86_64/dasum.c:8:
/opt/x86_64-linux-gnu/lib/gcc/x86_64-linux-gnu/8.1.0/include/avx512fintrin.h:7730:23: note: expected ‘__m512’ {aka ‘__vector(16) float’} but argument is of type ‘__m512d’ {aka ‘__vector(8) double’}
 _mm512_abs_pd (__m512 __A)
                ~~~~~~~^~~
In file included from ../kernel/x86_64/dasum.c:8:
../kernel/x86_64/dasum_microk_skylakex-2.c:43:38: error: incompatible type for argument 1 of ‘_mm512_abs_pd’
             accum_1 += _mm512_abs_pd(_mm512_load_pd(&x1[i + 8]));
                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /opt/x86_64-linux-gnu/lib/gcc/x86_64-linux-gnu/8.1.0/include/immintrin.h:45,
                 from ../kernel/x86_64/dasum_microk_skylakex-2.c:6,
                 from ../kernel/x86_64/dasum.c:8:
/opt/x86_64-linux-gnu/lib/gcc/x86_64-linux-gnu/8.1.0/include/avx512fintrin.h:7730:23: note: expected ‘__m512’ {aka ‘__vector(16) float’} but argument is of type ‘__m512d’ {aka ‘__vector(8) double’}
 _mm512_abs_pd (__m512 __A)
                ~~~~~~~^~~
In file included from ../kernel/x86_64/dasum.c:8:
../kernel/x86_64/dasum_microk_skylakex-2.c:44:38: error: incompatible type for argument 1 of ‘_mm512_abs_pd’
             accum_2 += _mm512_abs_pd(_mm512_load_pd(&x1[i +16]));
                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /opt/x86_64-linux-gnu/lib/gcc/x86_64-linux-gnu/8.1.0/include/immintrin.h:45,
/opt/x86_64-linux-gnu/lib/gcc/x86_64-linux-gnu/8.1.0/include/avx512fintrin.h:7730:23: note: expected ‘__m512’ {aka ‘__vector(16) float’} but argument is of type ‘__m512d’ {aka ‘__vector(8) double’}
 _mm512_abs_pd (__m512 __A)
                ~~~~~~~^~~
```