### PR TITLE
Create independent kernel Makfile & configuration when building DYNAM…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -387,11 +387,11 @@ clean ::
 	@$(MAKE) -C kernel clean
 #endif
 	@$(MAKE) -C reference clean
-	@rm -f *.$(LIBSUFFIX) *.so *~ *.exe getarch getarch_2nd *.dll *.lib *.$(SUFFIX) *.dwf $(LIBPREFIX).$(LIBSUFFIX) $(LIBPREFIX)_p.$(LIBSUFFIX) $(LIBPREFIX).so.$(MAJOR_VERSION) *.lnk myconfig.h *.so.renamed *.a.renamed *.so.0
+	@rm -f *.$(LIBSUFFIX) *.so *~ *.exe getarch getarch-* getarch_2nd getarch_2nd-* *.dll *.lib *.$(SUFFIX) *.dwf $(LIBPREFIX).$(LIBSUFFIX) $(LIBPREFIX)_p.$(LIBSUFFIX) $(LIBPREFIX).so.$(MAJOR_VERSION) *.lnk myconfig.h *.so.renamed *.a.renamed *.so.0
 ifeq ($(OSNAME), Darwin)
 	@rm -rf getarch.dSYM getarch_2nd.dSYM
 endif
-	@rm -f Makefile.conf config.h Makefile_kernel.conf config_kernel.h st* *.dylib
+	@rm -f Makefile.conf config.h Makefile_kernel*.conf config_kernel*.h st* *.dylib
 	@rm -f cblas.tmp cblas.tmp2
 	@touch $(NETLIB_LAPACK_DIR)/make.inc
 	@$(MAKE) -C $(NETLIB_LAPACK_DIR) clean

--- a/Makefile.prebuild
+++ b/Makefile.prebuild
@@ -8,11 +8,19 @@ override HOST_CFLAGS += -DDYNAMIC_ARCH
 endif
 
 ifdef TARGET_CORE
+ifdef DYNAMIC_ARCH
+TARGET_MAKE = Makefile_kernel_$(TARGET_CORE).conf
+TARGET_CONF = config_kernel_$(TARGET_CORE).h
+GETARCH_FLAVOR = -$(TARGET_CORE)
+else
 TARGET_MAKE = Makefile_kernel.conf
 TARGET_CONF = config_kernel.h
+GETARCH_FLAVOR = -$(TARGET_CORE)
+endif
 else
 TARGET_MAKE = Makefile.conf
 TARGET_CONF = config.h
+GETARCH_FLAVOR =
 endif
 
 # CPUIDEMU = ../../cpuid/table.o
@@ -49,11 +57,11 @@ ifeq ($(TARGET), C910V)
 TARGET_FLAGS = -march=rv64gcvxthead -mabi=lp64v
 endif
 
-all: getarch_2nd
-	./getarch_2nd  0 >> $(TARGET_MAKE)
-	./getarch_2nd  1 >> $(TARGET_CONF)
+all: getarch_2nd$(GETARCH_FLAVOR)
+	./getarch_2nd$(GETARCH_FLAVOR)  0 >> $(TARGET_MAKE)
+	./getarch_2nd$(GETARCH_FLAVOR)  1 >> $(TARGET_CONF)
 
-config.h : c_check f_check getarch
+config.h : c_check f_check getarch$(GETARCH_FLAVOR)
 	perl ./c_check $(TARGET_MAKE) $(TARGET_CONF) $(CC) $(TARGET_FLAGS) $(CFLAGS)
 ifneq ($(ONLY_CBLAS), 1)
 	perl ./f_check $(TARGET_MAKE) $(TARGET_CONF) $(FC) $(TARGET_FLAGS)
@@ -66,18 +74,18 @@ else
 	echo "#define BUNDERSCORE _" >> $(TARGET_CONF)
 	echo "#define NEEDBUNDERSCORE 1" >> $(TARGET_CONF)
 endif
-	./getarch 0 >> $(TARGET_MAKE)
-	./getarch 1 >> $(TARGET_CONF)
+	./getarch$(GETARCH_FLAVOR) 0 >> $(TARGET_MAKE)
+	./getarch$(GETARCH_FLAVOR) 1 >> $(TARGET_CONF)
 
 
-getarch : getarch.c cpuid.S dummy $(CPUIDEMU)
+getarch$(GETARCH_FLAVOR) : getarch.c cpuid.S dummy $(CPUIDEMU)
 	$(HOSTCC) $(HOST_CFLAGS) $(EXFLAGS) -o $(@F) getarch.c cpuid.S $(CPUIDEMU)
 
-getarch_2nd : getarch_2nd.c config.h dummy
+getarch_2nd$(GETARCH_FLAVOR) : getarch_2nd.c config.h dummy
 ifndef TARGET_CORE
 	$(HOSTCC) -I. $(HOST_CFLAGS) -o $(@F) getarch_2nd.c
 else
-	$(HOSTCC) -I. $(HOST_CFLAGS) -DBUILD_KERNEL -o $(@F) getarch_2nd.c
+	$(HOSTCC) -I. $(HOST_CFLAGS) -DBUILD_KERNEL -DKERNEL_CONFIG=\"$(TARGET_CONF)\" -o $(@F) getarch_2nd.c
 endif
 
 dummy:

--- a/Makefile.system
+++ b/Makefile.system
@@ -298,7 +298,11 @@ HAVE_SSE5=
 HAVE_AVX=
 HAVE_AVX2=
 HAVE_FMA3=
