### PR TITLE
Add shortcut for small-size S/D GEMV_N with increments of one

### DIFF
--- a/interface/gemv.c
+++ b/interface/gemv.c
@@ -202,6 +202,11 @@ void CNAME(enum CBLAS_ORDER order,
 
   if (alpha == ZERO) return;
 
+  if (trans == 0 && incx == 1 && incy == 1 && m*n < 2304 *GEMM_MULTITHREAD_THRESHOLD) {
+    GEMV_N(m, n, 0, alpha, a, lda, x, incx, y, incy, buffer);
+    return;
+  }    
+
   IDEBUG_START;
 
   FUNCTION_PROFILE_START();


### PR DESCRIPTION
primarily skips the buffer allocation and associated locking