### PR TITLE
riscv: Fix machine recognition for c910v

### DIFF
--- a/cpuid_riscv64.c
+++ b/cpuid_riscv64.c
@@ -81,23 +81,27 @@ static char *cpuname[] = {
 int detect(void){
 #ifdef __linux
   FILE *infile;
-  char buffer[512], *p;
+  char buffer[512],isa_buffer[512],model_buffer[512];
+  const char* check_c910_str = "T-HEAD C910";
+  char *pmodel = NULL, *pisa = NULL;
 
-  p = (char *)NULL;
   infile = fopen("/proc/cpuinfo", "r");
   while (fgets(buffer, sizeof(buffer), infile)){
-    if (!strncmp("isa", buffer, 3)){
-        p = strchr(buffer, '4') + 1; /* the 4 in rv64ima... */
-#if 0
-        fprintf(stderr, "%s\n", p);
-#endif
-        break;
-      }
+    if(!strncmp(buffer, "model name", 10)){
+      strcpy(model_buffer, buffer)
+      pmodel = strchr(isa_buffer, ':') + 1;
+    }
+
+    if(!strncmp(buffer, "isa", 3)){
+      strcpy(isa_buffer, buffer)
+      pisa = strchr(isa_buffer, '4') + 1;
+    }
   }
 
   fclose(infile);
 
-  if (strchr(p, 'v')) return CPU_C910V;
+  if (strstr(pmodel, check_c910_str) && strchr(p, 'v'))
+    return CPU_C910V;
 
   return CPU_GENERIC;
 #endif


### PR DESCRIPTION
Signed-off-by: Han Gao <gaohan@uniontech.com>

[c910v vector chinese guide](https://yoc.docs.t-head.cn/icebook/Chapter4-Linux%E4%B8%8B%E5%BA%94%E7%94%A8%E7%A8%8B%E5%BA%8F%E5%BC%80%E5%8F%91/6-%E4%BD%BF%E7%94%A8vector%E6%A0%B8.html)
It described proc/cpuinfo

```
root@thead-910:~# cat /proc/cpuinfo
processor       : 0
hart            : 2
isa             : rv64imafdcvsu
mmu             : sv39
model name      : T-HEAD C910
freq            : 1.2GHz
icache          : 64kB
dcache          : 64kB
l2cache         : 2MB
tlb             : 1024 4-ways
cache line      : 64Bytes
address sizes   : 40 bits physical, 39 bits virtual
vector version  : 0.7.1
```