+ifeq ($(DYNAMIC_ARCH), 1)
+include $(TOPDIR)/Makefile_kernel_$(TARGET_CORE).conf
+else
 include $(TOPDIR)/Makefile_kernel.conf
+endif
 endif
 
 endif

--- a/cmake/prebuild.cmake
+++ b/cmake/prebuild.cmake
@@ -629,7 +629,11 @@ else(NOT CMAKE_CROSSCOMPILING)
   endif ()
 
   set(GETARCH_DIR "${PROJECT_BINARY_DIR}/getarch_build")
-  set(GETARCH_BIN "getarch${CMAKE_EXECUTABLE_SUFFIX}")
+  if (DEFINED TARGET_CORE)
+    set(GETARCH_BIN "getarch-${TARGET_CORE}${CMAKE_EXECUTABLE_SUFFIX}")
+  else ()
+    set(GETARCH_BIN "getarch${CMAKE_EXECUTABLE_SUFFIX}")
+  endif ()
   file(MAKE_DIRECTORY ${GETARCH_DIR})
   configure_file(${TARGET_CONF_TEMP} ${GETARCH_DIR}/${TARGET_CONF} COPYONLY)
   if (NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "WindowsStore")
@@ -659,7 +663,7 @@ else(NOT CMAKE_CROSSCOMPILING)
   unset (HAVE_VFP)
   unset (HAVE_VFPV3)
   unset (HAVE_VFPV4)
-  message(STATUS "Running getarch")
+  message(STATUS "Running getarch (${GETARCH_BIN})")
 
   # use the cmake binary w/ the -E param to run a shell command in a cross-platform way
 execute_process(COMMAND "${PROJECT_BINARY_DIR}/${GETARCH_BIN}" 0 OUTPUT_VARIABLE GETARCH_MAKE_OUT)
@@ -672,7 +676,11 @@ execute_process(COMMAND "${PROJECT_BINARY_DIR}/${GETARCH_BIN}" 1 OUTPUT_VARIABLE
   ParseGetArchVars(${GETARCH_MAKE_OUT})
 
   set(GETARCH2_DIR "${PROJECT_BINARY_DIR}/getarch2_build")
-  set(GETARCH2_BIN "getarch_2nd${CMAKE_EXECUTABLE_SUFFIX}")
+  if (DEFINED TARGET_CORE)
+     set(GETARCH2_BIN "getarch_2nd-${TARGET_CORE}${CMAKE_EXECUTABLE_SUFFIX}")
+  else ()
+     set(GETARCH2_BIN "getarch_2nd${CMAKE_EXECUTABLE_SUFFIX}")
+  endif ()
   file(MAKE_DIRECTORY ${GETARCH2_DIR})
   configure_file(${TARGET_CONF_TEMP} ${GETARCH2_DIR}/${TARGET_CONF} COPYONLY)
   if (NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "WindowsStore")
@@ -684,7 +692,7 @@ execute_process(COMMAND "${PROJECT_BINARY_DIR}/${GETARCH_BIN}" 1 OUTPUT_VARIABLE
     )
 
     if (NOT ${GETARCH2_RESULT})
-      MESSAGE(FATAL_ERROR "Compiling getarch_2nd failed ${GETARCH2_LOG}")
+      MESSAGE(FATAL_ERROR "Compiling getarch_2nd (${GETARCH2_BIN}) failed ${GETARCH2_LOG}")
     endif ()
   endif ()
 

--- a/common.h
+++ b/common.h
@@ -57,7 +57,11 @@ extern "C" {
 #endif
 
 #ifdef BUILD_KERNEL
+#ifdef KERNEL_CONFIG
+#include KERNEL_CONFIG
+#else
 #include "config_kernel.h"
+#endif
 #else
 #include "config.h"
 #endif

--- a/getarch_2nd.c
+++ b/getarch_2nd.c
@@ -2,7 +2,11 @@
 #ifndef BUILD_KERNEL
 #include "config.h"
 #else
+#ifdef KERNEL_CONFIG
+#include KERNEL_CONFIG
+#else
 #include "config_kernel.h"
+#endif
 #endif
 #if (defined(__WIN32__) || defined(__WIN64__) || defined(__CYGWIN32__) || defined(__CYGWIN64__) || defined(_WIN32) || defined(_WIN64)) && defined(__64BIT__)
 typedef long long BLASLONG;

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -124,7 +124,7 @@ COMMONOBJS	+= lsame.$(SUFFIX) scabs1.$(SUFFIX) dcabs1.$(SUFFIX)
 
 ifeq ($(DYNAMIC_ARCH), 1)
 SBLASOBJS	+= setparam$(TSUFFIX).$(SUFFIX)
-CCOMMON_OPT	+= -DTS=$(TSUFFIX)
+CCOMMON_OPT	+= -DTS=$(TSUFFIX) -DKERNEL_CONFIG=\"config_kernel$(TSUFFIX).h\"
 endif
 
 KERNEL_INTERFACE = ../common_level1.h ../common_level2.h ../common_level3.h


### PR DESCRIPTION
…IC_ARCH

- For 'classic' builds, generate separate config_kernel_<TARGET>.h,
  Makfile_<TARGET>.conf and getarch-<TARGET> files/binaries
- For cmake builds, generate separate getarch-<TARGET> binaries
for better debugging.

Signed-off-by: Egbert Eich <eich@suse.com>