### PR TITLE
Fix minor typo in Makefile.system

### DIFF
--- a/Makefile.system
+++ b/Makefile.system
@@ -307,7 +307,7 @@ else
 SMP = 1
 endif
 else
-ifeq ($(NUM_THREAD), 1)
+ifeq ($(NUM_THREADS), 1)
 SMP =
 else
 SMP = 1


### PR DESCRIPTION
impact should be small ("SMP" flag erroneously got set when building with NUM_THREADS=1, possibly causing locking overhead)