### PR TITLE
Add TCORE Generic

### DIFF
--- a/cmake/prebuild.cmake
+++ b/cmake/prebuild.cmake
@@ -581,6 +581,15 @@ endif ()
     set(ZGEMM_UNROLL_M 8)
     set(ZGEMM_UNROLL_N 2)
     set(SYMV_P 8)
+  elseif ("${TCORE}" STREQUAL "GENERIC")
+    file(APPEND ${TARGET_CONF_TEMP}
+      "#define L1_DATA_SIZE 32768\n"
+      "#define L1_DATA_LINESIZE 128\n"
+      "#define L2_SIZE 524288\n"
+      "#define L2_LINESIZE 128 \n"
+      "#define DTB_DEFAULT_ENTRIES 128\n"
+      "#define DTB_SIZE 4096\n"
+      "#define L2_ASSOCIATIVE 8\n")
   endif()
   set(SBGEMM_UNROLL_M 8)
   set(SBGEMM_UNROLL_N 4)


### PR DESCRIPTION
During the cross-compilation on x64 host with MSVC for ARM, the build fails as there is no define directives for Generic core.