### PR TITLE
Add env variable OMP_ADAPTIVE to control OMP threadpool behaviour

### DIFF
--- a/driver/others/blas_server_omp.c
+++ b/driver/others/blas_server_omp.c
@@ -403,6 +403,7 @@ int exec_blas(BLASLONG num, blas_queue_t *queue){
       break;
   }
 
+if (openblas_omp_adaptive_env() != 0) {
 #pragma omp parallel for num_threads(num) schedule(OMP_SCHED)
   for (i = 0; i < num; i ++) {
 
@@ -412,6 +413,17 @@ int exec_blas(BLASLONG num, blas_queue_t *queue){
 
     exec_threads(&queue[i], buf_index);
   }
+} else {
+#pragma omp parallel for schedule(OMP_SCHED)
+  for (i = 0; i < num; i ++) {
+
+#ifndef USE_SIMPLE_THREADED_LEVEL3
+    queue[i].position = i;
+#endif
+
+    exec_threads(&queue[i], buf_index);
+  }
+}
 
 #ifdef HAVE_C11
   atomic_store(&blas_buffer_inuse[buf_index], false);

--- a/driver/others/openblas_env.c
+++ b/driver/others/openblas_env.c
@@ -39,6 +39,7 @@ static int openblas_env_block_factor=0;
 static int openblas_env_openblas_num_threads=0;
 static int openblas_env_goto_num_threads=0;
 static int openblas_env_omp_num_threads=0;
+static int openblas_env_omp_adaptive=0;
 
 int openblas_verbose() { return openblas_env_verbose;}
 unsigned int openblas_thread_timeout() { return openblas_env_thread_timeout;}
@@ -46,6 +47,7 @@ int openblas_block_factor() { return openblas_env_block_factor;}
 int openblas_num_threads_env() { return openblas_env_openblas_num_threads;}
 int openblas_goto_num_threads_env() { return openblas_env_goto_num_threads;}
 int openblas_omp_num_threads_env() { return openblas_env_omp_num_threads;}
+int openblas_omp_adaptive_env() { return openblas_env_omp_adaptive;}
 
 void openblas_read_env() {
   int ret=0;
@@ -78,6 +80,11 @@ void openblas_read_env() {
   if (readenv(p,"OMP_NUM_THREADS")) ret = atoi(p);
   if(ret<0) ret=0;
   openblas_env_omp_num_threads=ret;
+
+  ret=0;
+  if (readenv(p,"OMP_ADAPTIVE")) ret = atoi(p);
+  if(ret<0) ret=0;
+  openblas_env_omp_adaptive=ret;
 
 }
 


### PR DESCRIPTION
PR #3546 highlighted two conflicting scenarios for the number of threads created in the OpenMP exec_blas() call
- for consistently small workloads, it may be beneficial to limit the threadpool size to the actual demand rather than the available number of cores in order to avoid the overhead from creation of idly spinning threads. This behaviour was introduced by PR #2775
- for large and highly variable workloads, always creating the maximum feasible threadpool (as was the norm for OpenBLAS up to that PR, i.e. before version 0.3.11) will be much more efficient, as otherwise there would be huge overhead from OpenMP creating a completely new threadpool whenever a larger one is requested. Accordingly, PR #3546 effectively proposed a revert of PR #2775

This here is an attempt to consolidate both use cases by returning to the "old" default behaviour, but making a resizing threadpool optionally available through a new environment variable OMP_ADAPTIVE (nonzero for activating #2775's mechanism)