### PR TITLE
Adapt commands for tests with GNU make.

### DIFF
--- a/.github/workflows/dynamic_arch.yml
+++ b/.github/workflows/dynamic_arch.yml
@@ -121,11 +121,15 @@ jobs:
         run: |
           case "${{ matrix.build }}" in
             "make")
-              echo "::group::Tests for BLAS"
-              make blas-test
+              MAKE_FLAGS='DYNAMIC_ARCH=1 USE_OPENMP=0'
+              echo "::group::Tests in 'test' directory"
+              make -C test $MAKE_FLAGS FC="ccache ${{ matrix.fortran }}"
               echo "::endgroup::"
-              echo "::group::Tests for LAPACK"
-              make lapack-test
+              echo "::group::Tests in 'ctest' directory"
+              make -C ctest $MAKE_FLAGS FC="ccache ${{ matrix.fortran }}"
+              echo "::endgroup::"
+              echo "::group::Tests in 'utest' directory"
+              make -C utest $MAKE_FLAGS FC="ccache ${{ matrix.fortran }}"
               echo "::endgroup::"
               ;;
             "cmake")


### PR DESCRIPTION
Different commands are used for the tests in `azure-pipelines.yml`. Use similar commands for the tests run with the GitHub hosted runners.

Hopefully avoids the test errors after #3601.
