### PR TITLE
Remove MSVC limitation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,8 @@ include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 
 #######
+option(BUILD_WITHOUT_LAPACK "Do not build LAPACK and LAPACKE (Only BLAS or CBLAS)" OFF)
+
 option(BUILD_WITHOUT_CBLAS "Do not build the C interface (CBLAS) to the BLAS functions" OFF)
 
 option(DYNAMIC_ARCH "Include support for multiple CPU targets, with automatic selection at runtime (x86/x86_64, aarch64 or ppc only)" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,15 +17,7 @@ include(GNUInstallDirs)
 
 include(CMakePackageConfigHelpers)
 
-if(MSVC AND NOT DEFINED NOFORTRAN)
-  set(NOFORTRAN ON)
-endif()
-
 #######
-if(MSVC)
-  option(BUILD_WITHOUT_LAPACK "Do not build LAPACK and LAPACKE (Only BLAS or CBLAS)" ON)
-endif()
-
 option(BUILD_WITHOUT_CBLAS "Do not build the C interface (CBLAS) to the BLAS functions" OFF)
 
 option(DYNAMIC_ARCH "Include support for multiple CPU targets, with automatic selection at runtime (x86/x86_64, aarch64 or ppc only)" OFF)


### PR DESCRIPTION
Hi there! I've tweaked the `CMakeFiles.txt` to allow `LAPACK` to be compiled in `MSVC` using `vcpkg`. Essentially I've patched `vcpkg` to provide the `gfortran` compiler as default Fortran compiler.

The build steps are:

- Install `vcpkg`,
- Execute `vcpkg install openblas`.

A reproducible pipeline example can be found [here](https://github.com/AlessioZanga/grathe/blob/AlessioZanga/issue31/.github/workflows/build.yml).

If this pull request will be accepted, I'll update my `vcpkg` fork to this ref and submit a pull request to integrate this changes.