### PR TITLE
Fix malfunctioning AVX512 check

### DIFF
--- a/Makefile.prebuild
+++ b/Makefile.prebuild
@@ -71,7 +71,8 @@ endif
 
 
 getarch : getarch.c cpuid.S dummy $(CPUIDEMU)
-	$(HOSTCC) $(HOST_CFLAGS) $(EXFLAGS) -o $(@F) getarch.c cpuid.S $(CPUIDEMU)
+	avx512=$$(perl c_check - - gcc | grep NO_AVX512); \
+	$(HOSTCC) $(HOST_CFLAGS) $(EXFLAGS) $${avx512:+-D$${avx512}} -o $(@F) getarch.c cpuid.S $(CPUIDEMU)
 
 getarch_2nd : getarch_2nd.c config.h dummy
 ifndef TARGET_CORE

--- a/c_check
+++ b/c_check
@@ -254,7 +254,7 @@ if (($architecture eq "x86") || ($architecture eq "x86_64")) {
 #	$tmpf = new File::Temp( UNLINK => 1 );
 	($fh,$tmpf) = tempfile( SUFFIX => '.c' , UNLINK => 1 );
 	$code = '"vbroadcastss -4 * 4(%rsi), %zmm2"';
-	print $tmpf "#include <immintrin.h>\n\nint main(void){ __asm__ volatile($code); }\n";
+	print $fh "#include <immintrin.h>\n\nint main(void){ __asm__ volatile($code); }\n";
 	$args = " -march=skylake-avx512 -c -o $tmpf.o $tmpf";
 	if ($compiler eq "PGI") {
 	    $args = " -tp skylake -c -o $tmpf.o $tmpf";
@@ -278,7 +278,7 @@ if ($data =~ /HAVE_C11/) {
        $c11_atomics = 0;
     } else {
        ($fh,$tmpf) = tempfile( SUFFIX => '.c' , UNLINK => 1 );
-       print $tmpf "#include <stdatomic.h>\nint main(void){}\n";
+       print $fh "#include <stdatomic.h>\nint main(void){}\n";
        $args = " -c -o $tmpf.o $tmpf";
        my @cmd = ("$compiler_name $flags $args >/dev/null 2>/dev/null");
        system(@cmd) == 0;

--- a/getarch.c
+++ b/getarch.c
@@ -94,14 +94,6 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <sys/sysinfo.h>
 #endif
 
-#if defined(__x86_64__) || defined(_M_X64)
-#if (( defined(__GNUC__)  && __GNUC__   > 6 && defined(__AVX2__)) || (defined(__clang__) && __clang_major__ >= 6))
-#else
-#ifndef NO_AVX512
-#define NO_AVX512
-#endif
-#endif
-#endif
 /* #define FORCE_P2		*/
 /* #define FORCE_KATMAI		*/
 /* #define FORCE_COPPERMINE	*/


### PR DESCRIPTION
As explained in https://github.com/xianyi/OpenBLAS/issues/3557, the additional test introduced in https://github.com/xianyi/OpenBLAS/pull/1980 to ensure that the compiler is capable of handling AVX512 instructions is broken when compiled with gcc. As it turns out, the CMAKE build was already making the state of the NO_AVX512 variable from c_check available to the getarch build, this PR adds the equivalent for gmake. Additionally, the test in c_check appears to have been broken (always returning AVX512-capable) since 0.3.8 
Supersedes PR #3571 with a cleaner solution following suggestions by @e4t . 