### PR TITLE
Apply lapack-testing fix from Reference-LAPACK PR536

### DIFF
--- a/lapack-netlib/TESTING/EIG/cchkee.F
+++ b/lapack-netlib/TESTING/EIG/cchkee.F
@@ -1871,7 +1871,7 @@
          CALL XLAENV( 9, 25 )
          IF( TSTERR ) THEN
 #if defined(_OPENMP)
-            N_THREADS = OMP_GET_NUM_THREADS()
+            N_THREADS = OMP_GET_MAX_THREADS()
             CALL OMP_SET_NUM_THREADS(1)
 #endif
             CALL CERRST( 'CST', NOUT )
@@ -2338,7 +2338,7 @@
          CALL ALAREQ( C3, NTYPES, DOTYPE, MAXTYP, NIN, NOUT )
          IF( TSTERR ) THEN
 #if defined(_OPENMP)
-            N_THREADS = OMP_GET_NUM_THREADS()
+            N_THREADS = OMP_GET_MAX_THREADS()
             CALL OMP_SET_NUM_THREADS(1)
 #endif
             CALL CERRST( 'CHB', NOUT )

--- a/lapack-netlib/TESTING/EIG/dchkee.F
+++ b/lapack-netlib/TESTING/EIG/dchkee.F
@@ -1876,7 +1876,7 @@
          CALL XLAENV( 9, 25 )
          IF( TSTERR ) THEN
 #if defined(_OPENMP)
-            N_THREADS = OMP_GET_NUM_THREADS()
+            N_THREADS = OMP_GET_MAX_THREADS()
             CALL OMP_SET_NUM_THREADS(1)
 #endif
             CALL DERRST( 'DST', NOUT )

--- a/lapack-netlib/TESTING/EIG/schkee.F
+++ b/lapack-netlib/TESTING/EIG/schkee.F
@@ -1877,7 +1877,7 @@
          CALL XLAENV( 9, 25 )
          IF( TSTERR ) THEN
 #if defined(_OPENMP)
-            N_THREADS = OMP_GET_NUM_THREADS()
+            N_THREADS = OMP_GET_MAX_THREADS()
             CALL OMP_SET_NUM_THREADS(1)
 #endif
             CALL SERRST( 'SST', NOUT )

--- a/lapack-netlib/TESTING/EIG/zchkee.F
+++ b/lapack-netlib/TESTING/EIG/zchkee.F
@@ -1871,7 +1871,7 @@
          CALL XLAENV( 9, 25 )
          IF( TSTERR ) THEN
 #if defined(_OPENMP)
-            N_THREADS = OMP_GET_NUM_THREADS()
+            N_THREADS = OMP_GET_MAX_THREADS()
             CALL OMP_SET_NUM_THREADS(1)
 #endif
             CALL ZERRST( 'ZST', NOUT )
@@ -2336,7 +2336,7 @@
          CALL ALAREQ( C3, NTYPES, DOTYPE, MAXTYP, NIN, NOUT )
          IF( TSTERR ) THEN
 #if defined(_OPENMP)
-            N_THREADS = OMP_GET_NUM_THREADS()
+            N_THREADS = OMP_GET_MAX_THREADS()
             CALL OMP_SET_NUM_THREADS(1)
 #endif
             CALL ZERRST( 'ZHB', NOUT )


### PR DESCRIPTION
fixes changing back from a single OMP thread for error exit testing to the originally requested number of threads for computational tests