### PR TITLE
POWER10: Improve copy performance

### DIFF
--- a/kernel/power/ccopy_microk_power10.c
+++ b/kernel/power/ccopy_microk_power10.c
@@ -40,93 +40,64 @@ static void copy_kernel (BLASLONG n, FLOAT *x, FLOAT *y)
        "lxvp		44, 192(%2)	\n\t"
        "lxvp		46, 224(%2)	\n\t"
 
-       "lxvp		48, 256(%2)	\n\t"
-       "lxvp		50, 288(%2)	\n\t"
-       "lxvp		52, 320(%2)	\n\t"
-       "lxvp		54, 352(%2)	\n\t"
-       "lxvp		56, 384(%2)	\n\t"
-       "lxvp		58, 416(%2)	\n\t"
-       "lxvp		60, 448(%2)	\n\t"
-       "lxvp		62, 480(%2)	\n\t"
-       "addi		%2, %2, 512	\n\t"
-#if !defined(COMPLEX) && !defined(DOUBLE)
-       "addic.		%1, %1, -128	\n\t"
-#elif defined(COMPLEX) && defined(DOUBLE)
+       "addi		%2, %2, 256	\n\t"
        "addic.		%1, %1, -32	\n\t"
-#else
-       "addic.		%1, %1, -64	\n\t"
-#endif
        "ble		two%=		\n\t"
 
        ".align	5		\n"
      "one%=:				\n\t"
 
-       "stxvp		32, 0(%3)	\n\t"
-       "stxvp		34, 32(%3)	\n\t"
-       "stxvp		36, 64(%3)	\n\t"
-       "stxvp		38, 96(%3)	\n\t"
+       "stxv		33, 0(%3)	\n\t"
+       "stxv		32, 16(%3)	\n\t"
+       "stxv		35, 32(%3)	\n\t"
+       "stxv		34, 48(%3)	\n\t"
+       "stxv		37, 64(%3)	\n\t"
+       "stxv		36, 80(%3)	\n\t"
+       "stxv		39, 96(%3)	\n\t"
+       "stxv		38, 112(%3)	\n\t"
        "lxvp		32, 0(%2)	\n\t"
        "lxvp		34, 32(%2)	\n\t"
        "lxvp		36, 64(%2)	\n\t"
        "lxvp		38, 96(%2)	\n\t"
 
-       "stxvp		40, 128(%3)	\n\t"
-       "stxvp		42, 160(%3)	\n\t"
-       "stxvp		44, 192(%3)	\n\t"
-       "stxvp		46, 224(%3)	\n\t"
+       "stxv		41, 128(%3)	\n\t"
+       "stxv		40, 144(%3)	\n\t"
+       "stxv		43, 160(%3)	\n\t"
+       "stxv		42, 176(%3)	\n\t"
+       "stxv		45, 192(%3)	\n\t"
+       "stxv		44, 208(%3)	\n\t"
+       "stxv		47, 224(%3)	\n\t"
+       "stxv		46, 240(%3)	\n\t"
        "lxvp		40, 128(%2)	\n\t"
        "lxvp		42, 160(%2)	\n\t"
        "lxvp		44, 192(%2)	\n\t"
        "lxvp		46, 224(%2)	\n\t"
 
-       "stxvp		48, 256(%3)	\n\t"
-       "stxvp		50, 288(%3)	\n\t"
-       "stxvp		52, 320(%3)	\n\t"
-       "stxvp		54, 352(%3)	\n\t"
-       "lxvp		48, 256(%2)	\n\t"
-       "lxvp		50, 288(%2)	\n\t"
-       "lxvp		52, 320(%2)	\n\t"
-       "lxvp		54, 352(%2)	\n\t"
 
-       "stxvp		56, 384(%3)	\n\t"
-       "stxvp		58, 416(%3)	\n\t"
-       "stxvp		60, 448(%3)	\n\t"
-       "stxvp		62, 480(%3)	\n\t"
-       "lxvp		56, 384(%2)	\n\t"
-       "lxvp		58, 416(%2)	\n\t"
-       "lxvp		60, 448(%2)	\n\t"
-       "lxvp		62, 480(%2)	\n\t"
+       "addi		%3, %3, 256	\n\t"
+       "addi		%2, %2, 256	\n\t"
 
-       "addi		%3, %3, 512	\n\t"
-       "addi		%2, %2, 512	\n\t"
-
-#if !defined(COMPLEX) && !defined(DOUBLE)
-       "addic.		%1, %1, -128	\n\t"
-#elif defined(COMPLEX) && defined(DOUBLE)
        "addic.		%1, %1, -32	\n\t"
-#else
-       "addic.		%1, %1, -64	\n\t"
-#endif
        "bgt		one%=		\n"
 
      "two%=:				\n\t"
 
