### PR TITLE
Makefile: also consider -O, -Og and -Os when stripping flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ export NOFORTRAN
 export NO_LAPACK
 endif
 
-LAPACK_NOOPT := $(filter-out -O0 -O1 -O2 -O3 -Ofast,$(LAPACK_FFLAGS))
+LAPACK_NOOPT := $(filter-out -O0 -O1 -O2 -O3 -Ofast -O -Og -Os,$(LAPACK_FFLAGS))
 
 SUBDIRS_ALL = $(SUBDIRS) test ctest utest exports benchmark ../laswp ../bench cpp_thread_test
 


### PR DESCRIPTION
gcc also supports `-O`, `-Og` and `-Os` as optimization flags.
They may be given on the make command-line by users.

For the calculation of `LAPACK_NOOPT`, all such flags should be considered.

Signed-off-by: Thomas De Schampheleire <thomas.de_schampheleire@nokia.com>
[Retrieved from: https://git.buildroot.net/buildroot/tree/package/openblas/0003-Makefile-also-consider-Os-when-determining-LAPACK_NO.patch]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>