### PR TITLE
add embedded option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,4 @@ benchmark/*.goto
 benchmark/smallscaling
 CMakeCache.txt
 CMakeFiles/*
+.vscode

--- a/README.md
+++ b/README.md
@@ -212,7 +212,8 @@ Please note that it is not possible to combine support for different architectur
 - **Android**: Supported by the community. Please read <https://github.com/xianyi/OpenBLAS/wiki/How-to-build-OpenBLAS-for-Android>.
 - **AIX**: Supported on PPC up to POWER8
 - **Haiku**: Supported by the community. We don't actively test the library on this OS.
-- **SunOS**: Supported by the community. We don't actively test the library on this OS:
+- **SunOS**: Supported by the community. We don't actively test the library on this OS.
+- **Cortex-M**: Supported by the community. Please read <https://github.com/xianyi/OpenBLAS/wiki/How-to-use-OpenBLAS-on-Cortex-M>.
 
 ## Usage
 

--- a/cmake/system.cmake
+++ b/cmake/system.cmake
@@ -233,6 +233,11 @@ if (BINARY64)
   endif ()
 endif ()
 
+if(EMBEDDED)
+  set(CCOMMON_OPT "${CCOMMON_OPT} -DOS_EMBEDDED")
+  set(CCOMMON_OPT "${CCOMMON_OPT} -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16")
+endif()
+
 if (NEED_PIC)
   if (${CMAKE_C_COMPILER} STREQUAL "IBM")
     set(CCOMMON_OPT "${CCOMMON_OPT} -qpic=large")

--- a/common.h
+++ b/common.h
@@ -122,7 +122,7 @@ extern "C" {
 #define ATOM GOTO_ATOM
 #undef  GOTO_ATOM
 #endif
-#else
+#elif !defined(OS_EMBEDDED)
 #include <sys/mman.h>
 #ifndef NO_SYSV_IPC
 #include <sys/shm.h>
@@ -134,6 +134,9 @@ extern "C" {
 #if defined(SMP) || defined(USE_LOCKING)
 #include <pthread.h>
 #endif
+#else
+#include <time.h>
+#include <math.h>
 #endif
 
 #if defined(OS_SUNOS)
@@ -488,10 +491,12 @@ static inline unsigned long long rpcc(void){
   struct timespec ts;
   clock_gettime(CLOCK_MONOTONIC, &ts);
   return (unsigned long long)ts.tv_sec * 1000000000ull + ts.tv_nsec;
-#else
+#elif !defined(OS_EMBEDDED)
   struct timeval tv;
   gettimeofday(&tv,NULL);
   return (unsigned long long)tv.tv_sec * 1000000000ull + tv.tv_usec * 1000;
+#else
+  return 0;
 #endif
 }
 #define RPCC_DEFINED
@@ -519,6 +524,10 @@ static void __inline blas_lock(volatile BLASULONG *address){
 
 #ifdef OS_LINUX
 #include "common_linux.h"
+#endif
+
+#ifdef OS_EMBEDDED
+#define DTB_DEFAULT_ENTRIES 64
 #endif
 
 #define MMAP_ACCESS (PROT_READ | PROT_WRITE)

--- a/driver/others/memory.c
+++ b/driver/others/memory.c
@@ -1673,6 +1673,11 @@ void gotoblas_dummy_for_PGI(void) {
 #define ALLOC_MALLOC
 #else
 #define ALLOC_MALLOC
+
+inline int puts(const char *str) { return 0; }
+inline int printf(const char *format, ...) { return 0; }
+inline char *getenv(const char *name) { return ""; }
+inline int atoi(const char *str) { return 0; }
 #endif
 
 #include <stdlib.h>

--- a/driver/others/memory.c
+++ b/driver/others/memory.c
@@ -1668,8 +1668,10 @@ void gotoblas_dummy_for_PGI(void) {
 #ifndef MEM_LARGE_PAGES
 #define MEM_LARGE_PAGES  0x20000000
 #endif
-#else
+#elif !defined(OS_EMBEDDED)
 #define ALLOC_MMAP
+#define ALLOC_MALLOC
+#else
 #define ALLOC_MALLOC
 #endif
 
@@ -1677,7 +1679,7 @@ void gotoblas_dummy_for_PGI(void) {
 #include <stdio.h>
 #include <fcntl.h>
 
-#if !defined(OS_WINDOWS) || defined(OS_CYGWIN_NT)
+#if (!defined(OS_WINDOWS) || defined(OS_CYGWIN_NT)) && !defined(OS_EMBEDDED)
 #include <sys/mman.h>
 #ifndef NO_SYSV_IPC
 #include <sys/shm.h>


### PR DESCRIPTION
the main thing this does is removes the mmap memory allocator so that the standard "malloc" is used, and removes the "gettimeofday" which is not available on embedded. The CMakeLists.txt modification is wrong, but I would like some advice about what that should look like.