### PR TITLE
reduce drone ci cmake processes to number of CPUs mimicking normal make

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -87,11 +87,11 @@ steps:
   commands:
     - echo "CMAKE_FLAGS:= $CMAKE_FLAGS"
     - apt-get update -y
-    - apt-get install -y make $CC g++ perl cmake
+    - apt-get install -y make $CC perl cmake
     - $CC --version
     - mkdir build && cd build
     - cmake $CMAKE_FLAGS ..
-    - make -j
+    - make -j `nproc`
     - ctest -V
 
 ---
@@ -115,7 +115,7 @@ steps:
     - $CC --version
     - mkdir build && cd build
     - cmake $CMAKE_FLAGS ..
-    - make -j
+    - make -j `nproc`
     - ctest -V
 
 ---
@@ -135,11 +135,11 @@ steps:
   commands:
     - echo "CMAKE_FLAGS:= $CMAKE_FLAGS"
     - apt-get update -y
-    - apt-get install -y make $CC g++ perl cmake
+    - apt-get install -y make $CC perl cmake
     - $CC --version
     - mkdir build && cd build
     - cmake $CMAKE_FLAGS ..
-    - make -j
+    - make -j `nproc`
     - ctest -V
 
 ---


### PR DESCRIPTION
Moderate drone's number of cpus instead of priming up all at once.