### PR TITLE
Temporarily disable the SkylakeX sgemv_t microkernel

### DIFF
--- a/kernel/x86_64/sgemv_t_4.c
+++ b/kernel/x86_64/sgemv_t_4.c
@@ -38,7 +38,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "sgemv_t_microk_haswell-4.c"
 #elif defined (SKYLAKEX) || defined (COOPERLAKE)
 #include "sgemv_t_microk_haswell-4.c"
-#include "sgemv_t_microk_skylakex.c"
+/*#include "sgemv_t_microk_skylakex.c"*/
 #endif
 
 #if defined(STEAMROLLER) || defined(EXCAVATOR)


### PR DESCRIPTION
(partial revert of #3260 due to LAPACK testsuite failures)