### PR TITLE
Disable flang (over-)optimizations in BLAS tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,7 +6,7 @@ if (CMAKE_Fortran_COMPILER_ID STREQUAL GNU)
         set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fno-tree-vectorize")
 endif()
 if (CMAKE_Fortran_COMPILER_ID STREQUAL flang)
-	set(CMAKE_Fortran_FLAGS "$CMAKE_Fortran_FLAGS -fno-vectorize -fno-slp-vectorize")
+	set(CMAKE_Fortran_FLAGS "$CMAKE_Fortran_FLAGS -O2")
 endif()
 
 if (BUILD_SINGLE)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,7 +5,7 @@ enable_language(Fortran)
 if (CMAKE_Fortran_COMPILER_ID STREQUAL GNU)
         set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fno-tree-vectorize")
 endif()
-if (CMAKE_Fortran_COMPILER_ID STREQUAL flang)
+if (CMAKE_Fortran_COMPILER_ID STREQUAL Flang)
 	set(CMAKE_Fortran_FLAGS "$CMAKE_Fortran_FLAGS -O2")
 endif()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,7 +5,7 @@ enable_language(Fortran)
 if (CMAKE_Fortran_COMPILER_ID STREQUAL GNU)
         set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fno-tree-vectorize")
 endif()
-if (CMAKE_Fortran_COMPILER_ID STREQUAL FLANG)
+if (CMAKE_Fortran_COMPILER_ID STREQUAL flang)
 	set(CMAKE_Fortran_FLAGS "$CMAKE_Fortran_FLAGS -fno-vectorize -fno-slp-vectorize")
 endif()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,7 +5,9 @@ enable_language(Fortran)
 if (CMAKE_Fortran_COMPILER_ID STREQUAL GNU)
         set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fno-tree-vectorize")
 endif()
-
+if (CMAKE_Fortran_COMPILER_ID STREQUAL FLANG)
+	set(CMAKE_Fortran_FLAGS "$CMAKE_Fortran_FLAGS -fno-vectorize -fno-slp-vectorize")
+endif()
 
 if (BUILD_SINGLE)
 	list( APPEND OpenBLAS_Tests sblat1 sblat2 sblat3)


### PR DESCRIPTION
CMAKE's default of -O3 for "Release" builds causes spurious test failures in ?TRMM and ?TRMM that are not reflected in the corresponding CBLAS tests, and go away when just the BLAS3 tests themselves are compiled at -O2. Fixes test failures seen both locally and in Azure CI