### PR TITLE
POWER: fix issues with the small matrix kernel

### DIFF
--- a/Makefile.system
+++ b/Makefile.system
@@ -261,7 +261,7 @@ endif
 #For small matrix optimization
 ifeq ($(ARCH), x86_64)
 SMALL_MATRIX_OPT = 1
-else ifeq ($(CORE), POWER10)
+else ifeq ($(ARCH), power)
 SMALL_MATRIX_OPT = 1
 endif
 ifeq ($(SMALL_MATRIX_OPT), 1)

--- a/kernel/power/gemm_small_kernel_permit_power10.c
+++ b/kernel/power/gemm_small_kernel_permit_power10.c
@@ -69,6 +69,7 @@ int CNAME(int transa, int transb, BLASLONG M, BLASLONG N, BLASLONG K, FLOAT alph
 
 #endif
 
+#ifdef SMP
   // Multi-threading execution outperforms (or approaches) the execution of the
   // small kernel.
   if (num_cpu_avail(3) > 1) {
@@ -77,6 +78,9 @@ int CNAME(int transa, int transb, BLASLONG M, BLASLONG N, BLASLONG K, FLOAT alph
   } else {
     return 1;
   }
+#else
+  return 1;
+#endif
 
 #endif
 


### PR DESCRIPTION
This patch:

1 - fixes an issue when compiling OpenBLAS for TARGET=POWER10 if USE_THREAD is set to 0;
2 - enables SMALL_MATRIX_OPT as default for dynamic arch compilation.

About (1), `num_cpu_avail` is only enabled for use when USE_THREAD=1.

cc: @rafaelcfsousa 