### PR TITLE
Do not include symbols defined in driver/others/parameter.c in DYNAMI…

### DIFF
--- a/common_macro.h
+++ b/common_macro.h
@@ -2610,8 +2610,9 @@
 #endif
 
 #ifndef ASSEMBLER
-#if defined(ARCH_X86) || defined(ARCH_X86_64) || defined(ARCH_IA64) || defined(ARCH_MIPS64) || defined(ARCH_ARM64)\
-|| defined(ARCH_LOONGARCH64) || defined(ARCH_E2K)
+#if !defined(DYNAMIC_ARCH) \
+  && (defined(ARCH_X86) || defined(ARCH_X86_64) || defined(ARCH_IA64) || defined(ARCH_MIPS64) || defined(ARCH_ARM64) \
+      || defined(ARCH_LOONGARCH64) || defined(ARCH_E2K))
 extern BLASLONG gemm_offset_a;
 extern BLASLONG gemm_offset_b;
 extern BLASLONG sbgemm_p;


### PR DESCRIPTION
…C_ARCH

driver/others/parameter.c does not get build during DYNAMIC_ARCH, thus,
do not declare its symbols. This will make the build fail early and in
an obvious way if functions are trying to use these symbols.

This helps to catch issues like the one fixed in PR #3547 / PR #3580 earlier
as they become obvious when building the library already.

Signed-off-by: Egbert Eich <eich@suse.com>