### PR TITLE
Fix NULL pointer checks in blas_memory_alloc

### DIFF
--- a/driver/others/memory.c
+++ b/driver/others/memory.c
@@ -2921,7 +2921,7 @@ void *blas_memory_alloc(int procpos){
 
       func = &memoryalloc[0];
 
-      while ((func != NULL) && (map_address == (void *) -1)) {
+      while ((*func != NULL) && (map_address == (void *) -1)) {
 
         map_address = (*func)((void *)base_address);
 
@@ -3032,7 +3032,7 @@ allocation2:
 
       func = &memoryalloc[0];
 
-      while ((func != NULL) && (map_address == (void *) -1)) {
+      while ((*func != NULL) && (map_address == (void *) -1)) {
 
         map_address = (*func)((void *)base_address);
 


### PR DESCRIPTION
Same as #3085 but affecting the non-TLS branch
fixes #3441 as suggested by NdK73 there