### PR TITLE
Fix massive warnings on raspberry

### DIFF
--- a/common_arm64.h
+++ b/common_arm64.h
@@ -84,7 +84,7 @@ static __inline BLASULONG rpcc(void){
   blasint shift;
  
   __asm__ __volatile__ ("isb; mrs %0,cntvct_el0":"=r"(ret));
-  __asm__ __volatile__ ("mrs %0,cntfrq_el0; clz %w0, %w0":"=&r"(shift));
+  __asm__ __volatile__ ("mrs %w0,cntfrq_el0; clz %w0, %w0":"=&r"(shift));
 
   return ret << shift;
 }


### PR DESCRIPTION
Ubuntu 20.04 + clang 10.0.0-4ubuntu1 shows warning regarding register width otherwise compiling each file
