### PR TITLE
Fix unwanted fallback to implicit typing in slanv2/dlanv2

### DIFF
--- a/lapack-netlib/SRC/dlanv2.f
+++ b/lapack-netlib/SRC/dlanv2.f
@@ -139,7 +139,7 @@
 *  =====================================================================
 *
 *     .. Parameters ..
-      DOUBLE PRECISION   ZERO, HALF, ONE
+      DOUBLE PRECISION   ZERO, HALF, ONE, TWO
       PARAMETER          ( ZERO = 0.0D+0, HALF = 0.5D+0, ONE = 1.0D+0,
      $                     TWO = 2.0D0 )
       DOUBLE PRECISION   MULTPL

--- a/lapack-netlib/SRC/slanv2.f
+++ b/lapack-netlib/SRC/slanv2.f
@@ -139,7 +139,7 @@
 *  =====================================================================
 *
 *     .. Parameters ..
-      REAL               ZERO, HALF, ONE
+      REAL               ZERO, HALF, ONE, TWO
       PARAMETER          ( ZERO = 0.0E+0, HALF = 0.5E+0, ONE = 1.0E+0,
      $                     TWO = 2.0E+0 )
       REAL               MULTPL


### PR DESCRIPTION
omission in #3172 (and original Reference-lapack PR 445) that will break builds with (non-default) "-fimplicit-none"