### PR TITLE
Revert PR #3250 (shortcut without buffer allocation) as it is unsafe …

### DIFF
--- a/interface/gemv.c
+++ b/interface/gemv.c
@@ -201,12 +201,14 @@ void CNAME(enum CBLAS_ORDER order,
   if (beta != ONE) SCAL_K(leny, 0, 0, beta, y, blasabs(incy), NULL, 0, NULL, 0);
 
   if (alpha == ZERO) return;
-
+	
+#if 0
+/* this optimization causes stack corruption on x86_64 under OSX, Windows and FreeBSD */	
   if (trans == 0 && incx == 1 && incy == 1 && m*n < 2304 *GEMM_MULTITHREAD_THRESHOLD) {
     GEMV_N(m, n, 0, alpha, a, lda, x, incx, y, incy, NULL);
     return;
   }    
-
+#endif
   IDEBUG_START;
 
   FUNCTION_PROFILE_START();


### PR DESCRIPTION
…on at least some x86_64 cpus under various operating systems (though not Linux)
fixes #3309 but this topic needs revisiting to see if I misunderstood the present code or if some of the x86_64 kernels implicitly rely on having a safe stack space that was allocated for something else.