### PR TITLE
Fix riscv64 detect

### DIFF
--- a/Makefile.system
+++ b/Makefile.system
@@ -847,7 +847,7 @@ CCOMMON_OPT += -mabi=32
 BINARY_DEFINED = 1
 endif
 
-ifeq ($(CORE), $(filter $(CORE),LOONGSON3R3 LOONGSON3R4))
+ifneq (, $(filter $(CORE),LOONGSON3R3 LOONGSON3R4))
 CCOMMON_OPT += -march=loongson3a
 FCOMMON_OPT += -march=loongson3a
 endif

--- a/cpuid_riscv64.c
+++ b/cpuid_riscv64.c
@@ -1,5 +1,5 @@
 /*****************************************************************************
-Copyright (c) 2011-2014, The OpenBLAS Project
+Copyright (c) 2011-2022, The OpenBLAS Project
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -13,9 +13,9 @@ met:
       notice, this list of conditions and the following disclaimer in
       the documentation and/or other materials provided with the
       distribution.
-   3. Neither the name of the OpenBLAS project nor the names of 
-      its contributors may be used to endorse or promote products 
-      derived from this software without specific prior written 
+   3. Neither the name of the OpenBLAS project nor the names of
+      its contributors may be used to endorse or promote products
+      derived from this software without specific prior written
       permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
@@ -70,16 +70,16 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 /* or implied, of The University of Texas at Austin.                 */
 /*********************************************************************/
 
-#define CPU_UNKNOWN     0
-#define CPU_C910V       1
+#define CPU_GENERIC   0
+#define CPU_C910V     1
 
 static char *cpuname[] = {
-  "UNKOWN",
+  "RISCV64_GENERIC",
   "C910V"
 };
 
 int detect(void){
-    return CPU_UNKNOWN;
+  return CPU_GENERIC;
 }
 
 char *get_corename(void){
@@ -98,7 +98,7 @@ void get_subdirname(void){
 }
 
 void get_cpuconfig(void){
-  printf("#define UNKNOWN\n");
+  printf("#define %s\n", cpuname[detect()]);
   printf("#define L1_DATA_SIZE 65536\n");
   printf("#define L1_DATA_LINESIZE 32\n");
   printf("#define L2_SIZE 512488\n");

--- a/getarch.c
+++ b/getarch.c
@@ -1731,7 +1731,7 @@ int main(int argc, char *argv[]){
 #ifdef FORCE
     printf("CORE=%s\n", CORENAME);
 #else
-#if defined(INTEL_AMD) || defined(POWER) || defined(__mips__) || defined(__arm__) || defined(__aarch64__) || defined(ZARCH) || defined(sparc) || defined(__loongarch__)
+#if defined(INTEL_AMD) || defined(POWER) || defined(__mips__) || defined(__arm__) || defined(__aarch64__) || defined(ZARCH) || defined(sparc) || defined(__loongarch__) || defined(__riscv)
     printf("CORE=%s\n", get_corename());
 #endif
 #endif
@@ -1879,7 +1879,7 @@ printf("ELF_VERSION=2\n");
 #ifdef FORCE
     printf("#define CHAR_CORENAME \"%s\"\n", CORENAME);
 #else
-#if defined(INTEL_AMD) || defined(POWER) || defined(__mips__) || defined(__arm__) || defined(__aarch64__) || defined(ZARCH) || defined(sparc) || defined(__loongarch__)
+#if defined(INTEL_AMD) || defined(POWER) || defined(__mips__) || defined(__arm__) || defined(__aarch64__) || defined(ZARCH) || defined(sparc) || defined(__loongarch__) || defined(__riscv)
     printf("#define CHAR_CORENAME \"%s\"\n", get_corename());
 #endif
 #endif


### PR DESCRIPTION
Fix https://github.com/xianyi/OpenBLAS/issues/3606

When CORE is empty, use -march=loongson3a. Fix it.

And Fix riscv64 detect