### PR TITLE
Fix crash in RISCV autodetection when pmodel is not present in /proc/cpuinfo 

### DIFF
--- a/cpuid_riscv64.c
+++ b/cpuid_riscv64.c
@@ -88,18 +88,21 @@ int detect(void){
   infile = fopen("/proc/cpuinfo", "r");
   while (fgets(buffer, sizeof(buffer), infile)){
     if(!strncmp(buffer, "model name", 10)){
-      strcpy(model_buffer, buffer)
+      strcpy(model_buffer, buffer);
       pmodel = strchr(isa_buffer, ':') + 1;
     }
 
     if(!strncmp(buffer, "isa", 3)){
-      strcpy(isa_buffer, buffer)
+      strcpy(isa_buffer, buffer);
       pisa = strchr(isa_buffer, '4') + 1;
     }
   }
 
   fclose(infile);
 
+  if (!pmodel)
+   return(CPU_GENERIC);
+   
   if (strstr(pmodel, check_c910_str) && strchr(pisa, 'v'))
     return CPU_C910V;
 


### PR DESCRIPTION
problem observed on HiFive Unmatched (host gcc92 in the gcc compile farm)