### PR TITLE
Fix compilation of Skylake AVX512 kernels with GCC 6

### DIFF
--- a/kernel/x86_64/dgemm_small_kernel_nn_skylakex.c
+++ b/kernel/x86_64/dgemm_small_kernel_nn_skylakex.c
@@ -590,6 +590,6 @@ int CNAME(BLASLONG M, BLASLONG N, BLASLONG K, FLOAT * A, BLASLONG lda, FLOAT alp
 	return 0;
 }
 #else
-#include ../generic/gemm_small_matrix_kernel_nn.c
+#include "../generic/gemm_small_matrix_kernel_nn.c"
 #endif
 

--- a/kernel/x86_64/dgemm_small_kernel_tn_skylakex.c
+++ b/kernel/x86_64/dgemm_small_kernel_tn_skylakex.c
@@ -322,6 +322,6 @@ int CNAME(BLASLONG M, BLASLONG N, BLASLONG K, FLOAT * A, BLASLONG lda, FLOAT alp
 	return 0;
 }
 #else
-#include ../generic/gemm_small_matrix_kernel_tn.c
+#include "../generic/gemm_small_matrix_kernel_tn.c"
 #endif
 

--- a/kernel/x86_64/sgemm_small_kernel_nn_skylakex.c
+++ b/kernel/x86_64/sgemm_small_kernel_nn_skylakex.c
@@ -612,6 +612,6 @@ int CNAME(BLASLONG M, BLASLONG N, BLASLONG K, FLOAT * A, BLASLONG lda, FLOAT alp
 	return 0;
 }
 #else
-#include ../generic/gemm_small_matrix_kernel_nn.c
+#include "../generic/gemm_small_matrix_kernel_nn.c"
 #endif
 

--- a/kernel/x86_64/sgemm_small_kernel_tn_skylakex.c
+++ b/kernel/x86_64/sgemm_small_kernel_tn_skylakex.c
@@ -316,6 +316,6 @@ int CNAME(BLASLONG M, BLASLONG N, BLASLONG K, FLOAT * A, BLASLONG lda, FLOAT alp
 	return 0;
 }
 #else
-#include ../generic/gemm_small_matrix_kernel_tn.c
+#include "../generic/gemm_small_matrix_kernel_tn.c"
 #endif
 


### PR DESCRIPTION
Ref: https://github.com/xianyi/OpenBLAS/pull/3541#discussion_r813384485.  I can
confirm with this PR I can build OpenBLAS with GCC 6 for x86_64.