### PR TITLE
Use CC and full command line instead of hard-coding gcc for AVX512 ch…

### DIFF
--- a/Makefile.prebuild
+++ b/Makefile.prebuild
@@ -71,7 +71,7 @@ endif
 
 
 getarch : getarch.c cpuid.S dummy $(CPUIDEMU)
-	avx512=$$(perl c_check - - gcc | grep NO_AVX512); \
+	avx512=$$(perl c_check - - $(CC) $(TARGET_FLAGS) $(CFLAGS) | grep NO_AVX512); \
 	$(HOSTCC) $(HOST_CFLAGS) $(EXFLAGS) $${avx512:+-D$${avx512}} -o $(@F) getarch.c cpuid.S $(CPUIDEMU)
 
 getarch_2nd : getarch_2nd.c config.h dummy


### PR DESCRIPTION
…ecking

Hard-coding gcc may not provide incorrect results when a different compiler
for the target build is used. To remain in sync with the main call to c_check,
pass the full command line.

Signed-off-by: Egbert Eich <eich@suse.com>