### PR TITLE
POWER: Fix complex dot function failures

### DIFF
--- a/kernel/power/cdot.c
+++ b/kernel/power/cdot.c
@@ -29,6 +29,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "common.h"
 #if defined(POWER10)
+#pragma GCC optimize "O1"
 #include "cdot_microk_power10.c"
 #else
 #ifndef HAVE_KERNEL_8

--- a/kernel/power/zdot.c
+++ b/kernel/power/zdot.c
@@ -38,6 +38,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #if defined(POWER8) || defined(POWER9) || defined(POWER10)
 #if defined(__VEC__) || defined(__ALTIVEC__)
+#pragma GCC optimize "O1"
 #include "zdot_microk_power8.c"
 #endif
 #endif


### PR DESCRIPTION
There are some test failures in complex dot functions when compiling with gcc12.
The machine constraints used now do not update all the four elements in the
expected result array. Fixing this with a reduced level of optimization.
This is not changing any performance numbers but will be converted to C code in future.