### PR TITLE
Fix test errors reported by cblas_cgemm & cblas_ctrmm

### DIFF
--- a/kernel/mips/cgemm_kernel_8x4_msa.c
+++ b/kernel/mips/cgemm_kernel_8x4_msa.c
@@ -758,10 +758,10 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     pc0[1] += alphar * res1;  \
     pc0[1] += alphai * res0;  \
                               \
-    pc1[2] += alphar * res2;  \
-    pc1[2] -= alphai * res3;  \
-    pc1[3] += alphar * res3;  \
-    pc1[3] += alphai * res2;  \
+    pc1[0] += alphar * res2;  \
+    pc1[0] -= alphai * res3;  \
+    pc1[1] += alphar * res3;  \
+    pc1[1] += alphai * res2;  \
 }
 
 #define CGEMM_SCALE_1X1       \
@@ -1067,10 +1067,10 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     pc0[1] = alphar * res1;   \
     pc0[1] += alphai * res0;  \
                               \
-    pc1[2] = alphar * res2;   \
-    pc1[2] -= alphai * res3;  \
-    pc1[3] = alphar * res3;   \
-    pc1[3] += alphai * res2;  \
+    pc1[0] = alphar * res2;   \
+    pc1[0] -= alphai * res3;  \
+    pc1[1] = alphar * res3;   \
+    pc1[1] += alphai * res2;  \
 }
 
 #define CGEMM_TRMM_SCALE_1X1  \


### PR DESCRIPTION
The file cgemm_kernel_8x4_msa.c holds the MSA optimization
codes of cblas_cgemm and cblas_ctrmm. It defines two
macros: CGEMM_SCALE_1X2 and CGEMM_TRMM_SCALE_1X2. The pc1
array index in the two macros should be 0 and 1.