### PR TITLE
POWER: Enable bfloat16 kernels by default

### DIFF
--- a/Makefile.system
+++ b/Makefile.system
@@ -263,6 +263,7 @@ ifeq ($(ARCH), x86_64)
 SMALL_MATRIX_OPT = 1
 else ifeq ($(ARCH), power)
 SMALL_MATRIX_OPT = 1
+BUILD_BFLOAT16 = 1
 endif
 ifeq ($(SMALL_MATRIX_OPT), 1)
 CCOMMON_OPT += -DSMALL_MATRIX_OPT

--- a/test/compare_sgemm_sbgemm.c
+++ b/test/compare_sgemm_sbgemm.c
@@ -51,9 +51,15 @@ typedef union
   float v;
   struct
   {
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+    uint32_t s:1;
+    uint32_t e:8;
+    uint32_t m:23;
+#else
     uint32_t m:23;
     uint32_t e:8;
     uint32_t s:1;
+#endif
   } bits;
 } float32_bits;
 


### PR DESCRIPTION
This patch enables bfloat16 kernels by default for POWER processors.
Tested on Linux POWER8, POWER9, POWER10 and AIX POWER10 systems.