### PR TITLE
POWER: Fixing syntax error in makefile

### DIFF
--- a/Makefile.power
+++ b/Makefile.power
@@ -12,7 +12,7 @@ endif
 ifeq ($(CORE), POWER10)
 ifneq ($(C_COMPILER), PGI)
 CCOMMON_OPT += -Ofast -mcpu=power10 -mtune=power10 -mvsx -fno-fast-math
-ifeq ($(F_COMPILER, IBM)
+ifeq ($(F_COMPILER), IBM)
 FCOMMON_OPT += -O2 -qrecur -qnosave
 else
 FCOMMON_OPT += -O2 -frecursive -mcpu=power10 -mtune=power10  -fno-fast-math


### PR DESCRIPTION
Fixing syntax issue in Makefile.power added by recent commit
af19cda65aef4d033ae33213013c88b0a99f9da2