### PR TITLE
Fix potentially wrong HOSTARCH definition in cross-compilation

### DIFF
--- a/Makefile.system
+++ b/Makefile.system
@@ -9,11 +9,10 @@ ifndef TOPDIR
 TOPDIR = . 
 endif
 
- # If ARCH is not set, we use the host system's architecture for getarch compile options.
-ifndef ARCH
+# we need to use the host system's architecture for getarch compile options even especially when cross-compiling
 HOSTARCH := $(shell uname -m)
-else
-HOSTARCH = $(ARCH)
+ifeq ($(HOSTARCH), amd64)
+HOSTARCH=x86_64
 endif
 
 HAVE_GAS := $(shell as -v < /dev/null 2>&1 | grep GNU 2>&1 >/dev/null)


### PR DESCRIPTION
Fixes cross-compilation for x86_64 on aarch64 (bug introduced by #2110 and  #2239 )
Fixes #3446 as suggested by leleliu008 there