### PR TITLE
Makefile fixes related to C_LAPACK, plus Travis CI fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ matrix:
       arch: s390x
       before_script:
         - COMMON_FLAGS="DYNAMIC_ARCH=1 TARGET=Z13 NUM_THREADS=32"
+        - apt-get install --only-upgrade binutils
       env:
         # for matrix annotation only
         - TARGET_BOX=IBMZ_LINUX
@@ -56,6 +57,7 @@ matrix:
       compiler: clang
       before_script:
         - COMMON_FLAGS="DYNAMIC_ARCH=1 TARGET=Z13 NUM_THREADS=32"
+        - apt-get install --only-upgrade binutils
       env:
         # for matrix annotation only
         - TARGET_BOX=IBMZ_LINUX

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,8 @@ matrix:
 #        - BTYPE="BINARY=64"
 #
 #    - <<: *test-ubuntu
-      os: linux-ppc64le
+      os: linux
+      arch: ppc64le
       before_script: &common-before
         - COMMON_FLAGS="DYNAMIC_ARCH=1 TARGET=POWER8 NUM_THREADS=32"
       script:
@@ -269,9 +270,9 @@ matrix:
 #        - CFLAGS="-O2 -mno-thumb -Wno-macro-redefined -isysroot /Applications/Xcode-11.5.GM.Seed.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS13.5.sdk -arch armv7 -miphoneos-version-min=5.1"
 #        - BTYPE="TARGET=ARMV7 HOSTCC=clang NOFORTRAN=1"
 
-    - &test-graviton2
+    - &test-neoversen1
       os: linux
-      arch: arm64-graviton2
+      arch: arm64
       dist: focal
       group: edge
       virt: lxd

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ matrix:
       arch: s390x
       before_script:
         - COMMON_FLAGS="DYNAMIC_ARCH=1 TARGET=Z13 NUM_THREADS=32"
-        - apt-get install --only-upgrade binutils
+        - sudo apt-get install --only-upgrade binutils
       env:
         # for matrix annotation only
         - TARGET_BOX=IBMZ_LINUX
@@ -57,7 +57,7 @@ matrix:
       compiler: clang
       before_script:
         - COMMON_FLAGS="DYNAMIC_ARCH=1 TARGET=Z13 NUM_THREADS=32"
-        - apt-get install --only-upgrade binutils
+        - sudo apt-get install --only-upgrade binutils
       env:
         # for matrix annotation only
         - TARGET_BOX=IBMZ_LINUX

--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,7 @@ ifeq ($(CORE), UNKNOWN)
 	$(error OpenBLAS: Detecting CPU failed. Please set TARGET explicitly, e.g. make TARGET=your_cpu_target. Please read README for the detail.)
 endif
 ifeq ($(NOFORTRAN), 1)
-	$(info OpenBLAS: Detecting fortran compiler failed. Cannot compile LAPACK. Only compile BLAS.)
+	$(info OpenBLAS: Detecting fortran compiler failed. Can only compile BLAS and f2c-converted LAPACK.)
 endif
 ifeq ($(NO_STATIC), 1)
 ifeq ($(NO_SHARED), 1)

--- a/Makefile.system
+++ b/Makefile.system
@@ -1041,8 +1041,10 @@ FCOMMON_OPT += -frecursive
 # work around ABI problem with passing single-character arguments
 FCOMMON_OPT += -fno-optimize-sibling-calls
 #Don't include -lgfortran, when NO_LAPACK=1 or lsbcc
+ifneq ($(NOFORTRAN), 1)
 ifneq ($(NO_LAPACK), 1)
 EXTRALIB += -lgfortran
+endif
 endif
 ifdef NO_BINARY_MODE
 ifeq ($(ARCH), $(filter $(ARCH),mips64))

--- a/lapack-netlib/SRC/Makefile
+++ b/lapack-netlib/SRC/Makefile
@@ -58,7 +58,6 @@ TOPSRCDIR = ..
 include $(TOPSRCDIR)/make.inc
 
 ifneq ($(C_LAPACK), 1)
-$(info fortran... C_LAPACK ist $(C_LAPACK))
 .SUFFIXES:
 .SUFFIXES: .f .o
 .f.o:
@@ -67,7 +66,6 @@ $(info fortran... C_LAPACK ist $(C_LAPACK))
 .F.o:
 	$(FC) $(FFLAGS) -c -o $@ $<
 else
-$(info C_LAPACK ist $(C_LAPACK))
 .SUFFIXES: .c .o
 .c.o:
 	$(CC) $(CFLAGS) -c -o $@ $<


### PR DESCRIPTION
- update informational message that used to state that "only BLAS" would be built without Fortran
- with no fortran compiler found, f_check still sets F_COMPILER in addition to NOFORTRAN - do not add -lgfortran to utest's EXTRALIB in that case