### PR TITLE
Add support for compilation with the NAG Fortran compiler

### DIFF
--- a/Makefile.system
+++ b/Makefile.system
@@ -899,6 +899,18 @@ endif
 #  Fortran Compiler dependent settings
 #
 
+ifeq ($(F_COMPILER), NAG)
+FCOMMON_OPT += -dcfuns -recursive -ieee=full -w=obs -thread_safe
+ifdef INTERFACE64
+ifneq ($(INTERFACE64), 0)
+FCOMMON_OPT += -i8
+endif
+endif
+ifeq ($(USE_OPENMP), 1)
+FCOMMON_OPT += -openmp
+endif
+endif
+
 ifeq ($(F_COMPILER), FLANG)
 CCOMMON_OPT += -DF_INTERFACE_FLANG
 FCOMMON_OPT += -Mrecursive -Kieee
@@ -1207,6 +1219,8 @@ CCOMMON_OPT += -fPIC
 endif
 ifeq ($(F_COMPILER), SUN)
 FCOMMON_OPT  += -pic
+else ifeq ($(F_COMPILER), NAG)
+FCOMMON_OPT += -PIC
 else
 FCOMMON_OPT += -fPIC
 endif
@@ -1463,6 +1477,10 @@ LAPACK_FPFLAGS := $(filter-out -fopenmp -mp -openmp -xopenmp=parallel,$(FPFLAGS)
 else
 LAPACK_FFLAGS := $(FFLAGS)
 LAPACK_FPFLAGS := $(FPFLAGS)
+endif
+
+ifeq ($(F_COMPILER),NAG)
+LAPACK_FFLAGS := $(filter-out -msse3 -mssse3 -msse4.1 -mavx -mavx2 -mskylake-avx512 ,$(FFLAGS))
 endif
 
 LAPACK_CFLAGS = $(CFLAGS)

--- a/Makefile.x86_64
+++ b/Makefile.x86_64
@@ -10,26 +10,36 @@ endif
 
 ifdef HAVE_SSE3
 CCOMMON_OPT += -msse3
+ifneq ($(F_COMPILER), NAG)
 FCOMMON_OPT += -msse3
+endif
 endif
 ifdef HAVE_SSSE3
 CCOMMON_OPT += -mssse3
+ifneq ($(F_COMPILER), NAG)
 FCOMMON_OPT += -mssse3
+endif
 endif
 ifdef HAVE_SSE4_1
 CCOMMON_OPT += -msse4.1
+ifneq ($(F_COMPILER), NAG)
 FCOMMON_OPT += -msse4.1
+endif
 endif
 ifndef OLDGCC
 ifdef HAVE_AVX
 CCOMMON_OPT += -mavx
+ifneq ($(F_COMPILER), NAG)
 FCOMMON_OPT += -mavx
+endif
 endif
 endif
 ifndef NO_AVX2
 ifdef HAVE_AVX2
 CCOMMON_OPT += -mavx2
+ifneq ($(F_COMPILER), NAG)
 FCOMMON_OPT += -mavx2
+endif
 endif
 endif
 
@@ -37,7 +47,9 @@ ifeq ($(CORE), SKYLAKEX)
 ifndef DYNAMIC_ARCH
 ifndef NO_AVX512
 CCOMMON_OPT += -march=skylake-avx512
+ifneq ($(F_COMPILER), NAG)
 FCOMMON_OPT += -march=skylake-avx512
+endif
 ifeq ($(OSNAME), CYGWIN_NT)
 CCOMMON_OPT += -fno-asynchronous-unwind-tables
 FCOMMON_OPT += -fno-asynchronous-unwind-tables
@@ -59,7 +71,9 @@ ifeq ($(C_COMPILER), GCC)
 # cooperlake support was added in 10.1
 ifeq ($(GCCVERSIONGTEQ10)$(GCCMINORVERSIONGTEQ1), 11)
 CCOMMON_OPT += -march=cooperlake
+ifneq ($(F_COMPILER), NAG)
 FCOMMON_OPT += -march=cooperlake
+endif
 endif
 endif
 ifeq ($(OSNAME), CYGWIN_NT)

--- a/ctest/Makefile
+++ b/ctest/Makefile
@@ -212,6 +212,9 @@ ifeq ($(C_COMPILER), CLANG)
 CEXTRALIB = -lomp
 endif
 endif
+ifeq ($(F_COMPILER), NAG)
+CEXTRALIB = -lgomp
+endif
 endif
 
 ifeq ($(BUILD_SINGLE),1)

--- a/f_check
+++ b/f_check
@@ -34,7 +34,7 @@ if ($compiler eq "") {
 	      "pathf90", "pathf95",
 	      "pgf95", "pgf90", "pgf77", "pgfortran", "nvfortran",
 	      "flang", "egfortran",
-              "ifort");
+              "ifort", "nagfor");
 
 OUTER:
     foreach $lists (@lists) {
@@ -64,6 +64,9 @@ if ($compiler eq "") {
     if (!$?) {
 
 	$data = `$compiler -O2 -S ftest.f > /dev/null 2>&1 && cat ftest.s && rm -f ftest.s`;
+	if ($data eq "") {
+		$data = `$compiler -O2 -S ftest.f > /dev/null 2>&1 && cat ftest.c && rm -f ftest.c`;
+	}
 	if ($data =~ /zhoge_/) {
 	    $bu       = "_";
 	}
@@ -133,8 +136,16 @@ if ($compiler eq "") {
 	    $openmp = "-openmp";
 	}
 
+	if ($data =~ /NAG/) {
+	    $vendor = NAG;
+	    $openmp = "-openmp";
+	}
+
 	# for embedded underscore name, e.g. zho_ge, it may append 2 underscores.
 	$data = `$compiler -O2 -S ftest3.f > /dev/null 2>&1 && cat ftest3.s && rm -f ftest3.s`;
+	if ($data eq "") {
+		$data = `$compiler -O2 -S ftest3.f > /dev/null 2>&1 && cat ftest3.c && rm -f ftest3.c`;
+	}
 	if ($data =~ / zho_ge__/) {
 	    $need2bu       = 1;
 	}
@@ -222,6 +233,12 @@ if ($compiler eq "") {
 	    $openmp = "-fopenmp";
 	}
 
+	if ($compiler =~ /nagfor/) {
+	    $vendor = NAG;
+	    $bu     = "_";
+	    $openmp = "-openmp";
+	}
+
 	if ($vendor eq "") {
 	    $nofortran = 1;
 	    $compiler = "gfortran";
@@ -275,14 +292,20 @@ if (!$?) {
 	if ($?) {
 	    $link = `$compiler $openmp -mabi=64 -v ftest2.f 2>&1 && rm -f a.out a.exe`;
 	}
+       #For nagfor
+	if ($?) {
+	    $link = `$compiler $openmp -dryrun ftest2.f 2>&1 && rm -f a.out a.exe`;
+        }
 	$binary = "" if ($?);
     }
-
     if ($binary eq "") {
 	$link = `$compiler $openmp -v ftest2.f 2>&1 && rm -f a.out a.exe`;
     }
 }
 
+if ( $vendor == NAG) {
+	    $link = `$compiler $openmp -dryrun ftest2.f 2>&1 && rm -f a.out a.exe`;
+    }
 $linker_L = "";
 $linker_l = "";
 $linker_a = "";
@@ -336,6 +359,7 @@ if ($link ne "") {
 
 	if (
 	    ($flags =~ /^\-l/)
+	    && ($flags !~ /ibrary/)
 	    && ($flags !~ /gfortranbegin/)
 	    && ($flags !~ /frtbegin/)
 	    && ($flags !~ /pathfstart/)
@@ -349,6 +373,16 @@ if ($link ne "") {
 	    && ($flags !~ /[0-9]+/ || ($vendor == FUJITSU && $flags =~ /^-lfj90/))
 		&& ($flags !~ /^\-l$/)
 	    ) {
+	    $linker_l .= $flags . " ";
+	}
+
+	if ( $flags =~ /quickfit.o/ && $vendor == NAG) {
+	    $linker_l .= $flags . " ";
+	}
+	if ( $flags =~ /safefit.o/ && $vendor == NAG) {
+	    $linker_l .= $flags . " ";
+	}
+	if ( $flags =~ /thsafe.o/ && $vendor == NAG) {
 	    $linker_l .= $flags . " ";
 	}
 

--- a/f_check
+++ b/f_check
@@ -303,7 +303,7 @@ if (!$?) {
     }
 }
 
-if ( $vendor == NAG) {
+if ( $vendor eq "NAG") {
 	    $link = `$compiler $openmp -dryrun ftest2.f 2>&1 && rm -f a.out a.exe`;
     }
 $linker_L = "";

--- a/test/Makefile
+++ b/test/Makefile
@@ -270,6 +270,9 @@ ifeq ($(C_COMPILER), CLANG)
 CEXTRALIB = -lomp
 endif
 endif
+ifeq ($(F_COMPILER), NAG)
+CEXTRALIB = -lgomp
+endif
 endif
 
 ifeq ($(BUILD_SINGLE),1)


### PR DESCRIPTION
suggested in #3071 due to their advertised native support for the Apple M1 chip (though my initial impression is that this product is more like a modern successor to f2c rather than a standalone Fortran compiler in its own right - at least on x86_64)