### PR TITLE
Add .NOTPARALLEL: to MATGEN Makefile as a workaround for builds on DFS

### DIFF
--- a/lapack-netlib/TESTING/MATGEN/Makefile
+++ b/lapack-netlib/TESTING/MATGEN/Makefile
@@ -66,6 +66,7 @@ ZMATGEN = zlatms.o zlatme.o zlatmr.o zlatmt.o \
 endif
 
 .PHONY: all
+.NOTPARALLEL:
 all: $(TMGLIB)
 
 ALLOBJ = $(SMATGEN) $(CMATGEN) $(SCATGEN) $(DMATGEN) $(ZMATGEN) \


### PR DESCRIPTION
... as there are now two reports that this fixes #2973 (even if we just got lucky for the time being - this has much less of an impact on non-DFS builds than building all of LAPACK sequentially