### PR TITLE
Fix miscounting of threadpool size on Linux with OMP_PROC_BIND=TRUE

### DIFF
--- a/driver/others/memory.c
+++ b/driver/others/memory.c
@@ -250,7 +250,8 @@ int get_num_procs(void) {
   return nums;
 #endif
 #if defined(USE_OPENMP)
-  if (omp_get_proc_bind() != omp_proc_bind_false)
+/*  if (omp_get_proc_bind() != omp_proc_bind_false)*/
+    nums = omp_get_num_places();
     return nums;
 #endif
 
@@ -1814,7 +1815,8 @@ int get_num_procs(void) {
   return nums;
 #endif
 #if defined(USE_OPENMP)
-  if (omp_get_proc_bind() != omp_proc_bind_false)
+/*  if (omp_get_proc_bind() != omp_proc_bind_false) */
+    nums = omp_get_num_places();	  
     return nums;
 #endif
 

--- a/driver/others/memory.c
+++ b/driver/others/memory.c
@@ -251,7 +251,9 @@ int get_num_procs(void) {
 #endif
 #if defined(USE_OPENMP)
 /*  if (omp_get_proc_bind() != omp_proc_bind_false)*/
+#if _OPENMP >= 201307
     nums = omp_get_num_places();
+#endif
     return nums;
 #endif
 
@@ -1816,7 +1818,9 @@ int get_num_procs(void) {
 #endif
 #if defined(USE_OPENMP)
 /*  if (omp_get_proc_bind() != omp_proc_bind_false) */
+#if_OPENMP >= 201307
     nums = omp_get_num_places();	  
+#endif
     return nums;
 #endif
 

--- a/driver/others/memory.c
+++ b/driver/others/memory.c
@@ -1817,7 +1817,7 @@ int get_num_procs(void) {
 
 #if defined(USE_OPENMP)
 /*  if (omp_get_proc_bind() != omp_proc_bind_false) */
-#if_OPENMP >= 201307
+#if _OPENMP >= 201307
     nums = omp_get_num_places();	  
 #endif
     return nums;

--- a/driver/others/memory.c
+++ b/driver/others/memory.c
@@ -249,6 +249,10 @@ int get_num_procs(void) {
 #if !defined(OS_LINUX)
   return nums;
 #endif
+#if defined(USE_OPENMP)
+  if (omp_get_proc_bind() != omp_proc_bind_false)
+    return nums;
+#endif
 
 #if !defined(__GLIBC_PREREQ)
   return nums;
@@ -1808,6 +1812,10 @@ int get_num_procs(void) {
   if (!nums) nums = sysconf(_SC_NPROCESSORS_CONF);
 #if !defined(OS_LINUX)
   return nums;
+#endif
+#if defined(USE_OPENMP)
+  if (omp_get_proc_bind() != omp_proc_bind_false)
+    return nums;
 #endif
 
 #if !defined(__GLIBC_PREREQ)

--- a/driver/others/memory.c
+++ b/driver/others/memory.c
@@ -253,7 +253,6 @@ int get_num_procs(void) {
 #endif
     return nums;
 #endif
-#endif
 
 #if !defined(OS_LINUX)
   return nums;
@@ -1822,7 +1821,6 @@ int get_num_procs(void) {
     nums = omp_get_num_places();	  
 #endif
     return nums;
-#endif
 #endif
 
 #if !defined(OS_LINUX)

--- a/driver/others/memory.c
+++ b/driver/others/memory.c
@@ -248,7 +248,7 @@ int get_num_procs(void) {
   if (!nums) nums = sysconf(_SC_NPROCESSORS_CONF);
 
 #if defined(USE_OPENMP)
-#if _OPENMP >= 201307
+#if _OPENMP >= 201511
     nums = omp_get_num_places();
 #endif
     return nums;
@@ -1817,7 +1817,7 @@ int get_num_procs(void) {
 
 #if defined(USE_OPENMP)
 /*  if (omp_get_proc_bind() != omp_proc_bind_false) */
-#if _OPENMP >= 201307
+#if _OPENMP >= 201511
     nums = omp_get_num_places();	  
 #endif
     return nums;

--- a/driver/others/memory.c
+++ b/driver/others/memory.c
@@ -246,15 +246,17 @@ int get_num_procs(void) {
 #endif
 
   if (!nums) nums = sysconf(_SC_NPROCESSORS_CONF);
-#if !defined(OS_LINUX)
-  return nums;
-#endif
+
 #if defined(USE_OPENMP)
-/*  if (omp_get_proc_bind() != omp_proc_bind_false)*/
 #if _OPENMP >= 201307
     nums = omp_get_num_places();
 #endif
     return nums;
+#endif
+#endif
+
+#if !defined(OS_LINUX)
+  return nums;
 #endif
 
 #if !defined(__GLIBC_PREREQ)
@@ -1813,9 +1815,7 @@ int get_num_procs(void) {
 #endif
 
   if (!nums) nums = sysconf(_SC_NPROCESSORS_CONF);
-#if !defined(OS_LINUX)
-  return nums;
-#endif
+
 #if defined(USE_OPENMP)
 /*  if (omp_get_proc_bind() != omp_proc_bind_false) */
 #if_OPENMP >= 201307
@@ -1823,7 +1823,12 @@ int get_num_procs(void) {
 #endif
     return nums;
 #endif
+#endif
 
+#if !defined(OS_LINUX)
+  return nums;
+#endif
+	
 #if !defined(__GLIBC_PREREQ)
   return nums;
 #else


### PR DESCRIPTION
fixes #3435