### PR TITLE
Move the threads overflow flag under the protection of the local blas lock

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -283,6 +283,20 @@ matrix:
       script:
         - travis_wait 45 make && make lapack-test
         
+    - &test-nothread-threads
+      os: linux
+      arch: arm64-graviton2
+      dist: focal
+      group: edge
+      virt: lxd
+      compiler: gcc
+      addons:
+        apt:
+          packages:
+            - gfortran
+      script:
+        - travis_wait 45 make USE_THREAD=0 CPP_THREAD_SAFETY_TEST=1
+       
 # whitelist
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -282,20 +282,6 @@ matrix:
             - gfortran
       script:
         - travis_wait 45 make && make lapack-test
-        
-    - &test-nothread-threads
-      os: linux
-      arch: arm64-graviton2
-      dist: focal
-      group: edge
-      virt: lxd
-      compiler: gcc
-      addons:
-        apt:
-          packages:
-            - gfortran
-      script:
-        - travis_wait 45 make USE_THREAD=0 CPP_THREAD_SAFETY_TEST=1
        
 # whitelist
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -282,7 +282,7 @@ matrix:
             - gfortran
       script:
         - travis_wait 45 make && make lapack-test
-       
+   
 # whitelist
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -282,7 +282,7 @@ matrix:
             - gfortran
       script:
         - travis_wait 45 make && make lapack-test
-   
+        
 # whitelist
 branches:
   only:

--- a/driver/others/memory.c
+++ b/driver/others/memory.c
@@ -2871,32 +2871,28 @@ void *blas_memory_alloc(int procpos){
     position ++;
 
   } while (position < NUM_BUFFERS);
-#if (defined(SMP) || defined(USE_LOCKING)) && !defined(USE_OPENMP)
-  UNLOCK_COMMAND(&alloc_lock);
-#endif
+
   if (memory_overflowed) {
-#if (defined(SMP) || defined(USE_LOCKING)) && !defined(USE_OPENMP)
-  LOCK_COMMAND(&alloc_lock);
-#endif
-  do {
-    RMB;
+
+    do {
+      RMB;
 #if defined(USE_OPENMP)
-    if (!newmemory[position-NUM_BUFFERS].used) {
-      blas_lock(&newmemory[position-NUM_BUFFERS].lock);
+      if (!newmemory[position-NUM_BUFFERS].used) {
+        blas_lock(&newmemory[position-NUM_BUFFERS].lock);
 #endif
-      if (!newmemory[position-NUM_BUFFERS].used) goto allocation2;
+        if (!newmemory[position-NUM_BUFFERS].used) goto allocation2;
 
 #if defined(USE_OPENMP)
-      blas_unlock(&newmemory[position-NUM_BUFFERS].lock);
-    }
+        blas_unlock(&newmemory[position-NUM_BUFFERS].lock);
+      }
 #endif
-    position ++;
+      position ++;
 
-  } while (position < 512+NUM_BUFFERS);
+    } while (position < 512+NUM_BUFFERS);
+  }
 #if (defined(SMP) || defined(USE_LOCKING)) && !defined(USE_OPENMP)
   UNLOCK_COMMAND(&alloc_lock);
 #endif
-} 
   goto error;
 
   allocation :
@@ -3001,6 +2997,9 @@ void *blas_memory_alloc(int procpos){
   return (void *)memory[position].addr;
 
  error:
+#if (defined(SMP) || defined(USE_LOCKING)) && !defined(USE_OPENMP)
+  LOCK_COMMAND(&alloc_lock);
+#endif
  if (memory_overflowed) goto terminate;
   fprintf(stderr,"OpenBLAS warning: precompiled NUM_THREADS exceeded, adding auxiliary array for thread metadata.\n");
   memory_overflowed=1;
@@ -3014,7 +3013,6 @@ void *blas_memory_alloc(int procpos){
   newmemory[i].used   = 0;
   newmemory[i].lock   = 0;
 }
-  newmemory[position-NUM_BUFFERS].used = 1;
   
 allocation2:
   newmemory[position-NUM_BUFFERS].used = 1;
@@ -3086,6 +3084,9 @@ allocation2:
   return (void *)newmemory[position-NUM_BUFFERS].addr;
 
 terminate:
+#if (defined(SMP) || defined(USE_LOCKING)) && !defined(USE_OPENMP)
+    UNLOCK_COMMAND(&alloc_lock);
+#endif
   printf("OpenBLAS : Program is Terminated. Because you tried to allocate too many memory regions.\n");
   printf("This library was built to support a maximum of %d threads - either rebuild OpenBLAS\n", NUM_BUFFERS);
   printf("with a larger NUM_THREADS value or set the environment variable OPENBLAS_NUM_THREADS to\n");


### PR DESCRIPTION
should fix races seen in #3470 when the NUM_THREADS overflow condition is triggered