### PR TITLE
Add cblas_{c/z}srot cblas_{c/z}rotg support

### DIFF
--- a/interface/zrot.c
+++ b/interface/zrot.c
@@ -42,13 +42,19 @@
 #include "functable.h"
 #endif
 
+#ifndef CBLAS
 void NAME(blasint *N, FLOAT *x, blasint *INCX, FLOAT *y, blasint *INCY, FLOAT *C, FLOAT *S){
-
   BLASLONG n    = *N;
   BLASLONG incx = *INCX;
   BLASLONG incy = *INCY;
   FLOAT c = *C;
   FLOAT s = *S;
+
+#else
+void CNAME(blasint n, void *VX, blasint incx, void *VY, blasint incy, FLOAT c, FLOAT s) {
+    FLOAT *x = (FLOAT*) VX;
+    FLOAT *y = (FLOAT*) VY;
+#endif /* CBLAS */
 
   PRINT_DEBUG_NAME;
 

--- a/interface/zrotg.c
+++ b/interface/zrotg.c
@@ -4,7 +4,15 @@
 #include "functable.h"
 #endif
 
+#ifndef CBLAS
 void NAME(FLOAT *DA, FLOAT *DB, FLOAT *C, FLOAT *S){
+
+#else
+void CNAME(void *VDA, void *VDB, FLOAT *C, void *VS) {
+    FLOAT *DA = (FLOAT*) VDA;
+    FLOAT *DB = (FLOAT*) VDB;
+    FLOAT *S  = (FLOAT*) VS;
+#endif /* CBLAS */
 
 #if defined(__i386__) || defined(__x86_64__) || defined(__ia64__) || defined(_M_X64) || defined(_M_IX86)
 


### PR DESCRIPTION
Fixed the following issue：
```
/usr/bin/ld: /tmp/ccOl9R8p.o: in function `.LM6':
test.c:(.text+0x90): undefined reference to `cblas_crotg'
collect2: error: ld returned 1 exit status
```