### PR TITLE
Update Makefile.arm64

### DIFF
--- a/Makefile.arm64
+++ b/Makefile.arm64
@@ -107,4 +107,13 @@ FCOMMON_OPT += -march=armv8.2-a -mtune=tsv110
 endif
 endif
 endif
+
+ifeq ($(GCCVERSIONGTEQ9), 1)
+ifeq ($(CORE), EMAG8180)
+CCOMMON_OPT += -march=armv8-a -mtune=emag
+ifneq ($(F_COMPILER), NAG)
+FCOMMON_OPT += -march=armv8-a -mtune=emag
+endif
+endif
+endif
 endif


### PR DESCRIPTION
Added -march and -mtune flags for EMAG processors when GCC 9 or later. See https://github.com/gcc-mirror/gcc/commit/e02669dbdf1d1099710dbc515f07d0b4785ae2fd