### PR TITLE
Add error message token for SBGEMM in gemm.c

### DIFF
--- a/interface/gemm.c
+++ b/interface/gemm.c
@@ -49,6 +49,8 @@
 #define ERROR_NAME "QGEMM "
 #elif defined(DOUBLE)
 #define ERROR_NAME "DGEMM "
+#elif defined(BFLOAT16)
+#define ERROR_NAME "SBGEMM "
 #else
 #define ERROR_NAME "SGEMM "
 #endif


### PR DESCRIPTION
Fairly simple fix, so that when there is an error, it prints out the correct function call.