-       "stxvp		32, 0(%3)	\n\t"
-       "stxvp		34, 32(%3)	\n\t"
-       "stxvp		36, 64(%3)	\n\t"
-       "stxvp		38, 96(%3)	\n\t"
-       "stxvp		40, 128(%3)	\n\t"
-       "stxvp		42, 160(%3)	\n\t"
-       "stxvp		44, 192(%3)	\n\t"
-       "stxvp		46, 224(%3)	\n\t"
-       "stxvp		48, 256(%3)	\n\t"
-       "stxvp		50, 288(%3)	\n\t"
-       "stxvp		52, 320(%3)	\n\t"
-       "stxvp		54, 352(%3)	\n\t"
-       "stxvp		56, 384(%3)	\n\t"
-       "stxvp		58, 416(%3)	\n\t"
-       "stxvp		60, 448(%3)	\n\t"
-       "stxvp		62, 480(%3)	\n\t"
+       "stxv		33, 0(%3)	\n\t"
+       "stxv		32, 16(%3)	\n\t"
+       "stxv		35, 32(%3)	\n\t"
+       "stxv		34, 48(%3)	\n\t"
+       "stxv		37, 64(%3)	\n\t"
+       "stxv		36, 80(%3)	\n\t"
+       "stxv		39, 96(%3)	\n\t"
+       "stxv		38, 112(%3)	\n\t"
+       "stxv		41, 128(%3)	\n\t"
+       "stxv		40, 144(%3)	\n\t"
+       "stxv		43, 160(%3)	\n\t"
+       "stxv		42, 176(%3)	\n\t"
+       "stxv		45, 192(%3)	\n\t"
+       "stxv		44, 208(%3)	\n\t"
+       "stxv		47, 224(%3)	\n\t"
+       "stxv		46, 240(%3)	\n\t"
 
      "#n=%1 x=%4=%2 y=%0=%3"
      :
@@ -139,8 +110,6 @@ static void copy_kernel (BLASLONG n, FLOAT *x, FLOAT *y)
      :
        "cr0",
        "vs32","vs33","vs34","vs35","vs36","vs37","vs38","vs39",
-       "vs40","vs41","vs42","vs43","vs44","vs45","vs46","vs47",
-       "vs48","vs49","vs50","vs51","vs52","vs53","vs54","vs55",
-       "vs56","vs57","vs58","vs59","vs60","vs61","vs62","vs63"
+       "vs40","vs41","vs42","vs43","vs44","vs45","vs46","vs47"
      );
 }

--- a/kernel/power/ccopy_power10.c
+++ b/kernel/power/ccopy_power10.c
@@ -28,7 +28,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "common.h"
 
 #if defined(__VEC__) || defined(__ALTIVEC__)
-#include "copy_microk_power10.c"
+#include "ccopy_microk_power10.c"
 #endif
 
 #ifndef HAVE_KERNEL
@@ -86,7 +86,7 @@ int CNAME(BLASLONG n, FLOAT *x, BLASLONG inc_x, FLOAT *y, BLASLONG inc_y)
 	if ( (inc_x == 1) && (inc_y == 1 ))
 	{
 
-		BLASLONG n1 = n & -64;
+		BLASLONG n1 = n & -32;
 		if ( n1 > 0 )
 		{
 			copy_kernel(n1, x, y);

--- a/kernel/power/dcopy_power10.c
+++ b/kernel/power/dcopy_power10.c
@@ -85,12 +85,18 @@ int CNAME(BLASLONG n, FLOAT *x, BLASLONG inc_x, FLOAT *y, BLASLONG inc_y)
 
 	if ( (inc_x == 1) && (inc_y == 1 ))
 	{
-
-		BLASLONG n1 = n & -64;
-		if ( n1 > 0 )
+		if ( n >= 64 )
 		{
-			copy_kernel(n1, x, y);
-			i=n1;
+			BLASLONG align = ((32 - ((uintptr_t)y & (uintptr_t)0x1F)) >> 3) & 0x3;
+			for (i = 0; i < align; i++) {
+				y[i] = x[i] ;
+			}
+		}
+		BLASLONG n1 = (n-i) & -64;
+		if ( n1 )
+		{
+			copy_kernel(n1, &x[i], &y[i]);
+			i += n1;
 		}
 
 		while(i < n)

--- a/kernel/power/scopy_power10.c
+++ b/kernel/power/scopy_power10.c
@@ -86,11 +86,18 @@ int CNAME(BLASLONG n, FLOAT *x, BLASLONG inc_x, FLOAT *y, BLASLONG inc_y)
 	if ( (inc_x == 1) && (inc_y == 1 ))
 	{
 
-		BLASLONG n1 = n & -128;
-		if ( n1 > 0 )
+		if ( n >= 128 )
 		{
-			copy_kernel (n1, x, y);
-			i=n1;
+			BLASLONG align = ((32 - ((uintptr_t)y & (uintptr_t)0x1F)) >> 2) & 0x7;
+			for (i = 0; i < align; i++) {
+				y[i] = x[i] ;
+			}
+		}
+		BLASLONG n1 = (n-i) & -128;
+		if ( n1 )
+		{
+			copy_kernel(n1, &x[i], &y[i]);
+			i += n1;
 		}
 
 		while(i < n)


### PR DESCRIPTION
This patch aligns the stores to 32 byte boundary for scopy and dcopy
before entering into vector pair loop. For ccopy, changed the store
instructions to stxv to improve performance of unaligned cases.