### PR TITLE
Fix null pointer check in blas_memory_alloc

### DIFF
--- a/driver/others/memory.c
+++ b/driver/others/memory.c
@@ -1241,7 +1241,7 @@ UNLOCK_COMMAND(&alloc_lock);
 
       func = &memoryalloc[0];
 
-      while ((func != NULL) && (map_address == (void *) -1)) {
+      while ((*func != NULL) && (map_address == (void *) -1)) {
 
         map_address = (*func)((void *)base_address);
 


### PR DESCRIPTION
`func` is always non-NULL because it is an address within the stack. `*func`, on the other hand, will be NULL if none of the functions in the list were successful.

Defect identified by [scan-build](https://clang-analyzer.llvm.org/scan-build.html).