### PR TITLE
Further shortcuts for (small) cases that do not need buffer allocation

### DIFF
--- a/interface/ger.c
+++ b/interface/ger.c
@@ -164,6 +164,11 @@ void CNAME(enum CBLAS_ORDER order,
   if (m == 0 || n == 0) return;
   if (alpha == 0.) return;
 
+  if (incx == 1 && incy == 1 && 1L*m*n <= 2048 *GEMM_MULTITHREAD_THRESHOLD) {
+    GER(m, n, 0, alpha, x, incx, y, incy, a, lda, buffer);
+    return;
+  }  
+
   IDEBUG_START;
 
   FUNCTION_PROFILE_START();

--- a/interface/spr.c
+++ b/interface/spr.c
@@ -167,6 +167,26 @@ void CNAME(enum CBLAS_ORDER order,
 
   FUNCTION_PROFILE_START();
 
+  if (incx == 1 && n <100) {
+    blasint i;
+    if (uplo==0) {
+      for (i = 0; i < n; i++){
+        if (x[i] != ZERO) {
+          AXPYU_K(i + 1, 0, 0, alpha * x[i], x,     1, a, 1, NULL, 0);
+        }
+        a += i + 1;
+      }
+    } else { 
+      for (i = 0; i < n; i++){
+        if (x[i] != ZERO) {
+          AXPYU_K(n - i, 0, 0, alpha * x[i], x + i, 1, a, 1, NULL, 0);
+        }
+        a += n - i;
+      }
+    }
+    return;
+  }
+
   if (incx < 0 ) x -= (n - 1) * incx;
 
   buffer = (FLOAT *)blas_memory_alloc(1);

--- a/interface/spr2.c
+++ b/interface/spr2.c
@@ -168,6 +168,24 @@ void CNAME(enum CBLAS_ORDER order,
 
   if (alpha == ZERO) return;
 
+  if (incx == 1 && incy == 1 && n < 50) {
+    blasint i;
+    if (!uplo) {
+      for (i = 0; i < n; i++){
+        AXPYU_K(i + 1, 0, 0, alpha * x[i], y,     1, a, 1, NULL, 0);
+        AXPYU_K(i + 1, 0, 0, alpha * y[i], x,     1, a, 1, NULL, 0);
+        a += i + 1;
+      }
+    } else {
+      for (i = 0; i < n; i++){
+	AXPYU_K(n - i, 0, 0, alpha * x[i], y + i, 1, a, 1, NULL, 0);
+        AXPYU_K(n - i, 0, 0, alpha * y[i], x + i, 1, a, 1, NULL, 0);
+        a += n - i;
+      }
+    }
+    return;
+  }
+
   IDEBUG_START;
 
   FUNCTION_PROFILE_START();

--- a/interface/symv.c
+++ b/interface/symv.c
@@ -170,10 +170,6 @@ void CNAME(enum CBLAS_ORDER order, enum CBLAS_UPLO Uplo, blasint n, FLOAT alpha,
 
   if (alpha == ZERO) return;
 
-  if (incx == 1 && incy == 1 && n*n < 2304 *GEMM_MULTITHREAD_THRESHOLD) {
-    (symv[uplo])(n, n, alpha, a, lda, x, incx, y, incy, buffer);
-    return;
-  }
   IDEBUG_START;
 
   FUNCTION_PROFILE_START();

--- a/interface/symv.c
+++ b/interface/symv.c
@@ -170,6 +170,10 @@ void CNAME(enum CBLAS_ORDER order, enum CBLAS_UPLO Uplo, blasint n, FLOAT alpha,
 
   if (alpha == ZERO) return;
 
+  if (incx == 1 && incy == 1 && n*n < 2304 *GEMM_MULTITHREAD_THRESHOLD) {
+    (symv[uplo])(n, n, alpha, a, lda, x, incx, y, incy, buffer);
+    return;
+  }
   IDEBUG_START;
 
   FUNCTION_PROFILE_START();

--- a/interface/syr2.c
+++ b/interface/syr2.c
@@ -170,6 +170,25 @@ void CNAME(enum CBLAS_ORDER order, enum CBLAS_UPLO Uplo, blasint n, FLOAT alpha,
 
   IDEBUG_START;
 
+  if (incx == 1 && incy == 1 && n < 100) {
+    blasint i;
+    if (!uplo) {
+      for (i = 0; i < n; i++){
+        AXPYU_K(i + 1, 0, 0, alpha * x[i], y,     1, a, 1, NULL, 0);
+        AXPYU_K(i + 1, 0, 0, alpha * y[i], x,     1, a, 1, NULL, 0);
+        a += lda;
+      }
+    } else {
+      for (i = 0; i < n; i++){
+        AXPYU_K(n - i, 0, 0, alpha * x[i], y + i, 1, a, 1, NULL, 0);
+        AXPYU_K(n - i, 0, 0, alpha * y[i], x + i, 1, a, 1, NULL, 0);
+        a += 1 + lda;
+      }
+    }
+    return;
+  }
+
+	  
   FUNCTION_PROFILE_START();
 
   if (incx < 0 ) x -= (n - 1) * incx;

--- a/interface/trsv.c
+++ b/interface/trsv.c
@@ -188,6 +188,12 @@ void CNAME(enum CBLAS_ORDER order, enum CBLAS_UPLO Uplo,
 
   if (n == 0) return;
 
+  if (incx == 1 && trans == 0 && n < 50) {
+    buffer = NULL;
+    (trsv[(trans<<2) | (uplo<<1) | unit])(n, a, lda, x, incx, buffer);
+    return;  
+  }
+
   IDEBUG_START;
 
   FUNCTION_PROFILE_START();

--- a/interface/zsyr.c
+++ b/interface/zsyr.c
@@ -172,6 +172,32 @@ void CNAME(enum CBLAS_ORDER order, enum CBLAS_UPLO Uplo, int n, FLOAT alpha, FLO
 
   if ((alpha_r == ZERO) && (alpha_i == ZERO)) return;
 
+  if (incx == 1 && incy == 1 && n < 50) {
+    blasint i;
+    if (!uplo) {
+      for (i = 0; i < n; i++){
+        if ((x[i * 2 + 0] != ZERO) || (x[i * 2 + 1] != ZERO)) {
+          AXPYU_K(i + 1, 0, 0,
+              alpha_r * x[i * 2 + 0] - alpha_i * x[i * 2 + 1],
+              alpha_i * x[i * 2 + 0] + alpha_r * x[i * 2 + 1],
+              x,         1, a, 1, NULL, 0);
+        }
+        a += lda;
+      }
+    } else {
+      for (i = 0; i < n; i++){
+        if ((x[i * 2 + 0] != ZERO) || (x[i * 2 + 1] != ZERO)) {
+          AXPYU_K(m - i, 0, 0,
+              alpha_r * x[i * 2 + 0] - alpha_i * x[i * 2 + 1],
+              alpha_i * x[i * 2 + 0] + alpha_r * x[i * 2 + 1],
+              x + i * 2, 1, a, 1, NULL, 0);
+        }
+        a += 2 + lda;
+      }
+    }
+    return;
+  }
+
   IDEBUG_START;
 
   FUNCTION_PROFILE_START();

--- a/interface/zsyr.c
+++ b/interface/zsyr.c
@@ -172,7 +172,7 @@ void CNAME(enum CBLAS_ORDER order, enum CBLAS_UPLO Uplo, int n, FLOAT alpha, FLO
 
   if ((alpha_r == ZERO) && (alpha_i == ZERO)) return;
 
-  if (incx == 1 && incy == 1 && n < 50) {
+  if (incx == 1 && n < 50) {
     blasint i;
     if (!uplo) {
       for (i = 0; i < n; i++){
@@ -187,7 +187,7 @@ void CNAME(enum CBLAS_ORDER order, enum CBLAS_UPLO Uplo, int n, FLOAT alpha, FLO
     } else {
       for (i = 0; i < n; i++){
         if ((x[i * 2 + 0] != ZERO) || (x[i * 2 + 1] != ZERO)) {
-          AXPYU_K(m - i, 0, 0,
+          AXPYU_K(n - i, 0, 0,
               alpha_r * x[i * 2 + 0] - alpha_i * x[i * 2 + 1],
               alpha_i * x[i * 2 + 0] + alpha_r * x[i * 2 + 1],
               x + i * 2, 1, a, 1, NULL, 0);

--- a/interface/ztrsv.c
+++ b/interface/ztrsv.c
@@ -199,6 +199,12 @@ void CNAME(enum CBLAS_ORDER order, enum CBLAS_UPLO Uplo,
 
   if (n == 0) return;
 
+  if (incx == 1 && trans == 0 && n < 50) {
+    buffer = NULL;
+    (trsv[(trans<<2) | (uplo<<1) | unit])(n, a, lda, x, incx, buffer);
+    return;
+  }
+
   IDEBUG_START;
 
   FUNCTION_PROFILE_START();


### PR DESCRIPTION
For problem sizes that are too small to benefit from multithreading, we can also skip the locking-intensive allocation and freeing of a temporary buffer if the data does not need compacting or sorting. This PR speeds up the single and double precision real versions of GER, SPR, SPR2, SYR2 and TRSV as well as the single and double precision complex versions of SYR and TRSV.
On x86_64, the same method should be applcable to SYMV as none of the present kernels make use of the buffer array under these circumstances, but this does not hold for all architectures.