### PR TITLE
Fix build on new-world LoongArch

### DIFF
--- a/Makefile.loongarch64
+++ b/Makefile.loongarch64
@@ -1,4 +1,13 @@
 ifeq ($(CORE), LOONGSON3R5)
-CCOMMON_OPT += -march=loongarch64 -mabi=lp64
-FCOMMON_OPT += -march=loongarch64 -mabi=lp64
+CCOMMON_OPT += -march=loongarch64
+FCOMMON_OPT += -march=loongarch64
+
+ifeq ($(LOONGARCH_CC_FLAVOR), NEW)
+CCOMMON_OPT += -mabi=lp64d
+FCOMMON_OPT += -mabi=lp64d
+endif
+ifeq ($(LOONGARCH_CC_FLAVOR), OLD)
+CCOMMON_OPT += -mabi=lp64
+FCOMMON_OPT += -mabi=lp64
+endif
 endif

--- a/Makefile.loongarch64
+++ b/Makefile.loongarch64
@@ -1,3 +1,4 @@
-ifdef BINARY64
-else
+ifeq ($(CORE), LOONGSON3R5)
+CCOMMON_OPT += -march=loongarch64 -mabi=lp64
+FCOMMON_OPT += -march=loongarch64 -mabi=lp64
 endif

--- a/Makefile.system
+++ b/Makefile.system
@@ -1702,6 +1702,7 @@ export TARGET_CORE
 export NO_AVX512
 export NO_AVX2
 export BUILD_BFLOAT16
+export NO_LASX
 
 export SBGEMM_UNROLL_M
 export SBGEMM_UNROLL_N

--- a/Makefile.system
+++ b/Makefile.system
@@ -1702,6 +1702,7 @@ export TARGET_CORE
 export NO_AVX512
 export NO_AVX2
 export BUILD_BFLOAT16
+export LOONGARCH_CC_FLAVOR
 export NO_LASX
 
 export SBGEMM_UNROLL_M

--- a/Makefile.system
+++ b/Makefile.system
@@ -895,11 +895,6 @@ ifeq ($(OSNAME), AIX)
 BINARY_DEFINED = 1
 endif
 
-ifeq ($(ARCH), loongarch64)
-CCOMMON_OPT += -march=loongarch64 -mabi=lp64
-FCOMMON_OPT += -march=loongarch64 -mabi=lp64
-endif
-
 endif
 
 ifndef BINARY_DEFINED

--- a/c_check
+++ b/c_check
@@ -112,7 +112,7 @@ case "$architecture" in
     	defined=1
     	;;
     arm|arm64) defined=1 ;;
-    zarch|e2k|alpha|ia64|riscv64|loonarch64)
+    zarch|e2k|alpha|ia64|riscv64|loongarch64)
     	defined=1
     	BINARY=64
     	;;
@@ -240,6 +240,29 @@ if [ "$architecture" = "riscv64" ]; then
     rm -rf "$tmpd"
 fi
 
+no_lasx=0
+if [ "$architecture" = "loongarch64" ]; then
+    tmpd=`mktemp -d`
+    tmpf="$tmpd/a.c"
+    # Old-world assembly flavor: LASX registers named "$xrNN", different
+    # from the ISA manual which suggests "$xNN". This is the flavor we
+    # currently support.
+    #
+    # As the LASX ISA manual is not out yet, we cannot predict what the
+    # new-world flavor would look like, so do not probe flavor for now.
+    # The compiler flags are also unsuitable for new-world gcc.
+    code='"xvld $xr0, $a0, 0\n"'
+    printf "int main(void){ __asm__ volatile(%s); }\n" "$code" >> "$tmpf"
+    args=" -march=loongarch64 -mabi=lp64 -mlasx -c -o $tmpf.o $tmpf"
+    no_lasx=0
+    {
+        $compiler_name $flags $args >/dev/null 2>&1
+    } || {
+        no_lasx=1
+    }
+    rm -rf "$tmpd"
+fi
+
 c11_atomics=0
 case "$data" in
     *HAVE_C11*)
@@ -350,6 +373,7 @@ done
 
  [ "$makefile" = "-" ] && {
     [ "$no_rv64gv" -eq 1 ] && printf "NO_RV64GV=1\n"
+    [ "$no_lasx" -eq 1 ] && printf "NO_LASX=1\n"
     [ "$no_avx512" -eq 1 ] && printf "NO_AVX512=1\n"
     [ "$no_avx2" -eq 1 ] && printf "NO_AVX2=1\n"
     [ "$oldgcc" -eq 1 ] && printf "OLDGCC=1\n"
@@ -380,6 +404,7 @@ done
         printf "MSA_FLAGS=%s\n" "$msa_flags"
     }
     [ "$no_rv64gv" -eq 1 ] && printf "NO_RV64GV=1\n"
