### PR TITLE
Enable (C)EXTRALIB as for any other platform when building the tests on RISCV C910V

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -259,10 +259,6 @@ endif
 
 FLDFLAGS = $(FFLAGS:-fPIC=) $(LDFLAGS)
 
-ifeq ($(CORE), C910V)
-EXTRALIB =
-CEXTRALIB =
-endif
 
 ifeq ($(USE_OPENMP), 1)
 ifeq ($(F_COMPILER), GFORTRAN)


### PR DESCRIPTION
fixes #3290