### PR TITLE
Fix compilation on older x86_64 targets with old compilers that lack intrinsics support

### DIFF
--- a/kernel/x86_64/sgemm_direct_skylakex.c
+++ b/kernel/x86_64/sgemm_direct_skylakex.c
@@ -1,8 +1,11 @@
 /* the direct sgemm code written by Arjan van der Ven */
+
+
+#if defined(SKYLAKEX) || defined (COOPERLAKE)
+
 #include <immintrin.h>
 #include "common.h"
 
-#if defined(SKYLAKEX) || defined (COOPERLAKE)
 /*
  * "Direct sgemm" code. This code operates directly on the inputs and outputs
  * of the sgemm call, avoiding the copies, memory realignments and threading,


### PR DESCRIPTION
issue seen while trying to reproduce #3139 on an AMD K9 with gcc 4.3.2 