### PR TITLE
Add support for windows/arm64 targets with clang

### DIFF
--- a/common_arm64.h
+++ b/common_arm64.h
@@ -120,7 +120,7 @@ static inline int blas_quickdivide(blasint x, blasint y){
 	.text ;
 	.p2align 2 ;
 	.global	REALNAME ;
-#ifndef __APPLE__
+#if !defined(__APPLE__) && !defined(_WIN32)
 	.type	REALNAME, %function ;
 #endif
 REALNAME:

--- a/ctest.c
+++ b/ctest.c
@@ -84,7 +84,7 @@ OS_AIX
 OS_OSF
 #endif
 
-#if defined(__WIN32) || defined(__WIN64) || defined(__WINNT)
+#if defined(__WIN32) || defined(__WIN64) || defined(_WIN32) || defined(_WIN64) || defined(__WINNT)
 OS_WINNT
 #endif
 
@@ -141,7 +141,7 @@ ARCH_SPARC
 ARCH_IA64
 #endif
 
-#if defined(__LP64) || defined(__LP64__) || defined(__ptr64) || defined(__x86_64__) || defined(__amd64__) || defined(__64BIT__)
+#if defined(__LP64) || defined(__LP64__) || defined(__ptr64) || defined(__x86_64__) || defined(__amd64__) || defined(__64BIT__) || defined(__aarch64__)
 BINARY_64
 #endif
 

--- a/utest/ctest.h
+++ b/utest/ctest.h
@@ -65,8 +65,13 @@ struct ctest {
 #undef CTEST_SEGFAULT
 #endif
 
-#if defined(_WIN32) && defined(_MSC_VER)
+#if defined(_WIN32)
+#if defined(__clang__)
+#define __CTEST_NO_TIME
+#undef CTEST_SEGFAULT
+#elif defined(_MSC_VER)
 #define __CTEST_MSVC
+#endif
 #endif
 
 //config for MSVC compiler
@@ -286,7 +291,7 @@ void assert_dbl_far(double exp, double real, double tol, const char* caller, int
 #endif
 #include <stdint.h>
 
-#ifdef __CTEST_MSVC
+#ifdef _WIN32
 #include <io.h>
 #else
 #include <unistd.h>


### PR DESCRIPTION
This change would enable building OpenBLAS (without LAPACK) using clang on a windows on arm machine.

```
cmake ..  -G Ninja -DCMAKE_C_COMPILER=clang -DBUILD_WITHOUT_LAPACK=1 -DNOFORTRAN=1 -DDYNAMIC_ARCH=0 -DTARGET=ARMV8 -DARCH=arm64 -DBINARY=64 -DUSE_OPENMP=0

cmake --build . --config Release
```
### Log for unit test

TEST 1/31 min:smin_negative [OK]
TEST 2/31 min:dmin_positive [OK]
TEST 3/31 min:smin_zero [OK]
TEST 4/31 max:smax_negative [OK]
TEST 5/31 max:dmax_positive [OK]
TEST 6/31 max:smax_zero [OK]
TEST 7/31 amax:samax [OK]
TEST 8/31 amax:damax [OK]
TEST 9/31 ismin:positive_step_2 [OK]
TEST 10/31 ismin:negative_step_2 [OK]
TEST 11/31 ismax:positive_step_2 [OK]
TEST 12/31 ismax:negative_step_2 [OK]
TEST 18/31 rot:zdrot_inc_0 [OK]
TEST 19/31 rot:srot_inc_0 [OK]
TEST 20/31 rot:csrot_inc_0 [OK]
TEST 21/31 axpy:daxpy_inc_0 [OK]
TEST 22/31 axpy:zaxpy_inc_0 [OK]
TEST 23/31 axpy:saxpy_inc_0 [OK]
TEST 24/31 axpy:caxpy_inc_0 [OK]
TEST 25/31 dsdot:dsdot_n_1 [OK]
TEST 26/31 swap:dswap_inc_0 [OK]
TEST 27/31 swap:zswap_inc_0 [OK]
TEST 28/31 swap:sswap_inc_0 [OK]
TEST 29/31 swap:cswap_inc_0 [OK]
TEST 30/31 zdotu:zdotu_n_1 [OK]
TEST 31/31 zdotu:zdotu_offset_1 [OK]
←[0;32mRESULTS: 31 tests (31 ok, 0 failed, 0 skipped)←[0m