### PR TITLE
Label the assembly part of the ARMV8 dynamic arch detection as volatile

### DIFF
--- a/driver/others/dynamic_arm64.c
+++ b/driver/others/dynamic_arm64.c
@@ -68,7 +68,7 @@ extern void openblas_warning(int verbose, const char * msg);
 #endif
 
 #define get_cpu_ftr(id, var) ({					\
-		__asm__("mrs %0, "#id : "=r" (var));		\
+		__asm__ __volatile__("mrs %0, "#id : "=r" (var));		\
 	})
 
 static char *corename[] = {


### PR DESCRIPTION
to keep gcc from rearranging the code to the point where it generates a SIGILL -  for https://github.com/numpy/numpy/issues/18131