### PR TITLE
Restore conditional compilation and fix for parallel make in LAPACK MATGEN

### DIFF
--- a/lapack-netlib/TESTING/MATGEN/Makefile
+++ b/lapack-netlib/TESTING/MATGEN/Makefile
@@ -73,7 +73,7 @@ ZMATGEN = zlatms.o zlatme.o zlatmr.o zlatmt.o \
 endif
 
 .PHONY: all
-.NOTPARALLEL
+.NOTPARALLEL:
 all: $(TMGLIB)
 
 ALLOBJ = $(SMATGEN) $(CMATGEN) $(SCATGEN) $(DMATGEN) $(ZMATGEN) \

--- a/lapack-netlib/TESTING/MATGEN/Makefile
+++ b/lapack-netlib/TESTING/MATGEN/Makefile
@@ -40,27 +40,40 @@ ifneq ($(C_LAPACK), 1)
 	$(FC) $(FFLAGS) -c -o $@ $<
 endif
 
+ifneq "$(or $(BUILD_SINGLE),$(BUILD_COMPLEX))" ""
 SCATGEN = slatm1.o slatm7.o slaran.o slarnd.o
+endif
 
+ifeq ($(BUILD_SINGLE),1)
 SMATGEN = slatms.o slatme.o slatmr.o slatmt.o \
    slagge.o slagsy.o slakf2.o slarge.o slaror.o slarot.o slatm2.o \
    slatm3.o slatm5.o slatm6.o slahilb.o
+endif
 
+ifeq ($(BUILD_COMPLEX),1)
 CMATGEN = clatms.o clatme.o clatmr.o clatmt.o \
    clagge.o claghe.o clagsy.o clakf2.o clarge.o claror.o clarot.o \
    clatm1.o clarnd.o clatm2.o clatm3.o clatm5.o clatm6.o clahilb.o
+endif
 
+ifneq "$(or $(BUILD_DOUBLE),$(BUILD_COMPLEX16))" ""
 DZATGEN = dlatm1.o dlatm7.o dlaran.o dlarnd.o
+endif
 
+ifeq ($(BUILD_DOUBLE),1)
 DMATGEN = dlatms.o dlatme.o dlatmr.o dlatmt.o \
    dlagge.o dlagsy.o dlakf2.o dlarge.o dlaror.o dlarot.o dlatm2.o \
    dlatm3.o dlatm5.o dlatm6.o dlahilb.o
+endif
 
+ifeq ($(BUILD_COMPLEX16),1)
 ZMATGEN = zlatms.o zlatme.o zlatmr.o zlatmt.o \
    zlagge.o zlaghe.o zlagsy.o zlakf2.o zlarge.o zlaror.o zlarot.o \
    zlatm1.o zlarnd.o zlatm2.o zlatm3.o zlatm5.o zlatm6.o zlahilb.o
+endif
 
 .PHONY: all
+.NOTPARALLEL
 all: $(TMGLIB)
 
 ALLOBJ = $(SMATGEN) $(CMATGEN) $(SCATGEN) $(DMATGEN) $(ZMATGEN) \
@@ -107,9 +120,17 @@ cleanlib:
 	rm -f $(TMGLIB)
 
 ifneq ($(C_LAPACK), 1)
+ifeq ($(filter $(BUILD_SINGLE) $(BUILD_COMPLEX),1),)
 slaran.o: slaran.f ; $(FC) $(FFLAGS_NOOPT) -c -o $@ $<
+endif
+ifeq ($(filter $(BUILD_DOUBLE) $(BUILD_COMPLEX16),1),)
 dlaran.o: dlaran.f ; $(FC) $(FFLAGS_NOOPT) -c -o $@ $<
+endif
 else
+ifeq ($(filter $(BUILD_SINGLE) $(BUILD_COMPLEX),1),)
 slaran.o: slaran.c ; $(CC) $(CFLAGS) -O0 -c -o $@ $<
+endif
+ifeq ($(filter $(BUILD_DOUBLE) $(BUILD_COMPLEX16),1),)
 dlaran.o: dlaran.c ; $(CC) $(CFLAGS) -O0 -c -o $@ $<
+endif
 endif


### PR DESCRIPTION
(these changes were accidentally overwritten by the testsuite update to Reference-LAPACK 3.10.1)
fixes #3729