### PR TITLE
Addressed issue #3100 - removing an unnecessary write to the include directory

### DIFF
--- a/cmake/lapacke.cmake
+++ b/cmake/lapacke.cmake
@@ -2499,6 +2499,5 @@ foreach (Utils_FILE ${Utils_SRC})
 endforeach ()
 
 set(lapacke_include_dir "${NETLIB_LAPACK_DIR}/LAPACKE/include")
-configure_file("${lapacke_include_dir}/lapacke_mangling_with_flags.h.in" "${lapacke_include_dir}/lapacke_mangling.h" COPYONLY)
 include_directories(${lapacke_include_dir})
 set_source_files_properties(${LAPACKE_SOURCES} PROPERTIES COMPILE_FLAGS "${LAPACK_CFLAGS}")


### PR DESCRIPTION
Removing an unnecessary write to the include directory, which @martin-frbg pointed out to appear redundant, and which prevents building when the source is read-only.

After removing the configure_file from line 2502 in `cmake/lapacke.cmake`, the build output is identical under the default configuration. When using CMake from the project root, the version in the build directory is used anyway - but this change should be tested on other configurations to ensure that this doesn't have unintended consequences. In particular, it could impact anyone using `cmake/lapacke.cmake` directly.