### PR TITLE
Initial attempt at proper cpu detection on RISCV

### DIFF
--- a/cpuid_riscv64.c
+++ b/cpuid_riscv64.c
@@ -79,6 +79,29 @@ static char *cpuname[] = {
 };
 
 int detect(void){
+#ifdef __linux
+  FILE *infile;
+  char buffer[512], *p;
+
+  p = (char *)NULL;
+  infile = fopen("/proc/cpuinfo", "r");
+  while (fgets(buffer, sizeof(buffer), infile)){
+    if (!strncmp("isa", buffer, 3)){
+        p = strchr(buffer, '4') + 1; /* the 4 in rv64ima... */
+#if 0
+        fprintf(stderr, "%s\n", p);
+#endif
+        break;
+      }
+  }
+
+  fclose(infile);
+
+  if (strchr(p, 'v')) return CPU_C910V;
+
+  return CPU_GENERIC;
+#endif
+
   return CPU_GENERIC;
 }
 
@@ -91,6 +114,7 @@ void get_architecture(void){
 }
 
 void get_subarchitecture(void){
+  printf("%s",cpuname[detect()]);
 }
 
 void get_subdirname(void){


### PR DESCRIPTION
maps vector-capable cpus to C910V, anything else to RISCV64_GENERIC