### PR TITLE
Replace spurious AVX512 requirement in the Haswell drot microkernel with an AVX2/FMA3 guard

### DIFF
--- a/kernel/x86_64/drot_microk_haswell-2.c
+++ b/kernel/x86_64/drot_microk_haswell-2.c
@@ -1,6 +1,4 @@
-/* need a new enough GCC for avx512 support */
-#if (( defined(__GNUC__)  && __GNUC__   > 6 && defined(__AVX512CD__)) || (defined(__clang__) && __clang_major__ >= 9))
-
+#if defined(HAVE_FMA3)  && defined(HAVE_AVX2)
 #define HAVE_DROT_KERNEL 1
 
 #include <immintrin.h>


### PR DESCRIPTION
same fix for #3128 as in #3130