### PR TITLE
[WIP] Set visibility attribute on internal function symbols to hidden

### DIFF
--- a/driver/level2/gbmv_k.c
+++ b/driver/level2/gbmv_k.c
@@ -48,7 +48,11 @@
 #define M n
 #endif
 
-void CNAME(BLASLONG m, BLASLONG n, BLASLONG ku, BLASLONG kl, FLOAT alpha,
+void
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(BLASLONG m, BLASLONG n, BLASLONG ku, BLASLONG kl, FLOAT alpha,
 	  FLOAT *a, BLASLONG lda,
 	  FLOAT *x, BLASLONG incx, FLOAT *y, BLASLONG incy, void *buffer){
 

--- a/driver/level2/gbmv_thread.c
+++ b/driver/level2/gbmv_thread.c
@@ -170,9 +170,17 @@ static int gbmv_kernel(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, F
 }
 
 #ifndef COMPLEX
-int CNAME(BLASLONG m, BLASLONG n, BLASLONG ku, BLASLONG kl, FLOAT  alpha, FLOAT *a, BLASLONG lda, FLOAT *x, BLASLONG incx, FLOAT *y, BLASLONG incy, FLOAT *buffer, int nthreads){
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(BLASLONG m, BLASLONG n, BLASLONG ku, BLASLONG kl, FLOAT  alpha, FLOAT *a, BLASLONG lda, FLOAT *x, BLASLONG incx, FLOAT *y, BLASLONG incy, FLOAT *buffer, int nthreads){
 #else
-int CNAME(BLASLONG m, BLASLONG n, BLASLONG ku, BLASLONG kl, FLOAT *alpha, FLOAT *a, BLASLONG lda, FLOAT *x, BLASLONG incx, FLOAT *y, BLASLONG incy, FLOAT *buffer, int nthreads){
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+       	CNAME(BLASLONG m, BLASLONG n, BLASLONG ku, BLASLONG kl, FLOAT *alpha, FLOAT *a, BLASLONG lda, FLOAT *x, BLASLONG incx, FLOAT *y, BLASLONG incy, FLOAT *buffer, int nthreads){
 #endif
 
   blas_arg_t args;

--- a/driver/level2/gemv_thread.c
+++ b/driver/level2/gemv_thread.c
@@ -154,9 +154,17 @@ static int gemv_kernel(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, F
 }
 
 #ifndef COMPLEX
-int CNAME(BLASLONG m, BLASLONG n, FLOAT  alpha, FLOAT *a, BLASLONG lda, FLOAT *x, BLASLONG incx, FLOAT *y, BLASLONG incy, FLOAT *buffer, int nthreads){
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(BLASLONG m, BLASLONG n, FLOAT  alpha, FLOAT *a, BLASLONG lda, FLOAT *x, BLASLONG incx, FLOAT *y, BLASLONG incy, FLOAT *buffer, int nthreads){
 #else
-int CNAME(BLASLONG m, BLASLONG n, FLOAT *alpha, FLOAT *a, BLASLONG lda, FLOAT *x, BLASLONG incx, FLOAT *y, BLASLONG incy, FLOAT *buffer, int nthreads){
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+       	CNAME(BLASLONG m, BLASLONG n, FLOAT *alpha, FLOAT *a, BLASLONG lda, FLOAT *x, BLASLONG incx, FLOAT *y, BLASLONG incy, FLOAT *buffer, int nthreads){
 #endif
 
   blas_arg_t args;

--- a/driver/level2/ger_thread.c
+++ b/driver/level2/ger_thread.c
@@ -111,9 +111,17 @@ static int ger_kernel(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, FL
 }
 
 #ifndef COMPLEX
-int CNAME(BLASLONG m, BLASLONG n, FLOAT  alpha, FLOAT *x, BLASLONG incx, FLOAT *y, BLASLONG incy, FLOAT *a, BLASLONG lda, FLOAT *buffer, int nthreads){
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(BLASLONG m, BLASLONG n, FLOAT  alpha, FLOAT *x, BLASLONG incx, FLOAT *y, BLASLONG incy, FLOAT *a, BLASLONG lda, FLOAT *buffer, int nthreads){
 #else
-int CNAME(BLASLONG m, BLASLONG n, FLOAT *alpha, FLOAT *x, BLASLONG incx, FLOAT *y, BLASLONG incy, FLOAT *a, BLASLONG lda, FLOAT *buffer, int nthreads){
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif 
+	CNAME(BLASLONG m, BLASLONG n, FLOAT *alpha, FLOAT *x, BLASLONG incx, FLOAT *y, BLASLONG incy, FLOAT *a, BLASLONG lda, FLOAT *buffer, int nthreads){
 #endif
 
   blas_arg_t args;

--- a/driver/level2/sbgemv_thread.c
+++ b/driver/level2/sbgemv_thread.c
@@ -82,7 +82,11 @@ static int sbgemv_kernel(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n,
     return 0;
 }
 
-int CNAME(BLASLONG m, BLASLONG n, float alpha, bfloat16 *a, BLASLONG lda, bfloat16 *x, BLASLONG incx, float beta, float *y, BLASLONG incy, int threads)
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(BLASLONG m, BLASLONG n, float alpha, bfloat16 *a, BLASLONG lda, bfloat16 *x, BLASLONG incx, float beta, float *y, BLASLONG incy, int threads)
 {
     blas_arg_t args;
     blas_queue_t queue[MAX_CPU_NUMBER];

--- a/driver/level2/sbmv_k.c
+++ b/driver/level2/sbmv_k.c
@@ -40,7 +40,11 @@
 #include <ctype.h>
 #include "common.h"
 
-int CNAME(BLASLONG n, BLASLONG k, FLOAT alpha,
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(BLASLONG n, BLASLONG k, FLOAT alpha,
 	  FLOAT *a, BLASLONG lda,
 	  FLOAT *x, BLASLONG incx, FLOAT *y, BLASLONG incy, void *buffer){
 

--- a/driver/level2/sbmv_thread.c
+++ b/driver/level2/sbmv_thread.c
@@ -171,9 +171,17 @@ static int sbmv_kernel(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, F
 }
 
 #ifndef COMPLEX
-int CNAME(BLASLONG n, BLASLONG k, FLOAT  alpha, FLOAT *a, BLASLONG lda, FLOAT *x, BLASLONG incx, FLOAT *y, BLASLONG incy, FLOAT *buffer, int nthreads){
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(BLASLONG n, BLASLONG k, FLOAT  alpha, FLOAT *a, BLASLONG lda, FLOAT *x, BLASLONG incx, FLOAT *y, BLASLONG incy, FLOAT *buffer, int nthreads){
 #else
-int CNAME(BLASLONG n, BLASLONG k, FLOAT *alpha, FLOAT *a, BLASLONG lda, FLOAT *x, BLASLONG incx, FLOAT *y, BLASLONG incy, FLOAT *buffer, int nthreads){
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+       	CNAME(BLASLONG n, BLASLONG k, FLOAT *alpha, FLOAT *a, BLASLONG lda, FLOAT *x, BLASLONG incx, FLOAT *y, BLASLONG incy, FLOAT *buffer, int nthreads){
 #endif
 
   blas_arg_t args;

--- a/driver/level2/spmv_k.c
+++ b/driver/level2/spmv_k.c
@@ -40,7 +40,11 @@
 #include <ctype.h>
 #include "common.h"
 
-int CNAME(BLASLONG m, FLOAT alpha, FLOAT *a,
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(BLASLONG m, FLOAT alpha, FLOAT *a,
 	  FLOAT *x, BLASLONG incx, FLOAT *y, BLASLONG incy, void *buffer){
 
   BLASLONG i;

--- a/driver/level2/spmv_thread.c
+++ b/driver/level2/spmv_thread.c
@@ -174,9 +174,17 @@ static int spmv_kernel(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, F
 }
 
 #ifndef COMPLEX
-int CNAME(BLASLONG m, FLOAT  alpha, FLOAT *a, FLOAT *x, BLASLONG incx, FLOAT *y, BLASLONG incy, FLOAT *buffer, int nthreads){
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(BLASLONG m, FLOAT  alpha, FLOAT *a, FLOAT *x, BLASLONG incx, FLOAT *y, BLASLONG incy, FLOAT *buffer, int nthreads){
 #else
-int CNAME(BLASLONG m, FLOAT *alpha, FLOAT *a, FLOAT *x, BLASLONG incx, FLOAT *y, BLASLONG incy, FLOAT *buffer, int nthreads){
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+       	CNAME(BLASLONG m, FLOAT *alpha, FLOAT *a, FLOAT *x, BLASLONG incx, FLOAT *y, BLASLONG incy, FLOAT *buffer, int nthreads){
 #endif
 
   blas_arg_t args;

--- a/driver/level2/spr2_k.c
+++ b/driver/level2/spr2_k.c
@@ -40,7 +40,11 @@
 #include <ctype.h>
 #include "common.h"
 
-int CNAME(BLASLONG m, FLOAT alpha_r, FLOAT *x, BLASLONG incx,
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(BLASLONG m, FLOAT alpha_r, FLOAT *x, BLASLONG incx,
 		       FLOAT *y, BLASLONG incy, FLOAT *a, FLOAT *buffer){
 
   BLASLONG i;

--- a/driver/level2/spr2_thread.c
+++ b/driver/level2/spr2_thread.c
@@ -213,9 +213,17 @@ static int syr_kernel(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, FL
 }
 
 #ifndef COMPLEX
-int CNAME(BLASLONG m, FLOAT  alpha, FLOAT *x, BLASLONG incx, FLOAT *y, BLASLONG incy, FLOAT *a, FLOAT *buffer, int nthreads){
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(BLASLONG m, FLOAT  alpha, FLOAT *x, BLASLONG incx, FLOAT *y, BLASLONG incy, FLOAT *a, FLOAT *buffer, int nthreads){
 #else
-int CNAME(BLASLONG m, FLOAT *alpha, FLOAT *x, BLASLONG incx, FLOAT *y, BLASLONG incy, FLOAT *a, FLOAT *buffer, int nthreads){
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+       	CNAME(BLASLONG m, FLOAT *alpha, FLOAT *x, BLASLONG incx, FLOAT *y, BLASLONG incy, FLOAT *a, FLOAT *buffer, int nthreads){
 #endif
 
   blas_arg_t args;

--- a/driver/level2/spr_k.c
+++ b/driver/level2/spr_k.c
@@ -38,7 +38,11 @@
 
 #include "common.h"
 
-int CNAME(BLASLONG m, FLOAT alpha_r,
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(BLASLONG m, FLOAT alpha_r,
 	  FLOAT *x, BLASLONG incx, FLOAT *a, FLOAT *buffer){
 
   BLASLONG i;

--- a/driver/level2/spr_thread.c
+++ b/driver/level2/spr_thread.c
@@ -150,9 +150,17 @@ static int syr_kernel(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, FL
 }
 
 #if !defined(COMPLEX) || defined(HEMV) || defined(HEMVREV)
-int CNAME(BLASLONG m, FLOAT  alpha, FLOAT *x, BLASLONG incx, FLOAT *a, FLOAT *buffer, int nthreads){
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(BLASLONG m, FLOAT  alpha, FLOAT *x, BLASLONG incx, FLOAT *a, FLOAT *buffer, int nthreads){
 #else
-int CNAME(BLASLONG m, FLOAT *alpha, FLOAT *x, BLASLONG incx, FLOAT *a, FLOAT *buffer, int nthreads){
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+       	CNAME(BLASLONG m, FLOAT *alpha, FLOAT *x, BLASLONG incx, FLOAT *a, FLOAT *buffer, int nthreads){
 #endif
 
   blas_arg_t args;

--- a/driver/level2/symv_thread.c
+++ b/driver/level2/symv_thread.c
@@ -108,9 +108,17 @@ static int symv_kernel(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, F
 }
 
 #ifndef COMPLEX
-int CNAME(BLASLONG m, FLOAT  alpha, FLOAT *a, BLASLONG lda, FLOAT *x, BLASLONG incx, FLOAT *y, BLASLONG incy, FLOAT *buffer, int nthreads){
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(BLASLONG m, FLOAT  alpha, FLOAT *a, BLASLONG lda, FLOAT *x, BLASLONG incx, FLOAT *y, BLASLONG incy, FLOAT *buffer, int nthreads){
 #else
-int CNAME(BLASLONG m, FLOAT *alpha, FLOAT *a, BLASLONG lda, FLOAT *x, BLASLONG incx, FLOAT *y, BLASLONG incy, FLOAT *buffer, int nthreads){
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+       	CNAME(BLASLONG m, FLOAT *alpha, FLOAT *a, BLASLONG lda, FLOAT *x, BLASLONG incx, FLOAT *y, BLASLONG incy, FLOAT *buffer, int nthreads){
 #endif
 
   blas_arg_t args;

--- a/driver/level2/syr2_k.c
+++ b/driver/level2/syr2_k.c
@@ -40,7 +40,11 @@
 #include <ctype.h>
 #include "common.h"
 
-int CNAME(BLASLONG m, FLOAT alpha_r, FLOAT *x, BLASLONG incx,
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(BLASLONG m, FLOAT alpha_r, FLOAT *x, BLASLONG incx,
 		       FLOAT *y, BLASLONG incy, FLOAT *a, BLASLONG lda, FLOAT *buffer){
 
   BLASLONG i;

--- a/driver/level2/syr2_thread.c
+++ b/driver/level2/syr2_thread.c
@@ -202,9 +202,17 @@ static int syr_kernel(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, FL
 }
 
 #ifndef COMPLEX
-int CNAME(BLASLONG m, FLOAT  alpha, FLOAT *x, BLASLONG incx, FLOAT *y, BLASLONG incy, FLOAT *a, BLASLONG lda, FLOAT *buffer, int nthreads){
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(BLASLONG m, FLOAT  alpha, FLOAT *x, BLASLONG incx, FLOAT *y, BLASLONG incy, FLOAT *a, BLASLONG lda, FLOAT *buffer, int nthreads){
 #else
-int CNAME(BLASLONG m, FLOAT *alpha, FLOAT *x, BLASLONG incx, FLOAT *y, BLASLONG incy, FLOAT *a, BLASLONG lda, FLOAT *buffer, int nthreads){
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+       	CNAME(BLASLONG m, FLOAT *alpha, FLOAT *x, BLASLONG incx, FLOAT *y, BLASLONG incy, FLOAT *a, BLASLONG lda, FLOAT *buffer, int nthreads){
 #endif
 
   blas_arg_t args;

--- a/driver/level2/syr_k.c
+++ b/driver/level2/syr_k.c
@@ -38,7 +38,11 @@
 
 #include "common.h"
 
-int CNAME(BLASLONG m, FLOAT alpha_r,
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(BLASLONG m, FLOAT alpha_r,
 	  FLOAT *x, BLASLONG incx, FLOAT *a, BLASLONG lda, FLOAT *buffer){
 
   BLASLONG i;

--- a/driver/level2/syr_thread.c
+++ b/driver/level2/syr_thread.c
@@ -142,9 +142,17 @@ static int syr_kernel(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, FL
 }
 
 #if !defined(COMPLEX) || defined(HER) || defined(HERREV)
-int CNAME(BLASLONG m, FLOAT  alpha, FLOAT *x, BLASLONG incx, FLOAT *a, BLASLONG lda, FLOAT *buffer, int nthreads){
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(BLASLONG m, FLOAT  alpha, FLOAT *x, BLASLONG incx, FLOAT *a, BLASLONG lda, FLOAT *buffer, int nthreads){
 #else
-int CNAME(BLASLONG m, FLOAT *alpha, FLOAT *x, BLASLONG incx, FLOAT *a, BLASLONG lda, FLOAT *buffer, int nthreads){
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+       	CNAME(BLASLONG m, FLOAT *alpha, FLOAT *x, BLASLONG incx, FLOAT *a, BLASLONG lda, FLOAT *buffer, int nthreads){
 #endif
 
   blas_arg_t args;

--- a/driver/level2/tbmv_L.c
+++ b/driver/level2/tbmv_L.c
@@ -42,7 +42,11 @@
 
 // const static FLOAT dp1 = 1.;
 
-int CNAME(BLASLONG n, BLASLONG k, FLOAT *a, BLASLONG lda, FLOAT *b, BLASLONG incb, void *buffer){
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(BLASLONG n, BLASLONG k, FLOAT *a, BLASLONG lda, FLOAT *b, BLASLONG incb, void *buffer){
 
   BLASLONG i;
   FLOAT *B = b;

--- a/driver/level2/tbmv_U.c
+++ b/driver/level2/tbmv_U.c
@@ -42,7 +42,11 @@
 
 // const static FLOAT dp1 = 1.;
 
-int CNAME(BLASLONG n, BLASLONG k, FLOAT *a, BLASLONG lda, FLOAT *b, BLASLONG incb, void *buffer){
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(BLASLONG n, BLASLONG k, FLOAT *a, BLASLONG lda, FLOAT *b, BLASLONG incb, void *buffer){
 
   BLASLONG i;
   FLOAT *B = b;

--- a/driver/level2/tbmv_thread.c
+++ b/driver/level2/tbmv_thread.c
@@ -213,9 +213,17 @@ static int trmv_kernel(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, F
 }
 
 #ifndef COMPLEX
-int CNAME(BLASLONG n, BLASLONG k, FLOAT *a, BLASLONG lda, FLOAT *x, BLASLONG incx, FLOAT *buffer, int nthreads){
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(BLASLONG n, BLASLONG k, FLOAT *a, BLASLONG lda, FLOAT *x, BLASLONG incx, FLOAT *buffer, int nthreads){
 #else
-int CNAME(BLASLONG n, BLASLONG k, FLOAT *a, BLASLONG lda, FLOAT *x, BLASLONG incx, FLOAT *buffer, int nthreads){
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(BLASLONG n, BLASLONG k, FLOAT *a, BLASLONG lda, FLOAT *x, BLASLONG incx, FLOAT *buffer, int nthreads){
 #endif
 
   blas_arg_t args;

--- a/driver/level2/tbsv_L.c
+++ b/driver/level2/tbsv_L.c
@@ -42,7 +42,11 @@
 
 // const static FLOAT dp1 = 1.;
 
-int CNAME(BLASLONG n, BLASLONG k, FLOAT *a, BLASLONG lda, FLOAT *b, BLASLONG incb, void *buffer){
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(BLASLONG n, BLASLONG k, FLOAT *a, BLASLONG lda, FLOAT *b, BLASLONG incb, void *buffer){
 
   BLASLONG i;
   FLOAT *B = b;

--- a/driver/level2/tbsv_U.c
+++ b/driver/level2/tbsv_U.c
@@ -42,7 +42,11 @@
 
 // const static FLOAT dp1 = 1.;
 
-int CNAME(BLASLONG n, BLASLONG k, FLOAT *a, BLASLONG lda, FLOAT *b, BLASLONG incb, void *buffer){
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(BLASLONG n, BLASLONG k, FLOAT *a, BLASLONG lda, FLOAT *b, BLASLONG incb, void *buffer){
 
   BLASLONG i;
   FLOAT *B = b;

--- a/driver/level2/tpmv_L.c
+++ b/driver/level2/tpmv_L.c
@@ -42,7 +42,11 @@
 
 // const static FLOAT dp1 = 1.;
 
-int CNAME(BLASLONG m, FLOAT *a, FLOAT *b, BLASLONG incb, void *buffer){
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+      CNAME(BLASLONG m, FLOAT *a, FLOAT *b, BLASLONG incb, void *buffer){
 
   BLASLONG i;
   FLOAT *B = b;

--- a/driver/level2/tpmv_U.c
+++ b/driver/level2/tpmv_U.c
@@ -42,7 +42,11 @@
 
 // const static FLOAT dp1 = 1.;
 
-int CNAME(BLASLONG m, FLOAT *a, FLOAT *b, BLASLONG incb, void *buffer){
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+      CNAME(BLASLONG m, FLOAT *a, FLOAT *b, BLASLONG incb, void *buffer){
 
   BLASLONG i;
   FLOAT *B = b;

--- a/driver/level2/tpmv_thread.c
+++ b/driver/level2/tpmv_thread.c
@@ -234,7 +234,11 @@ static int tpmv_kernel(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, F
   return 0;
 }
 
-int CNAME(BLASLONG m, FLOAT *a, FLOAT *x, BLASLONG incx, FLOAT *buffer, int nthreads){
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(BLASLONG m, FLOAT *a, FLOAT *x, BLASLONG incx, FLOAT *buffer, int nthreads){
 
   blas_arg_t args;
   blas_queue_t queue[MAX_CPU_NUMBER];

--- a/driver/level2/tpsv_L.c
+++ b/driver/level2/tpsv_L.c
@@ -40,7 +40,11 @@
 #include <ctype.h>
 #include "common.h"
 
-int CNAME(BLASLONG m, FLOAT *a, FLOAT *b, BLASLONG incb, void *buffer){
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(BLASLONG m, FLOAT *a, FLOAT *b, BLASLONG incb, void *buffer){
 
   BLASLONG i;
   FLOAT *B = b;

--- a/driver/level2/tpsv_U.c
+++ b/driver/level2/tpsv_U.c
@@ -40,7 +40,11 @@
 #include <ctype.h>
 #include "common.h"
 
-int CNAME(BLASLONG m, FLOAT *a, FLOAT *b, BLASLONG incb, void *buffer){
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif  
+      CNAME(BLASLONG m, FLOAT *a, FLOAT *b, BLASLONG incb, void *buffer){
 
   BLASLONG i;
   FLOAT *B = b;

--- a/driver/level2/trmv_L.c
+++ b/driver/level2/trmv_L.c
@@ -42,7 +42,11 @@
 
 const static FLOAT dp1 = 1.;
 
-int CNAME(BLASLONG m, FLOAT *a, BLASLONG lda, FLOAT *b, BLASLONG incb, FLOAT *buffer){
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(BLASLONG m, FLOAT *a, BLASLONG lda, FLOAT *b, BLASLONG incb, FLOAT *buffer){
 
   BLASLONG i, is, min_i;
   FLOAT *gemvbuffer = (FLOAT *)buffer;

--- a/driver/level2/trmv_U.c
+++ b/driver/level2/trmv_U.c
@@ -42,7 +42,11 @@
 
 const static FLOAT dp1 = 1.;
 
-int CNAME(BLASLONG m, FLOAT *a, BLASLONG lda, FLOAT *b, BLASLONG incb, FLOAT *buffer){
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(BLASLONG m, FLOAT *a, BLASLONG lda, FLOAT *b, BLASLONG incb, FLOAT *buffer){
 
   BLASLONG i, is, min_i;
   FLOAT *gemvbuffer = (FLOAT *)buffer;

--- a/driver/level2/trmv_thread.c
+++ b/driver/level2/trmv_thread.c
@@ -273,9 +273,17 @@ static int trmv_kernel(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, F
 }
 
 #ifndef COMPLEX
-int CNAME(BLASLONG m, FLOAT *a, BLASLONG lda, FLOAT *x, BLASLONG incx, FLOAT *buffer, int nthreads){
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(BLASLONG m, FLOAT *a, BLASLONG lda, FLOAT *x, BLASLONG incx, FLOAT *buffer, int nthreads){
 #else
-int CNAME(BLASLONG m, FLOAT *a, BLASLONG lda, FLOAT *x, BLASLONG incx, FLOAT *buffer, int nthreads){
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(BLASLONG m, FLOAT *a, BLASLONG lda, FLOAT *x, BLASLONG incx, FLOAT *buffer, int nthreads){
 #endif
 
   blas_arg_t args;

--- a/driver/level2/trsv_L.c
+++ b/driver/level2/trsv_L.c
@@ -45,7 +45,7 @@ const static FLOAT dm1 = -1.;
 #undef GEMV_UNROLL
 #define GEMV_UNROLL DTB_ENTRIES
 
-int CNAME(BLASLONG m, FLOAT *a, BLASLONG lda, FLOAT *b, BLASLONG incb, void *buffer){
+int __attribute__((visibility("hidden"))) CNAME(BLASLONG m, FLOAT *a, BLASLONG lda, FLOAT *b, BLASLONG incb, void *buffer){
 
   BLASLONG i, is, min_i;
   FLOAT *gemvbuffer = (FLOAT *)buffer;

--- a/driver/level2/trsv_L.c
+++ b/driver/level2/trsv_L.c
@@ -46,7 +46,7 @@ const static FLOAT dm1 = -1.;
 #define GEMV_UNROLL DTB_ENTRIES
 
 int
-#ifndef MSVC
+#ifndef C_MSVC
 __attribute__((visibility("hidden"))) 
 #endif
 	CNAME(BLASLONG m, FLOAT *a, BLASLONG lda, FLOAT *b, BLASLONG incb, void *buffer){

--- a/driver/level2/trsv_L.c
+++ b/driver/level2/trsv_L.c
@@ -45,7 +45,11 @@ const static FLOAT dm1 = -1.;
 #undef GEMV_UNROLL
 #define GEMV_UNROLL DTB_ENTRIES
 
-int __attribute__((visibility("hidden"))) CNAME(BLASLONG m, FLOAT *a, BLASLONG lda, FLOAT *b, BLASLONG incb, void *buffer){
+int
+#ifndef MSVC
+__attribute__((visibility("hidden"))) 
+#endif
+	CNAME(BLASLONG m, FLOAT *a, BLASLONG lda, FLOAT *b, BLASLONG incb, void *buffer){
 
   BLASLONG i, is, min_i;
   FLOAT *gemvbuffer = (FLOAT *)buffer;

--- a/driver/level2/trsv_U.c
+++ b/driver/level2/trsv_U.c
@@ -42,7 +42,11 @@
 
 const static FLOAT dm1 = -1.;
 
-int __attribute__((visibility("hidden"))) CNAME(BLASLONG m, FLOAT *a, BLASLONG lda, FLOAT *b, BLASLONG incb, void *buffer){
+int
+#ifndef MSVC
+__attribute__((visibility("hidden"))) 
+#endif
+	CNAME(BLASLONG m, FLOAT *a, BLASLONG lda, FLOAT *b, BLASLONG incb, void *buffer){
 
   BLASLONG i, is, min_i;
   FLOAT *gemvbuffer = (FLOAT *)buffer;

--- a/driver/level2/trsv_U.c
+++ b/driver/level2/trsv_U.c
@@ -43,7 +43,7 @@
 const static FLOAT dm1 = -1.;
 
 int
-#ifndef MSVC
+#ifndef C_MSVC
 __attribute__((visibility("hidden"))) 
 #endif
 	CNAME(BLASLONG m, FLOAT *a, BLASLONG lda, FLOAT *b, BLASLONG incb, void *buffer){

--- a/driver/level2/trsv_U.c
+++ b/driver/level2/trsv_U.c
@@ -42,7 +42,7 @@
 
 const static FLOAT dm1 = -1.;
 
-int CNAME(BLASLONG m, FLOAT *a, BLASLONG lda, FLOAT *b, BLASLONG incb, void *buffer){
+int __attribute__((visibility("hidden"))) CNAME(BLASLONG m, FLOAT *a, BLASLONG lda, FLOAT *b, BLASLONG incb, void *buffer){
 
   BLASLONG i, is, min_i;
   FLOAT *gemvbuffer = (FLOAT *)buffer;

--- a/driver/level2/zgbmv_k.c
+++ b/driver/level2/zgbmv_k.c
@@ -66,7 +66,11 @@
 #define M n
 #endif
 
-void CNAME(BLASLONG m, BLASLONG n, BLASLONG ku, BLASLONG kl, FLOAT alpha_r, FLOAT alpha_i,
+void
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(BLASLONG m, BLASLONG n, BLASLONG ku, BLASLONG kl, FLOAT alpha_r, FLOAT alpha_i,
 	  FLOAT *a, BLASLONG lda,
 	  FLOAT *x, BLASLONG incx, FLOAT *y, BLASLONG incy, void *buffer){
 

--- a/driver/level2/zhbmv_k.c
+++ b/driver/level2/zhbmv_k.c
@@ -40,7 +40,11 @@
 #include <ctype.h>
 #include "common.h"
 
-int CNAME(BLASLONG n, BLASLONG k, FLOAT alpha_r, FLOAT alpha_i,
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(BLASLONG n, BLASLONG k, FLOAT alpha_r, FLOAT alpha_i,
 	  FLOAT *a, BLASLONG lda,
 	  FLOAT *x, BLASLONG incx, FLOAT *y, BLASLONG incy, void *buffer){
 

--- a/driver/level2/zher2_k.c
+++ b/driver/level2/zher2_k.c
@@ -40,7 +40,11 @@
 #include <ctype.h>
 #include "common.h"
 
-int CNAME(BLASLONG m, FLOAT alpha_r, FLOAT alpha_i,
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(BLASLONG m, FLOAT alpha_r, FLOAT alpha_i,
 	 FLOAT *x, BLASLONG incx,
 	 FLOAT *y, BLASLONG incy, FLOAT *a, BLASLONG lda, FLOAT *buffer){
 

--- a/driver/level2/zher_k.c
+++ b/driver/level2/zher_k.c
@@ -38,7 +38,11 @@
 
 #include "common.h"
 
-int CNAME(BLASLONG m, FLOAT alpha, FLOAT *x,
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(BLASLONG m, FLOAT alpha, FLOAT *x,
 		      BLASLONG incx, FLOAT *a, BLASLONG lda, FLOAT *buffer){
 
   BLASLONG i;

--- a/driver/level2/zhpmv_k.c
+++ b/driver/level2/zhpmv_k.c
@@ -40,7 +40,11 @@
 #include <ctype.h>
 #include "common.h"
 
-int CNAME(BLASLONG m, FLOAT alpha_r, FLOAT alpha_i,
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(BLASLONG m, FLOAT alpha_r, FLOAT alpha_i,
 	 FLOAT *a, FLOAT *x, BLASLONG incx, FLOAT *y, BLASLONG incy, void *buffer){
 
   BLASLONG i;

--- a/driver/level2/zhpr2_k.c
+++ b/driver/level2/zhpr2_k.c
@@ -40,7 +40,11 @@
 #include <ctype.h>
 #include "common.h"
 
-int CNAME(BLASLONG m, FLOAT alpha_r, FLOAT alpha_i,
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(BLASLONG m, FLOAT alpha_r, FLOAT alpha_i,
 	 FLOAT *x, BLASLONG incx,
 	 FLOAT *y, BLASLONG incy, FLOAT *a, FLOAT *buffer){
 

--- a/driver/level2/zhpr_k.c
+++ b/driver/level2/zhpr_k.c
@@ -38,7 +38,11 @@
 
 #include "common.h"
 
-int CNAME(BLASLONG m, FLOAT alpha, FLOAT *x,
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(BLASLONG m, FLOAT alpha, FLOAT *x,
 		      BLASLONG incx, FLOAT *a, FLOAT *buffer){
 
   BLASLONG i;

--- a/driver/level2/zsbmv_k.c
+++ b/driver/level2/zsbmv_k.c
@@ -40,7 +40,11 @@
 #include <ctype.h>
 #include "common.h"
 
-int CNAME(BLASLONG n, BLASLONG k, FLOAT alpha_r, FLOAT alpha_i,
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(BLASLONG n, BLASLONG k, FLOAT alpha_r, FLOAT alpha_i,
 	  FLOAT *a, BLASLONG lda,
 	  FLOAT *x, BLASLONG incx, FLOAT *y, BLASLONG incy, void *buffer){
 

--- a/driver/level2/zspmv_k.c
+++ b/driver/level2/zspmv_k.c
@@ -40,7 +40,11 @@
 #include <ctype.h>
 #include "common.h"
 
-int CNAME(BLASLONG m, FLOAT alpha_r, FLOAT alpha_i,
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(BLASLONG m, FLOAT alpha_r, FLOAT alpha_i,
 	  FLOAT *a, FLOAT *x, BLASLONG incx, FLOAT *y, BLASLONG incy, void *buffer){
 
   BLASLONG i;

--- a/driver/level2/zspr2_k.c
+++ b/driver/level2/zspr2_k.c
@@ -40,7 +40,11 @@
 #include <ctype.h>
 #include "common.h"
 
-int CNAME(BLASLONG m, FLOAT alpha_r, FLOAT alpha_i, FLOAT *x, BLASLONG incx,
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(BLASLONG m, FLOAT alpha_r, FLOAT alpha_i, FLOAT *x, BLASLONG incx,
 		       FLOAT *y, BLASLONG incy, FLOAT *a, FLOAT *buffer){
 
   BLASLONG i;

--- a/driver/level2/zspr_k.c
+++ b/driver/level2/zspr_k.c
@@ -38,7 +38,11 @@
 
 #include "common.h"
 
-int CNAME(BLASLONG m, FLOAT alpha_r, FLOAT alpha_i,
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(BLASLONG m, FLOAT alpha_r, FLOAT alpha_i,
 	  FLOAT *x, BLASLONG incx, FLOAT *a, FLOAT *buffer){
 
   BLASLONG i;

--- a/driver/level2/zsyr2_k.c
+++ b/driver/level2/zsyr2_k.c
@@ -40,7 +40,11 @@
 #include <ctype.h>
 #include "common.h"
 
-int CNAME(BLASLONG m, FLOAT alpha_r, FLOAT alpha_i, FLOAT *x, BLASLONG incx,
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(BLASLONG m, FLOAT alpha_r, FLOAT alpha_i, FLOAT *x, BLASLONG incx,
 		       FLOAT *y, BLASLONG incy, FLOAT *a, BLASLONG lda, FLOAT *buffer){
 
   BLASLONG i;

--- a/driver/level2/zsyr_k.c
+++ b/driver/level2/zsyr_k.c
@@ -38,7 +38,11 @@
 
 #include "common.h"
 
-int CNAME(BLASLONG m, FLOAT alpha_r, FLOAT alpha_i,
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(BLASLONG m, FLOAT alpha_r, FLOAT alpha_i,
 	  FLOAT *x, BLASLONG incx, FLOAT *a, BLASLONG lda, FLOAT *buffer){
 
   BLASLONG i;

--- a/driver/level2/ztbmv_L.c
+++ b/driver/level2/ztbmv_L.c
@@ -42,7 +42,11 @@
 
 // const static FLOAT dp1 = 1.;
 
-int CNAME(BLASLONG n, BLASLONG k, FLOAT *a, BLASLONG lda, FLOAT *b, BLASLONG incb, void *buffer){
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(BLASLONG n, BLASLONG k, FLOAT *a, BLASLONG lda, FLOAT *b, BLASLONG incb, void *buffer){
 
   BLASLONG i;
   FLOAT *B = b;

--- a/driver/level2/ztbmv_U.c
+++ b/driver/level2/ztbmv_U.c
@@ -42,7 +42,11 @@
 
 // const static FLOAT dp1 = 1.;
 
-int CNAME(BLASLONG n, BLASLONG k, FLOAT *a, BLASLONG lda, FLOAT *b, BLASLONG incb, void *buffer){
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(BLASLONG n, BLASLONG k, FLOAT *a, BLASLONG lda, FLOAT *b, BLASLONG incb, void *buffer){
 
   BLASLONG i;
   FLOAT *B = b;

--- a/driver/level2/ztbsv_L.c
+++ b/driver/level2/ztbsv_L.c
@@ -42,7 +42,11 @@
 
 // const static FLOAT dp1 = 1.;
 
-int CNAME(BLASLONG n, BLASLONG k, FLOAT *a, BLASLONG lda, FLOAT *b, BLASLONG incb, void *buffer){
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(BLASLONG n, BLASLONG k, FLOAT *a, BLASLONG lda, FLOAT *b, BLASLONG incb, void *buffer){
 
   BLASLONG i;
   FLOAT *B = b;

--- a/driver/level2/ztbsv_U.c
+++ b/driver/level2/ztbsv_U.c
@@ -42,7 +42,11 @@
 
 // const static FLOAT dp1 = 1.;
 
-int CNAME(BLASLONG n, BLASLONG k, FLOAT *a, BLASLONG lda, FLOAT *b, BLASLONG incb, void *buffer){
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(BLASLONG n, BLASLONG k, FLOAT *a, BLASLONG lda, FLOAT *b, BLASLONG incb, void *buffer){
 
   BLASLONG i;
   FLOAT *B = b;

--- a/driver/level2/ztpmv_L.c
+++ b/driver/level2/ztpmv_L.c
@@ -40,7 +40,11 @@
 #include <ctype.h>
 #include "common.h"
 
-int CNAME(BLASLONG m, FLOAT *a, FLOAT *b, BLASLONG incb, void *buffer){
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(BLASLONG m, FLOAT *a, FLOAT *b, BLASLONG incb, void *buffer){
 
   BLASLONG i;
 #if (TRANSA == 2) || (TRANSA == 4)

--- a/driver/level2/ztpmv_U.c
+++ b/driver/level2/ztpmv_U.c
@@ -40,7 +40,11 @@
 #include <ctype.h>
 #include "common.h"
 
-int CNAME(BLASLONG m, FLOAT *a, FLOAT *b, BLASLONG incb, void *buffer){
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(BLASLONG m, FLOAT *a, FLOAT *b, BLASLONG incb, void *buffer){
 
   BLASLONG i;
 #if (TRANSA == 2) || (TRANSA == 4)

--- a/driver/level2/ztpsv_L.c
+++ b/driver/level2/ztpsv_L.c
@@ -42,7 +42,11 @@
 
 // const static FLOAT dm1 = -1.;
 
-int CNAME(BLASLONG m, FLOAT *a, FLOAT *b, BLASLONG incb, void *buffer){
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(BLASLONG m, FLOAT *a, FLOAT *b, BLASLONG incb, void *buffer){
 
   BLASLONG i;
 #if (TRANSA == 2) || (TRANSA == 4)

--- a/driver/level2/ztpsv_U.c
+++ b/driver/level2/ztpsv_U.c
@@ -40,7 +40,11 @@
 #include <ctype.h>
 #include "common.h"
 
-int CNAME(BLASLONG m, FLOAT *a, FLOAT *b, BLASLONG incb, void *buffer){
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(BLASLONG m, FLOAT *a, FLOAT *b, BLASLONG incb, void *buffer){
 
   BLASLONG i;
 #if (TRANSA == 2) || (TRANSA == 4)

--- a/driver/level2/ztrmv_L.c
+++ b/driver/level2/ztrmv_L.c
@@ -42,7 +42,11 @@
 
 static FLOAT dp1 = 1.;
 
-int CNAME(BLASLONG m, FLOAT *a, BLASLONG lda, FLOAT *b, BLASLONG incb, FLOAT *buffer){
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(BLASLONG m, FLOAT *a, BLASLONG lda, FLOAT *b, BLASLONG incb, FLOAT *buffer){
 
   BLASLONG i, is, min_i;
 #if (TRANSA == 2) || (TRANSA == 4)

--- a/driver/level2/ztrmv_U.c
+++ b/driver/level2/ztrmv_U.c
@@ -42,7 +42,11 @@
 
 static FLOAT dp1 = 1.;
 
-int CNAME(BLASLONG m, FLOAT *a, BLASLONG lda, FLOAT *b, BLASLONG incb, FLOAT *buffer){
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(BLASLONG m, FLOAT *a, BLASLONG lda, FLOAT *b, BLASLONG incb, FLOAT *buffer){
 
   BLASLONG i, is, min_i;
 #if (TRANSA == 2) || (TRANSA == 4)

--- a/driver/level2/ztrsv_L.c
+++ b/driver/level2/ztrsv_L.c
@@ -43,7 +43,7 @@
 const static FLOAT dm1 = -1.;
 
 int
-#ifndef MSVC
+#ifndef C_MSVC
 __attribute__((visibility("hidden")))
 #endif
 	CNAME(BLASLONG m, FLOAT *a, BLASLONG lda, FLOAT *b, BLASLONG incb, void *buffer){

--- a/driver/level2/ztrsv_L.c
+++ b/driver/level2/ztrsv_L.c
@@ -42,7 +42,7 @@
 
 const static FLOAT dm1 = -1.;
 
-int CNAME(BLASLONG m, FLOAT *a, BLASLONG lda, FLOAT *b, BLASLONG incb, void *buffer){
+int __attribute__((visibility("hidden"))) CNAME(BLASLONG m, FLOAT *a, BLASLONG lda, FLOAT *b, BLASLONG incb, void *buffer){
 
   BLASLONG i, is, min_i;
 #if (TRANSA == 2) || (TRANSA == 4)

--- a/driver/level2/ztrsv_L.c
+++ b/driver/level2/ztrsv_L.c
@@ -42,7 +42,11 @@
 
 const static FLOAT dm1 = -1.;
 
-int __attribute__((visibility("hidden"))) CNAME(BLASLONG m, FLOAT *a, BLASLONG lda, FLOAT *b, BLASLONG incb, void *buffer){
+int
+#ifndef MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(BLASLONG m, FLOAT *a, BLASLONG lda, FLOAT *b, BLASLONG incb, void *buffer){
 
   BLASLONG i, is, min_i;
 #if (TRANSA == 2) || (TRANSA == 4)

--- a/driver/level2/ztrsv_U.c
+++ b/driver/level2/ztrsv_U.c
@@ -43,7 +43,7 @@
 const static FLOAT dm1 = -1.;
 
 int
-#ifndef MSVC
+#ifndef C_MSVC
 __attribute__((visibility("hidden")))
 #endif
 	CNAME(BLASLONG m, FLOAT *a, BLASLONG lda, FLOAT *b, BLASLONG incb, void *buffer){

--- a/driver/level2/ztrsv_U.c
+++ b/driver/level2/ztrsv_U.c
@@ -42,7 +42,7 @@
 
 const static FLOAT dm1 = -1.;
 
-int CNAME(BLASLONG m, FLOAT *a, BLASLONG lda, FLOAT *b, BLASLONG incb, void *buffer){
+int __attribute__((visibility("hidden"))) CNAME(BLASLONG m, FLOAT *a, BLASLONG lda, FLOAT *b, BLASLONG incb, void *buffer){
 
   BLASLONG i, is, min_i;
 #if (TRANSA == 2) || (TRANSA == 4)

--- a/driver/level2/ztrsv_U.c
+++ b/driver/level2/ztrsv_U.c
@@ -42,7 +42,11 @@
 
 const static FLOAT dm1 = -1.;
 
-int __attribute__((visibility("hidden"))) CNAME(BLASLONG m, FLOAT *a, BLASLONG lda, FLOAT *b, BLASLONG incb, void *buffer){
+int
+#ifndef MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(BLASLONG m, FLOAT *a, BLASLONG lda, FLOAT *b, BLASLONG incb, void *buffer){
 
   BLASLONG i, is, min_i;
 #if (TRANSA == 2) || (TRANSA == 4)

--- a/driver/level3/gemm3m_level3.c
+++ b/driver/level3/gemm3m_level3.c
@@ -227,7 +227,11 @@
 #define STOP_RPCC(COUNTER)
 #endif
 
-int CNAME(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n,
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n,
 		  FLOAT *sa, FLOAT *sb, BLASLONG dummy){
   BLASLONG k, lda, ldb, ldc;
   FLOAT *alpha, *beta;

--- a/driver/level3/gemm_thread_m.c
+++ b/driver/level3/gemm_thread_m.c
@@ -40,7 +40,11 @@
 #include <stdlib.h>
 #include "common.h"
 
-int CNAME(int mode, blas_arg_t *arg, BLASLONG *range_m, BLASLONG *range_n, int (*function)(), void *sa, void *sb, BLASLONG nthreads) {
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(int mode, blas_arg_t *arg, BLASLONG *range_m, BLASLONG *range_n, int (*function)(), void *sa, void *sb, BLASLONG nthreads) {
 
   blas_queue_t queue[MAX_CPU_NUMBER];
   BLASLONG range[MAX_CPU_NUMBER + 1];

--- a/driver/level3/gemm_thread_mn.c
+++ b/driver/level3/gemm_thread_mn.c
@@ -60,7 +60,11 @@ static const int divide_rule[][2] =
    { 1, 61}, { 2, 31}, { 7,  9}, { 8,  8},
 };
 
-int CNAME(int mode, blas_arg_t *arg, BLASLONG *range_m, BLASLONG *range_n, int (*function)(), void *sa, void *sb, BLASLONG nthreads) {
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(int mode, blas_arg_t *arg, BLASLONG *range_m, BLASLONG *range_n, int (*function)(), void *sa, void *sb, BLASLONG nthreads) {
 
   blas_queue_t queue[MAX_CPU_NUMBER];
 

--- a/driver/level3/gemm_thread_n.c
+++ b/driver/level3/gemm_thread_n.c
@@ -40,7 +40,11 @@
 #include <stdlib.h>
 #include "common.h"
 
-int CNAME(int mode, blas_arg_t *arg, BLASLONG *range_m, BLASLONG *range_n, int (*function)(), void *sa, void *sb, BLASLONG nthreads) {
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(int mode, blas_arg_t *arg, BLASLONG *range_m, BLASLONG *range_n, int (*function)(), void *sa, void *sb, BLASLONG nthreads) {
 
   blas_queue_t queue[MAX_CPU_NUMBER];
   BLASLONG range[MAX_CPU_NUMBER + 1];

--- a/driver/level3/gemm_thread_variable.c
+++ b/driver/level3/gemm_thread_variable.c
@@ -40,7 +40,11 @@
 #include <stdlib.h>
 #include "common.h"
 
-int CNAME(int mode,
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(int mode,
 	  blas_arg_t *arg, BLASLONG *range_m, BLASLONG *range_n,
 	  int (*function)(), void *sa, void *sb, BLASLONG divM, BLASLONG divN) {
 

--- a/driver/level3/level3.c
+++ b/driver/level3/level3.c
@@ -169,7 +169,11 @@
 #define STOP_RPCC(COUNTER)
 #endif
 
-int CNAME(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n,
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n,
 		  XFLOAT *sa, XFLOAT *sb, BLASLONG dummy){
   BLASLONG k, lda, ldb, ldc;
   FLOAT *alpha, *beta;

--- a/driver/level3/level3_gemm3m_thread.c
+++ b/driver/level3/level3_gemm3m_thread.c
@@ -1007,7 +1007,11 @@ EnterCriticalSection((PCRITICAL_SECTION)&level3_lock);
   return 0;
 }
 
-int CNAME(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, FLOAT *sa, FLOAT *sb, BLASLONG mypos){
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, FLOAT *sa, FLOAT *sb, BLASLONG mypos){
 
   BLASLONG m = args -> m;
   // BLASLONG n = args -> n;

--- a/driver/level3/level3_syr2k.c
+++ b/driver/level3/level3_syr2k.c
@@ -102,7 +102,11 @@
 #define LDC	args -> ldc
 #endif
 
-int CNAME(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, FLOAT *sa, FLOAT *sb, BLASLONG dummy) {
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, FLOAT *sa, FLOAT *sb, BLASLONG dummy) {
 
   BLASLONG m_from, m_to, n_from, n_to, k, lda, ldb, ldc;
   FLOAT *a, *b, *c, *alpha, *beta;

--- a/driver/level3/level3_syrk.c
+++ b/driver/level3/level3_syrk.c
@@ -98,7 +98,11 @@
 #define STOP_RPCC(COUNTER)
 #endif
 
-int CNAME(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, FLOAT *sa, FLOAT *sb, BLASLONG dummy) {
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, FLOAT *sa, FLOAT *sb, BLASLONG dummy) {
 
   BLASLONG m_from, m_to, n_from, n_to, k, lda, ldc;
   FLOAT *a, *c, *alpha, *beta;

--- a/driver/level3/level3_syrk_threaded.c
+++ b/driver/level3/level3_syrk_threaded.c
@@ -505,7 +505,11 @@ static int inner_thread(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, 
   return 0;
 }
 
-int CNAME(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, FLOAT *sa, FLOAT *sb, BLASLONG mypos){
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, FLOAT *sa, FLOAT *sb, BLASLONG mypos){
 
   blas_arg_t newarg;
 

--- a/driver/level3/level3_thread.c
+++ b/driver/level3/level3_thread.c
@@ -731,7 +731,11 @@ EnterCriticalSection((PCRITICAL_SECTION)&level3_lock);
   return 0;
 }
 
-int CNAME(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, IFLOAT *sa, IFLOAT *sb, BLASLONG mypos){
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, IFLOAT *sa, IFLOAT *sb, BLASLONG mypos){
 
   BLASLONG m = args -> m;
   BLASLONG n = args -> n;

--- a/driver/level3/syr2k_kernel.c
+++ b/driver/level3/syr2k_kernel.c
@@ -39,7 +39,11 @@
 #include <stdio.h>
 #include "common.h"
 
-int CNAME(BLASLONG m, BLASLONG n, BLASLONG k, FLOAT alpha_r,
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(BLASLONG m, BLASLONG n, BLASLONG k, FLOAT alpha_r,
 #ifdef COMPLEX
 	   FLOAT alpha_i,
 #endif

--- a/driver/level3/syrk_kernel.c
+++ b/driver/level3/syrk_kernel.c
@@ -53,7 +53,11 @@
 #endif
 #endif
 
-int CNAME(BLASLONG m, BLASLONG n, BLASLONG k, FLOAT alpha_r,
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(BLASLONG m, BLASLONG n, BLASLONG k, FLOAT alpha_r,
 #ifdef COMPLEX
 	   FLOAT alpha_i,
 #endif

--- a/driver/level3/syrk_thread.c
+++ b/driver/level3/syrk_thread.c
@@ -41,7 +41,11 @@
 #include <math.h>
 #include "common.h"
 
-int CNAME(int mode, blas_arg_t *arg, BLASLONG *range_m, BLASLONG *range_n, int (*function)(), void *sa, void *sb, BLASLONG nthreads) {
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(int mode, blas_arg_t *arg, BLASLONG *range_m, BLASLONG *range_n, int (*function)(), void *sa, void *sb, BLASLONG nthreads) {
 
   blas_queue_t queue[MAX_CPU_NUMBER];
   BLASLONG range[MAX_CPU_NUMBER + 1];

--- a/driver/level3/trmm_L.c
+++ b/driver/level3/trmm_L.c
@@ -62,7 +62,11 @@ const static FLOAT dp1 = 1.;
 #define STOP_RPCC(COUNTER)
 #endif
 
-int CNAME(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, FLOAT *sa, FLOAT *sb, BLASLONG dummy) {
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, FLOAT *sa, FLOAT *sb, BLASLONG dummy) {
 
   BLASLONG m, n, lda, ldb;
   FLOAT *beta, *a, *b;

--- a/driver/level3/trmm_R.c
+++ b/driver/level3/trmm_R.c
@@ -62,7 +62,11 @@ const static FLOAT dp1 = 1.;
 #define GEMM_R 16
 #endif
 
-int CNAME(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, FLOAT *sa, FLOAT *sb, BLASLONG dummy) {
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, FLOAT *sa, FLOAT *sb, BLASLONG dummy) {
 
   BLASLONG m, n, lda, ldb;
   FLOAT *beta, *a, *b;

--- a/driver/level3/trsm_L.c
+++ b/driver/level3/trsm_L.c
@@ -68,7 +68,11 @@ const static FLOAT dm1 = -1.;
 #define GEMM_R 1600
 #endif
 
-int CNAME(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, FLOAT *sa, FLOAT *sb, BLASLONG dummy) {
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, FLOAT *sa, FLOAT *sb, BLASLONG dummy) {
 
   BLASLONG m, n, lda, ldb;
   FLOAT *beta, *a, *b;

--- a/driver/level3/trsm_R.c
+++ b/driver/level3/trsm_R.c
@@ -68,7 +68,11 @@ const static FLOAT dm1 = -1.;
 #define GEMM_R 24
 #endif
 
-int CNAME(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, FLOAT *sa, FLOAT *sb, BLASLONG dummy) {
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, FLOAT *sa, FLOAT *sb, BLASLONG dummy) {
 
   BLASLONG m, n, lda, ldb;
   FLOAT *beta, *a, *b;

--- a/driver/level3/zher2k_kernel.c
+++ b/driver/level3/zher2k_kernel.c
@@ -47,7 +47,11 @@
 #define GEMM_KERNEL_B0	GEMM_KERNEL_L_B0
 #endif
 
-int CNAME(BLASLONG m, BLASLONG n, BLASLONG k, FLOAT alpha_r, FLOAT alpha_i,
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(BLASLONG m, BLASLONG n, BLASLONG k, FLOAT alpha_r, FLOAT alpha_i,
 	   FLOAT *a, FLOAT *b, FLOAT *c, BLASLONG ldc, BLASLONG offset, int flag){
 
   BLASLONG i, j;

--- a/driver/level3/zherk_beta.c
+++ b/driver/level3/zherk_beta.c
@@ -40,7 +40,11 @@
 #include <ctype.h>
 #include "common.h"
 
-int CNAME(BLASLONG dummy1, BLASLONG n,  BLASLONG dummy2, FLOAT alpha_r, FLOAT alpha_i,
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(BLASLONG dummy1, BLASLONG n,  BLASLONG dummy2, FLOAT alpha_r, FLOAT alpha_i,
 	  FLOAT *dummy3, BLASLONG dummy4, FLOAT *dummy5, BLASLONG dummy6,
 	  FLOAT *c, BLASLONG ldc,
 	  FLOAT *dummy7, FLOAT *dummy8, BLASLONG from, BLASLONG to){

--- a/driver/level3/zherk_kernel.c
+++ b/driver/level3/zherk_kernel.c
@@ -47,7 +47,11 @@
 #define GEMM_KERNEL_B0	GEMM_KERNEL_L_B0
 #endif
 
-int CNAME(BLASLONG m, BLASLONG n, BLASLONG k, FLOAT alpha_r,
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(BLASLONG m, BLASLONG n, BLASLONG k, FLOAT alpha_r,
 	   FLOAT *a, FLOAT *b, FLOAT *c, BLASLONG ldc, BLASLONG offset){
 
   BLASLONG i, j;

--- a/driver/level3/zsyrk_beta.c
+++ b/driver/level3/zsyrk_beta.c
@@ -40,7 +40,11 @@
 #include <ctype.h>
 #include "common.h"
 
-int CNAME(BLASLONG dummy1, BLASLONG n,  BLASLONG dummy2, FLOAT alpha_r, FLOAT alpha_i,
+int
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(BLASLONG dummy1, BLASLONG n,  BLASLONG dummy2, FLOAT alpha_r, FLOAT alpha_i,
 	  FLOAT *dummy3, BLASLONG dummy4, FLOAT *dummy5, BLASLONG dummy6,
 	  FLOAT *c, BLASLONG ldc,
 	  FLOAT *dummy7, FLOAT *dummy8, BLASLONG from, BLASLONG to){

--- a/lapack/trti2/trti2_L.c
+++ b/lapack/trti2/trti2_L.c
@@ -45,7 +45,11 @@
 #define TRMV	TRMV_NLN
 #endif
 
-blasint CNAME(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, FLOAT *sa, FLOAT *sb, BLASLONG myid) {
+blasint
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, FLOAT *sa, FLOAT *sb, BLASLONG myid) {
 
   BLASLONG  n, lda;
   FLOAT *a;

--- a/lapack/trti2/trti2_U.c
+++ b/lapack/trti2/trti2_U.c
@@ -45,7 +45,11 @@
 #define TRMV	TRMV_NUN
 #endif
 
-blasint CNAME(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, FLOAT *sa, FLOAT *sb, BLASLONG myid) {
+blasint
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, FLOAT *sa, FLOAT *sb, BLASLONG myid) {
 
   BLASLONG  n, lda;
   FLOAT *a;

--- a/lapack/trti2/ztrti2_L.c
+++ b/lapack/trti2/ztrti2_L.c
@@ -45,7 +45,11 @@
 #define ZTRMV	ZTRMV_NLN
 #endif
 
-blasint CNAME(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, FLOAT *sa, FLOAT *sb, BLASLONG myid) {
+blasint
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, FLOAT *sa, FLOAT *sb, BLASLONG myid) {
 
   BLASLONG  n, lda;
   FLOAT *a;

--- a/lapack/trti2/ztrti2_U.c
+++ b/lapack/trti2/ztrti2_U.c
@@ -45,7 +45,11 @@
 #define ZTRMV	ZTRMV_NUN
 #endif
 
-blasint CNAME(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, FLOAT *sa, FLOAT *sb, BLASLONG myid) {
+blasint
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, FLOAT *sa, FLOAT *sb, BLASLONG myid) {
 
   BLASLONG  n, lda;
   FLOAT *a;

--- a/lapack/trtri/trtri_L_parallel.c
+++ b/lapack/trtri/trtri_L_parallel.c
@@ -49,7 +49,11 @@
 #define TRSM	TRSM_RNLN
 #endif
 
-blasint CNAME(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, FLOAT *sa, FLOAT *sb, BLASLONG mypos) {
+blasint
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, FLOAT *sa, FLOAT *sb, BLASLONG mypos) {
 
   BLASLONG n, info;
   BLASLONG bk, i, blocking, start_i;

--- a/lapack/trtri/trtri_L_single.c
+++ b/lapack/trtri/trtri_L_single.c
@@ -51,7 +51,11 @@
 #endif
 
 
-blasint CNAME(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, FLOAT *sa, FLOAT *sb, BLASLONG myid) {
+blasint
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, FLOAT *sa, FLOAT *sb, BLASLONG myid) {
 
   BLASLONG j, n, lda;
   FLOAT *a;

--- a/lapack/trtri/trtri_U_parallel.c
+++ b/lapack/trtri/trtri_U_parallel.c
@@ -49,7 +49,11 @@
 #define TRSM	TRSM_RNUN
 #endif
 
-blasint CNAME(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, FLOAT *sa, FLOAT *sb, BLASLONG mypos) {
+blasint
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, FLOAT *sa, FLOAT *sb, BLASLONG mypos) {
 
   BLASLONG n, info;
   BLASLONG bk, i, blocking;

--- a/lapack/trtri/trtri_U_single.c
+++ b/lapack/trtri/trtri_U_single.c
@@ -55,7 +55,11 @@
 #endif
 
 
-blasint CNAME(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, FLOAT *sa, FLOAT *sb, BLASLONG myid) {
+blasint
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, FLOAT *sa, FLOAT *sb, BLASLONG myid) {
 
   BLASLONG j, n, lda;
   FLOAT *a;

--- a/lapack/trtrs/trtrs_parallel.c
+++ b/lapack/trtrs/trtrs_parallel.c
@@ -73,7 +73,11 @@ static int inner_thread(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n,
   return 0;
 }
 
-blasint CNAME(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, FLOAT *sa, FLOAT *sb, BLASLONG mypos) {
+blasint
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, FLOAT *sa, FLOAT *sb, BLASLONG mypos) {
 
   int mode;
 

--- a/lapack/trtrs/trtrs_single.c
+++ b/lapack/trtrs/trtrs_single.c
@@ -65,7 +65,11 @@
 #define TRSV TRSV_TLN
 #endif
 
-blasint CNAME(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, FLOAT *sa, FLOAT *sb, BLASLONG mypos) {
+blasint
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, FLOAT *sa, FLOAT *sb, BLASLONG mypos) {
 
     if (args -> n == 1){
         TRSV (args -> m, args -> a, args -> lda, args -> b, 1, sb);

--- a/lapack/trtrs/ztrtrs_parallel.c
+++ b/lapack/trtrs/ztrtrs_parallel.c
@@ -96,7 +96,11 @@ static int inner_thread(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n,
   return 0;
 }
 
-blasint CNAME(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, FLOAT *sa, FLOAT *sb, BLASLONG mypos) {
+blasint
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, FLOAT *sa, FLOAT *sb, BLASLONG mypos) {
 
   int mode;
 

--- a/lapack/trtrs/ztrtrs_single.c
+++ b/lapack/trtrs/ztrtrs_single.c
@@ -89,7 +89,11 @@
 #define ZTRSV ZTRSV_CLN
 #endif
 
-blasint CNAME(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, FLOAT *sa, FLOAT *sb, BLASLONG mypos) {
+blasint
+#ifndef C_MSVC
+__attribute__((visibility("hidden")))
+#endif
+	CNAME(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, FLOAT *sa, FLOAT *sb, BLASLONG mypos) {
     if (args -> n == 1){
         ZTRSV (args -> m, args -> a, args -> lda, args -> b, 1, sb);
     } else {


### PR DESCRIPTION
cf. https://github.com/MacPython/openblas-libs/issues/79 (remaining symbol conflicts between builds with and without INTERFACE64 as the internally used functions to not get suffixed. Adding suffixes for them would be the second-best solution if some compiler balks at the attribute)