### PR TITLE
Increase MACOSX_DEPLOYMENT_TARGET to 11 on ARM macs

### DIFF
--- a/Makefile.system
+++ b/Makefile.system
@@ -384,7 +384,11 @@ endif
 
 ifeq ($(OSNAME), Darwin)
 ifndef MACOSX_DEPLOYMENT_TARGET
+ifeq ($(ARCH), arm64)
+export MACOSX_DEPLOYMENT_TARGET=11.0
+else
 export MACOSX_DEPLOYMENT_TARGET=10.8
+endif
 endif
 MD5SUM = md5 -r
 endif


### PR DESCRIPTION
should fix linker errors w.r.t chkstk_darwin symbol seen on M1 as mentioned in #3383 and recently #3652