### PR TITLE
Makefile.system: adjust mipsel/mips64el ARCH variables

### DIFF
--- a/Makefile.system
+++ b/Makefile.system
@@ -33,6 +33,10 @@ else ifeq ($(ARCH), armv7)
 override ARCH=arm
 else ifeq ($(ARCH), aarch64)
 override ARCH=arm64
+else ifeq ($(ARCH), mipsel)
+override ARCH=mips
+else ifeq ($(ARCH), mips64el)
+override ARCH=mips64
 else ifeq ($(ARCH), zarch)
 override ARCH=zarch
 endif


### PR DESCRIPTION
When building for MIPS{64} little-endian variants, the included makefiles
should be the same as for the big-endian.

There are already some adjustments being done for some ARCH names.
This change adds the ones for the `mipsel` and `mips64el` names, so that
the Makefile.mips{64} files get included.

This comes as a result of: https://github.com/openwrt/packages/issues/16649

Signed-off-by: Alexandru Ardelean <ardeleanalex@gmail.com>