### PR TITLE
Enable optimized Haswell/AVX2 kernels for sasum/dasum and srot/drot on Ryzen

### DIFF
--- a/kernel/x86_64/KERNEL.ZEN
+++ b/kernel/x86_64/KERNEL.ZEN
@@ -97,3 +97,5 @@ ZTRSMKERNEL_RT	= ../generic/trsm_kernel_RT.c
 CGEMM3MKERNEL    =  cgemm3m_kernel_8x4_haswell.c
 ZGEMM3MKERNEL    =  zgemm3m_kernel_4x4_haswell.c
 
+SROTKERNEL = srot.c
+DROTKERNEL = drot.c

--- a/kernel/x86_64/dasum.c
+++ b/kernel/x86_64/dasum.c
@@ -6,7 +6,7 @@
 
 #if defined(SKYLAKEX)
 #include "dasum_microk_skylakex-2.c"
-#elif defined(HASWELL)
+#elif defined(HASWELL) || defined(ZEN)
 #include "dasum_microk_haswell-2.c"
 #endif
 

--- a/kernel/x86_64/drot.c
+++ b/kernel/x86_64/drot.c
@@ -2,7 +2,7 @@
 
 #if defined(SKYLAKEX)
 #include "drot_microk_skylakex-2.c"
-#elif defined(HASWELL)
+#elif defined(HASWELL) || defined(ZEN)
 #include "drot_microk_haswell-2.c"
 #endif
 

--- a/kernel/x86_64/sasum.c
+++ b/kernel/x86_64/sasum.c
@@ -11,7 +11,7 @@
 
 #if defined(SKYLAKEX)
 #include "sasum_microk_skylakex-2.c"
-#elif defined(HASWELL)
+#elif defined(HASWELL) || defined(ZEN)
 #include "sasum_microk_haswell-2.c"
 #endif
 

--- a/kernel/x86_64/srot.c
+++ b/kernel/x86_64/srot.c
@@ -2,7 +2,7 @@
 
 #if defined(SKYLAKEX)
 #include "srot_microk_skylakex-2.c"
-#elif defined(HASWELL)
+#elif defined(HASWELL) || defined(ZEN)
 #include "srot_microk_haswell-2.c"
 #endif
 


### PR DESCRIPTION
for #3103