+    [ "$no_lasx" -eq 1 ] && printf "NO_LASX=1\n"
     [ "$no_avx512" -eq 1 ] && printf "NO_AVX512=1\n"
     [ "$no_avx2" -eq 1 ] && printf "NO_AVX2=1\n"
     [ "$oldgcc" -eq 1 ] && printf "OLDGCC=1\n"

--- a/c_check
+++ b/c_check
@@ -240,8 +240,19 @@ if [ "$architecture" = "riscv64" ]; then
     rm -rf "$tmpd"
 fi
 
+loongarch_cc_flavor=""
 no_lasx=0
 if [ "$architecture" = "loongarch64" ]; then
+    # Currently there are only 2 flavors: new-world and old-world.
+    # They differ in ABI names accepted, so check it to avoid creating temp
+    # files.
+    loongarch_cc_flavor="NEW"
+    {
+        $compiler_name -mabi=lp64d -E -o - /dev/null >/dev/null 2>&1
+    } || {
+        loongarch_cc_flavor="OLD"
+    }
+
     tmpd=`mktemp -d`
     tmpf="$tmpd/a.c"
     # Old-world assembly flavor: LASX registers named "$xrNN", different
@@ -260,6 +271,7 @@ if [ "$architecture" = "loongarch64" ]; then
     } || {
         no_lasx=1
     }
+
     rm -rf "$tmpd"
 fi
 
@@ -377,6 +389,7 @@ done
     [ "$no_avx512" -eq 1 ] && printf "NO_AVX512=1\n"
     [ "$no_avx2" -eq 1 ] && printf "NO_AVX2=1\n"
     [ "$oldgcc" -eq 1 ] && printf "OLDGCC=1\n"
+    [ -n "$loongarch_cc_flavor" ] && printf "LOONGARCH_CC_FLAVOR=%s\n" "$loongarch_cc_flavor"
     exit 0
 }
 
@@ -408,6 +421,7 @@ done
     [ "$no_avx512" -eq 1 ] && printf "NO_AVX512=1\n"
     [ "$no_avx2" -eq 1 ] && printf "NO_AVX2=1\n"
     [ "$oldgcc" -eq 1 ] && printf "OLDGCC=1\n"
+    [ -n "$loongarch_cc_flavor" ] && printf "LOONGARCH_CC_FLAVOR=%s\n" "$loongarch_cc_flavor"
 } >> "$makefile"
 
 os=`echo "$os" | tr '[[:lower:]]' '[[:upper:]]'/ `

--- a/kernel/loongarch64/KERNEL.LOONGSON3R5
+++ b/kernel/loongarch64/KERNEL.LOONGSON3R5
@@ -1,3 +1,7 @@
+ifeq ($(NO_LASX), 1)
+# No LASX support in compiler, unable to consume the optimized version
+# leave out DGEMMKERNEL to pull in the generic version
+else
 DGEMMKERNEL    = dgemm_kernel_16x4.S
 DGEMMINCOPY    = dgemm_ncopy_16.S
 DGEMMITCOPY    = dgemm_tcopy_16.S
@@ -7,6 +11,7 @@ DGEMMINCOPYOBJ = dgemm_incopy$(TSUFFIX).$(SUFFIX)
 DGEMMITCOPYOBJ = dgemm_itcopy$(TSUFFIX).$(SUFFIX)
 DGEMMONCOPYOBJ = dgemm_oncopy$(TSUFFIX).$(SUFFIX)
 DGEMMOTCOPYOBJ = dgemm_otcopy$(TSUFFIX).$(SUFFIX)
+endif
 
 DTRSMKERNEL_LN  = ../generic/trsm_kernel_LN.c
 DTRSMKERNEL_LT  = ../generic/trsm_kernel_LT.c


### PR DESCRIPTION
This is fix for https://bugs.gentoo.org/844013. The LoongArch port is tested only on old-world systems, and fails to build on new-world distros such as Gentoo.

I can successfully build and test OpenBLAS with the changes applied:

```
 OpenBLAS build complete. (BLAS CBLAS LAPACK LAPACKE)

  OS               ... Linux             
  Architecture     ... loongarch64               
  BINARY           ... 64bit                 
  C compiler       ... GCC  (cmd & version : cc (Gentoo 12.1.0 p5) 12.1.0)
  Fortran compiler ... GFORTRAN  (cmd & version : GNU Fortran (Gentoo 12.1.0 p5) 12.1.0)
  Library Name     ... libopenblas_loongson3r5p-r0.3.20.a (Multi-threading; Max num-threads is 4)
```

@gxw-loongson: Please test on the old world to make sure I don't regress your usecase.