### PR TITLE
Fix spillover of host-specific build flags into the shared part of x86 DYNAMIC_ARCH builds 

### DIFF
--- a/Makefile.x86
+++ b/Makefile.x86
@@ -1,10 +1,21 @@
 # COMPILER_PREFIX = mingw32-
 
-ifdef HAVE_SSE
-CCOMMON_OPT += -msse
-FCOMMON_OPT += -msse
+ifndef DYNAMIC_ARCH
+ADD_CPUFLAGS = 1
+else
+ifdef TARGET_CORE
+ADD_CPUFLAGS = 1
+endif
 endif
 
+ifdef ADD_CPUFLAGS
+ifdef HAVE_SSE
+CCOMMON_OPT += -msse
+ifneq ($(F_COMPILER), NAG)
+FCOMMON_OPT += -msse
+endif
+endif
+endif
 
 ifeq ($(OSNAME), Interix)
 ARFLAGS		= -m x86

--- a/Makefile.x86_64
+++ b/Makefile.x86_64
@@ -8,6 +8,20 @@ endif
 endif
 endif
 
+
+ifndef DYNAMIC_ARCH
+define ADD_CPUFLAGS
+1
+endef
+else
+ifdef TARGET_CORE
+define ADD_CPUFLAGS
+1
+endef
+endif
+endif
+
+ifdef ADD_CPUFLAGS
 ifdef HAVE_SSE3
 CCOMMON_OPT += -msse3
 ifneq ($(F_COMPILER), NAG)
@@ -44,7 +58,6 @@ endif
 endif
 
 ifeq ($(CORE), SKYLAKEX)
-ifndef DYNAMIC_ARCH
 ifndef NO_AVX512
 CCOMMON_OPT += -march=skylake-avx512
 ifneq ($(F_COMPILER), NAG)
@@ -62,10 +75,8 @@ endif
 endif
 endif
 endif
-endif
 
 ifeq ($(CORE), COOPERLAKE)
-ifndef DYNAMIC_ARCH
 ifndef NO_AVX512
 ifeq ($(C_COMPILER), GCC)
 # cooperlake support was added in 10.1
@@ -84,7 +95,6 @@ ifeq ($(OSNAME), WINNT)
 ifeq ($(C_COMPILER), GCC)
 CCOMMON_OPT += -fno-asynchronous-unwind-tables
 FCOMMON_OPT += -fno-asynchronous-unwind-tables
-endif
 endif
 endif
 endif
@@ -120,6 +130,7 @@ endif
 endif
 endif
 
+endif
 
 
 ifeq ($(OSNAME), Interix)

--- a/Makefile.x86_64
+++ b/Makefile.x86_64
@@ -10,14 +10,10 @@ endif
 
 
 ifndef DYNAMIC_ARCH
-define ADD_CPUFLAGS
-1
-endef
+ADD_CPUFLAGS = 1
 else
 ifdef TARGET_CORE
-define ADD_CPUFLAGS
-1
-endef
+ADD_CPUFLAGS = 1
 endif
 endif
 


### PR DESCRIPTION
for #3139