### PR TITLE
Rectify _?matcopy size calculation

### DIFF
--- a/interface/imatcopy.c
+++ b/interface/imatcopy.c
@@ -149,10 +149,7 @@ void CNAME( enum CBLAS_ORDER CORDER, enum CBLAS_TRANSPOSE CTRANS, blasint crows,
 
 #endif
 
-	if ( *lda >  *ldb )
-		msize = (*lda) * (*ldb)  * sizeof(FLOAT);
-	else
-		msize = (*ldb) * (*ldb)  * sizeof(FLOAT);
+	msize = (size_t)(*lda) * (size_t)(*ldb)  * sizeof(FLOAT);
 
 	b = malloc(msize);
 	if ( b == NULL )

--- a/interface/zimatcopy.c
+++ b/interface/zimatcopy.c
@@ -171,10 +171,7 @@ void CNAME( enum CBLAS_ORDER CORDER, enum CBLAS_TRANSPOSE CTRANS, blasint crows,
     }
 #endif
 
-	if ( *lda >  *ldb )
-                msize = (*lda) * (*ldb)  * sizeof(FLOAT) * 2;
-        else
-                msize = (*ldb) * (*ldb)  * sizeof(FLOAT) * 2;
+        msize = (size_t)(*lda) * (size_t)(*ldb)  * sizeof(FLOAT) * 2;
 
         b = malloc(msize);
         if ( b == NULL )


### PR DESCRIPTION
Shall address #3160 , avoiding oldest bit mis-handled as the sign. 