### PR TITLE
power10:  Fix build issues due to perl scripts conversion

### DIFF
--- a/c_check
+++ b/c_check
@@ -304,7 +304,7 @@ link=`$compiler_name $flags -c ctest2.c -o ctest2.o 2>&1 && $compiler_name $flag
 link=`echo "$link" | sed 's/\-Y[[:space:]]P\,/\-Y/g'`
 
 
-flags=`echo $link | tr '[[:space:]],\n' ' '`
+flags=`echo $link | tr "'[[:space:]],\n" " "`
 
 # Strip trailing quotes
 old_flags="$flags"

--- a/f_check
+++ b/f_check
@@ -84,7 +84,7 @@ else
                 ;;
             *GNU*|*GCC*)
 
-                v="${data##*GCC: *\) }"
+                v="${data#*GCC: *\) }"
                 v="${v%%\"*}"
 
                 major="${v%%.*}"
@@ -309,7 +309,7 @@ if [ -n "$link" ]; then
 
     link=`echo "$link" | sed 's/\-rpath-link[[:space:]]+/\-rpath-link\%/g'`
 
-    flags=`echo "$link" | tr ',\n' ' '`
+    flags=`echo "$link" | tr "',\n" " "`
     # remove leading and trailing quotes from each flag.
     #@flags = map {s/^['"]|['"]$//g; $_} @flags;
 


### PR DESCRIPTION
Due to recent perl script conversion, there are some build
errors when compiling openblas with advance toolchain compilers.