### PR TITLE
getarch.c: define OPENBLAS_SUPPORTED for riscv64

### DIFF
--- a/getarch.c
+++ b/getarch.c
@@ -1375,6 +1375,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #ifdef __riscv
 #include "cpuid_riscv64.c"
+#define OPENBLAS_SUPPORTED
 #endif
 
 #ifdef __arm__


### PR DESCRIPTION
For some reason, `getarch.c` doesn't define `OPENBLAS_SUPPORTED` for the riscv64 CPU, despite this CPU being supported. It looks like it has just been forgotten, so just add it.