### PR TITLE
cmake: Set SUFFIX64 also for NOFORTRAN

### DIFF
--- a/cmake/fc.cmake
+++ b/cmake/fc.cmake
@@ -3,11 +3,6 @@
 ## Description: Ported from portion of OpenBLAS/Makefile.system
 ##              Sets Fortran related variables.
 
-if (INTERFACE64)
-  set(SUFFIX64 64)
-  set(SUFFIX64_UNDERSCORE _64)
-endif()
-
 if (${F_COMPILER} STREQUAL "FLANG")
   set(CCOMMON_OPT "${CCOMMON_OPT} -DF_INTERFACE_FLANG")
   if (BINARY64 AND INTERFACE64)

--- a/cmake/system.cmake
+++ b/cmake/system.cmake
@@ -239,6 +239,11 @@ include("${PROJECT_SOURCE_DIR}/cmake/arch.cmake")
 # C Compiler dependent settings
 include("${PROJECT_SOURCE_DIR}/cmake/cc.cmake")
 
+if (INTERFACE64)
+  set(SUFFIX64 64)
+  set(SUFFIX64_UNDERSCORE _64)
+endif()
+
 if (NOT NOFORTRAN)
   # Fortran Compiler dependent settings
   include("${PROJECT_SOURCE_DIR}/cmake/fc.cmake")


### PR DESCRIPTION
When building OpenBLAS with `cmake -DINTERFACE64=1` using `gcc`, a suffix is added to the library and other files. That is a good thing imho.
However when doing the same using `clang`, that suffix isn't used.

Afaict, that is because `NOFORTRAN` is set in the latter case and setting these suffices is done depending on `NOFORTRAN` not being set.

IIUC, it would be ok to set these suffices independent of `NOFORTRAN`.