### PR TITLE
cmake: Check if Fortran compiler is usable before enabling it.

### DIFF
--- a/cmake/f_check.cmake
+++ b/cmake/f_check.cmake
@@ -20,19 +20,16 @@
 # NEEDBUNDERSCORE
 # NEED2UNDERSCORES
 
-if (NOT NO_LAPACK)
-  include(CheckLanguage)
-  check_language(Fortran)
-  if(CMAKE_Fortran_COMPILER)
-    enable_language(Fortran)
-  else()
-  message(STATUS "No Fortran compiler found, can build only BLAS but not LAPACK")
+include(CheckLanguage)
+check_language(Fortran)
+if(CMAKE_Fortran_COMPILER)
+  enable_language(Fortran)
+else()
+  if (NOT NO_LAPACK)
+    message(STATUS "No Fortran compiler found, can build only BLAS but not LAPACK")
+  endif()
   set (NOFORTRAN 1)
   set (NO_LAPACK 1)
-  endif()
-else()
-  include(CMakeForceCompiler)
-  CMAKE_FORCE_Fortran_COMPILER(gfortran GNU)
 endif()
 
 if (NOT ONLY_CBLAS)


### PR DESCRIPTION
When configuring with `cmake -DBUILD_WITHOUT_LAPACK=ON`, the Fortran compiler is forced to be `gfortran`. That causes the configuration (for the tests) to fail if no Fortran compiler is installed.
I don't understand why the compiler is forced to `gfortran` in that case. Afaict, that shouldn't be necessary.

The proposed change lets the build system check if a Fortran compiler is available before using it. 
