### PR TITLE
Remove extraneous qualifiers from struct definition

### DIFF
--- a/driver/others/memory.c
+++ b/driver/others/memory.c
@@ -2695,7 +2695,7 @@ static volatile struct {
 
 } memory[NUM_BUFFERS];
 
-static volatile struct newmemstruct 
+struct newmemstruct 
 {
   BLASULONG lock;
   void *addr;


### PR DESCRIPTION
fixes another harmless warning in recent code