### PR TITLE
Fix dnrm2_tiny testcase failure

### DIFF
--- a/kernel/loongarch64/dnrm2.S
+++ b/kernel/loongarch64/dnrm2.S
@@ -53,6 +53,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define s4     $f9
 #define ALPHA  $f4
 #define max    $f5
+#define INF    $f6
 
    PROLOGUE
 
@@ -60,6 +61,11 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
    LDINT   N,     0(N)
    LDINT   INCX,  0(INCX)
 #endif
+
+   // Init INF
+   addi.d  TEMP, $r0,  0x7FF
+   slli.d  TEMP, TEMP, 52
+   MTC  INF, TEMP
 
    MTC  s1, $r0
    bge $r0,    N, .L999
@@ -198,7 +204,11 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
    CMPEQ   $fcc0, s1, a1
    fcvt.d.s   ALPHA, ALPHA
    bcnez   $fcc0, .L999
+
    fdiv.d  ALPHA, ALPHA, s1
+   CMPEQ   $fcc0, INF, ALPHA
+   bcnez   $fcc0, .L999
+
    MOV max, s1
    MOV s1, a1
    MOV s2, a1

--- a/kernel/mips64/dnrm2.S
+++ b/kernel/mips64/dnrm2.S
@@ -68,6 +68,7 @@
 
 #define ALPHA	$f16
 #define max	$f17
+#define INF	$f18
 
 
 	PROLOGUE
@@ -85,6 +86,11 @@
 
 	move	XX, X
 	NOP
+
+	//Init INF
+	lui     TEMP, 0x7FF0
+	dsll    TEMP, TEMP, 32
+	MTC1    TEMP, INF
 
 	LD	a1,  0 * SIZE(X)
 	daddiu	N, N, -1
@@ -254,6 +260,9 @@
 
 	div.d	ALPHA, ALPHA, s1
 	MOV	max, s1
+
+	CMPEQ  $fcc0, ALPHA, INF
+	bc1t   $fcc0, .L999
 
 	MOV	s1, a1
 	MOV	s2, a1


### PR DESCRIPTION
`s1` stores the maximum value of the input vector, I think it will be better to  make sure `s1` is greater than or equal to 1.0