### PR TITLE
Fix compilation of the benchmarks on older OSX versions

### DIFF
--- a/benchmark/bench.h
+++ b/benchmark/bench.h
@@ -3,6 +3,8 @@
 #include <time.h>
 #ifdef __CYGWIN32__
 #include <sys/time.h>
+#elif defined(__APPLE__)
+#include <mach/mach_time.h>
 #endif
 #include "common.h"
 


### PR DESCRIPTION
as suggested by dhomeier in a comment on #3126