### PR TITLE
Annotate LAPACKE_lsame with attribute const for GCC(+compatible)

### DIFF
--- a/lapack-netlib/LAPACKE/include/lapacke_utils.h
+++ b/lapack-netlib/LAPACKE/include/lapacke_utils.h
@@ -67,7 +67,11 @@ extern "C" {
 void LAPACKE_xerbla( const char *name, lapack_int info );
 
 /* Compare two chars (case-insensitive) */
-lapack_logical LAPACKE_lsame( char ca,  char cb );
+lapack_logical LAPACKE_lsame( char ca,  char cb )
+#if defined __GNUC__
+	__attribute__((const))
+#endif
+	;
 
 /* Functions to convert column-major to row-major 2d arrays and vice versa. */
 void LAPACKE_cgb_trans( int matrix_layout, lapack_int m, lapack_int n,


### PR DESCRIPTION
fixes #3543