### PR TITLE
Skip BLAS tests if Windows powershell added a BOM

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -30,6 +30,10 @@ if(WIN32)
 FILE(WRITE ${CMAKE_CURRENT_BINARY_DIR}/test_helper.ps1
 "if (Test-Path $args[2]) { Remove-Item -Force $args[2] } \n"
 "$ErrorActionPreference = \"Stop\"\n"
+"If ((Get-Content $args[1] | & file - | %{$_ -match \"BOM\"}) -contains $true) {\n"
+"echo 'Skipped due to wrong input encoding'\n"
+"exit 0\n"
+"}\n"
 "Get-Content $args[1] | & $args[0]\n"
 "If ((Get-Content $args[2] | %{$_ -match \"FATAL\"}) -contains $true) {\n"
 "echo Error\n"


### PR DESCRIPTION
In some unclear circumstances (seen on Azure CI), powershell prepends a byte order mark to the first line of the .dat file. As this line holds the name of the output file, the test results end up in misnamed files (the three bytes of the BOM interpreted as characters, plus the intended name complete with quote characters), leading to test failures as the script cannot find them. 