### PR TITLE
Avoid redefinition of _GNU_SOURCE

### DIFF
--- a/openblas_config_template.h
+++ b/openblas_config_template.h
@@ -99,6 +99,8 @@ typedef int blasint;
 
 /* Inclusion of Linux-specific header is needed for definition of cpu_set_t. */
 #ifdef OPENBLAS_OS_LINUX
-#define _GNU_SOURCE
+#ifndef _GNU_SOURCE
+ #define _GNU_SOURCE
+#endif
 #include <sched.h>
 #endif


### PR DESCRIPTION
* _GNU_SOURCE may have been set by the application and redefinition
  trigger warnings or error with -Werror
* Fix for 220f6a1c5