### PR TITLE
Fix broken elif in dynamic.c

### DIFF
--- a/driver/others/dynamic.c
+++ b/driver/others/dynamic.c
@@ -96,7 +96,7 @@ extern gotoblas_t gotoblas_BARCELONA;
 #endif
 #ifdef DYN_ATOM
 extern gotoblas_t gotoblas_ATOM;
-elif defined(DYN_NEHALEM)
+#elif defined(DYN_NEHALEM)
 #define gotoblas_ATOM gotoblas_NEHALEM
 #else
 #define gotoblas_ATOM gotoblas_PRESCOTT


### PR DESCRIPTION
This fixes compilation in the following case:

```
$(MAKE) USE_OPENMP=1 USE_THREAD=1 NO_LAPACK=0 DYNAMIC_ARCH=1 \
DYNAMIC_LIST="HASWELL SKYLAKEX ATOM COOPERLAKE SAPPHIRERAPIDS ZEN"
```