### PR TITLE
DOC: Add tip about macOS SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,8 @@ If you compile this library with `USE_OPENMP=1`, you should set the `OMP_NUM_THR
 environment variable; OpenBLAS ignores `OPENBLAS_NUM_THREADS` and `GOTO_NUM_THREADS` when
 compiled with `USE_OPENMP=1`.
 
+On newer versions of Xcode and on arm64, you might need to compile with a newer macOS target (11.0) than the default (10.8) with `MACOSX_DEPLOYMENT_TARGET=11.0`, or switch your command-line tools to use an older SDK (e.g., [13.1](https://developer.apple.com/download/all/?q=Xcode%2013)).
+
 ### Setting the number of threads at runtime
 
 We provide the following functions to control the number of threads at runtime:


### PR DESCRIPTION
On my new M1 machine I installed Xcode a couple of weeks ago, and today did a fresh `git clone` here. When I did `make` I got a bunch of warnings:
```
ld: warning: object file (/opt/homebrew/Cellar/gcc/11.3.0_1/lib/gcc/11/gcc/aarch64-apple-darwin21/11/libgcc.a(enable-execute-stack.o)) was built for newer macOS version (11.0) than being linked (10.8)
```
then eventually get errors like the one in this issue:
```
Undefined symbols for architecture arm64:
  "___chkstk_darwin", referenced from:
      _sgemv_ in libopenblas_vortexp-r0.3.20.a(sgemv.o)
      _sger_ in libopenblas_vortexp-r0.3.20.a(sger.o)
      _cblas_sgemv in libopenblas_vortexp-r0.3.20.a(cblas_sgemv.o)
      _cblas_sger in libopenblas_vortexp-r0.3.20.a(cblas_sger.o)
      _dgemv_ in libopenblas_vortexp-r0.3.20.a(dgemv.o)
      _dger_ in libopenblas_vortexp-r0.3.20.a(dger.o)
      _cblas_dgemv in libopenblas_vortexp-r0.3.20.a(cblas_dgemv.o)
      ...
```
This seems to be an Xcode SDK problem, as I'm on 13.4 since this is what I downloaded a couple of weeks ago when I got my new M1 machine. I then tried `MACOSX_DEPLOYMENT_TARGET=11.0 make` and things compiled fine.

Another option is probably to install an older Xcode, so I made a note about that option, too.

I'm happy to do something else if there is a better recommendation, but figured if there isn't, then this could be something useful to add to the README!

FYI I'm trying to build locally so that I can determine if a SVD failure on M1 using NumPy from conda-forge is a cross-compilation problem or a problem with OpenBLAS itself:

https://github.com/numpy/numpy/issues/21756