### PR TITLE
Treat AVX512-enabled Alder Lake like Cooper Lake/Sapphire Rapids

### DIFF
--- a/cpuid_x86.c
+++ b/cpuid_x86.c
@@ -1495,6 +1495,10 @@ int get_cpuname(void){
         switch (model) {
         case 7: // Alder Lake desktop
         case 10: // Alder Lake mobile
+	  if(support_avx512_bf16())
+            return CPUTYPE_COOPERLAKE;	
+          if(support_avx512())
+            return CPUTYPE_SKYLAKEX;
           if(support_avx2())
             return CPUTYPE_HASWELL;
           if(support_avx())

--- a/driver/others/dynamic.c
+++ b/driver/others/dynamic.c
@@ -708,8 +708,11 @@ static gotoblas_t *get_coretype(void){
 	
       case 9:
         if (model == 7 || model == 10) { // Alder Lake
+	   if(support_avx512_bf16())
+             return &gotoblas_COOPERLAKE;
+          if (support_avx512()) 
+	    return &gotoblas_SKYLAKEX;
           if(support_avx2()){
-            openblas_warning(FALLBACK_VERBOSE, HASWELL_FALLBACK);
             return &gotoblas_HASWELL;
           }
           if(support_avx()) {


### PR DESCRIPTION
fixes #3490 for Alder Lake systems with E cores disabled and AVX512 enabled in (suitable older) BIOS