### PR TITLE
Restore __volatile__ keyword in ARM64 DYNAMIC_ARCH detection mechanism

### DIFF
--- a/driver/others/dynamic_arm64.c
+++ b/driver/others/dynamic_arm64.c
@@ -126,7 +126,7 @@ extern void openblas_warning(int verbose, const char * msg);
 #endif
 
 #define get_cpu_ftr(id, var) ({					\
-		__asm__ ("mrs %0, "#id : "=r" (var));		\
+		__asm__ __volatile__ ("mrs %0, "#id : "=r" (var));		\
 	})
 
 static char *corename[] = {


### PR DESCRIPTION
restores fix from #3060 (related to #2715), inadvertently taken out by #3083