### PR TITLE
revert "try to work around gcc update problems" in Homebrew workflow

### DIFF
--- a/.github/workflows/nightly-Homebrew-build.yml
+++ b/.github/workflows/nightly-Homebrew-build.yml
@@ -43,11 +43,6 @@ jobs:
       - name: Update Homebrew
         if: github.event_name != 'pull_request'
         run: brew update || true
-
-      - name: unlink installed gcc to allow updating
-        run: |
-          brew unlink gcc@8
-          brew unlink gcc@9
           
       - name: Install prerequisites
         run: brew install --fetch-HEAD --HEAD --only-dependencies --keep-tmp openblas


### PR DESCRIPTION
...as homebrew has dropped at least gcc8 now