### PR TITLE
arm64: add the missing d9 register to the clobber list

### DIFF
--- a/kernel/arm64/dznrm2_thunderx2t99.c
+++ b/kernel/arm64/dznrm2_thunderx2t99.c
@@ -321,7 +321,7 @@ static void nrm2_compute(BLASLONG n, FLOAT *x, BLASLONG inc_x,
 	: "cc",
 	  "memory",
 	  "x0", "x1", "x2", "x3", "x4", "x5", "x6",
-	  "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8"
+	  "d0", "d1", "d2", "d3", "d4", "d5", "d6", "d7", "d8", REGINF
 	);
 
 }


### PR DESCRIPTION
Refs. numpy/numpy#18422

Signed-off-by: Gilles Gouaillardet <gilles@rist.or.jp>