### PR TITLE
Fix build on FreeBSD/powerpc64le

### DIFF
--- a/Makefile.system
+++ b/Makefile.system
@@ -21,6 +21,8 @@ ifeq ($(ARCH), amd64)
 override ARCH=x86_64
 else ifeq ($(ARCH), powerpc64)
 override ARCH=power
+else ifeq ($(ARCH), powerpc64le)
+override ARCH=power
 else ifeq ($(ARCH), powerpc)
 override ARCH=power
 else ifeq ($(ARCH), i386)


### PR DESCRIPTION
FreeBSD has recently added support for powerpc64le (ppc64le in Linux). OpenBLAS needs to be aware that it's power.