### PR TITLE
No need to set OMP num_threads

### DIFF
--- a/driver/others/blas_server_omp.c
+++ b/driver/others/blas_server_omp.c
@@ -403,7 +403,7 @@ int exec_blas(BLASLONG num, blas_queue_t *queue){
       break;
   }
 
-#pragma omp parallel for num_threads(num) schedule(OMP_SCHED)
+#pragma omp parallel for schedule(OMP_SCHED)
   for (i = 0; i < num; i ++) {
 
 #ifndef USE_SIMPLE_THREADED_LEVEL3


### PR DESCRIPTION
No need to set num_threads, as num_threads(num) will cause more new threads' overhead in some scenarios. In openMP, if your required threads num is larger than your last used num, then new num threads will be created.
With this patch, pts/rbenchmark-1.0.3 will be 2.375x improved (0.385 secs VS 0.164 secs) on the Ice Lake server under CentOS 8.

Here are the steps on how to run rbenchmark on CentOS 8:
1. Install R package 
$ sudo dnf install R
2. Build your openblas
$ make TARGET=CORE2 USE_THREAD=1 USE_OPENMP=1 FC=gfortran CC=gcc  LIBPREFIX="libopenblas" INTERFACE64=0
3. Download R benchmark
$ wget http://www.phoronix-test-suite.com/benchmark-files/rbenchmarks-20160105.tar.bz2
$ tar -xf rbenchmarks-20160105.tar.bz2
$ cd rbenchmarks
$ export LD_LIBRARY_PATH=<Your openblas source root dir>
$ Rscript R-benchmark-25/R-benchmark-25.R
The benchmark' result is like "Overall mean (sum of I, II and III trimmed means/3)_ (sec):  0.166433631462761".