### PR TITLE
cmake: Allow specifying optimization level in COMMON_OPT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,41 @@ if(MSVC AND MSVC_STATIC_CRT)
   endforeach()
 endif()
 
+# Set default optimization level
+if (NOT MSVC)
+  # Check if user specified optimization level in COMMON_OPT flags.
+  string(REGEX MATCH "-O[0-9]|-Ofast|-Og|-Os" OPENBLAS_COMMON_OPT_OFLAGS
+         "${COMMON_OPT} ${CCOMMON_OPT} ${FCOMMON_OPT}")
+
+  string(TOUPPER "${CMAKE_BUILD_TYPE}" CMAKE_BUILD_TYPE)
+  if (NOT "${OPENBLAS_COMMON_OPT_OFLAGS}" STREQUAL "")
+    # Filter out optimization level from cmake's default flags.
+    # They would override the optimization level set in COMMON_OPTs.
+    set(CompilerLangs
+        C
+        CXX
+        Fortran
+        ASM
+        )
+    foreach(CompilerLang ${CompilerLangs})
+      string(REGEX REPLACE "-O[0-9]|-Ofast|-Og|-Os" ""
+             CMAKE_${CompilerLang}_FLAGS_${CMAKE_BUILD_TYPE}
+             "${CMAKE_${CompilerLang}_FLAGS_${CMAKE_BUILD_TYPE}}")
+    endforeach()
+  endif ()
+  # Prepend default optimization level to COMMON_OPTs.
+  # These flags might be overridden by cmake's default flags.
+  if ("${CMAKE_BUILD_TYPE}" STREQUAL "DEBUG")
+    set(COMMON_OPT "-Og ${COMMON_OPT}")
+    set(CCOMMON_OPT "-Og ${CCOMMON_OPT}")
+    set(FCOMMON_OPT "-Og ${FCOMMON_OPT}")
+  else ()
+    set(COMMON_OPT "-O2 ${COMMON_OPT}")
+    set(CCOMMON_OPT "-O2 ${CCOMMON_OPT}")
+    set(FCOMMON_OPT "-O2 ${FCOMMON_OPT}")
+  endif ()
+endif ()
+
 message(WARNING "CMake support is experimental. It does not yet support all build options and may not produce the same Makefiles that OpenBLAS ships with.")
 
 include("${PROJECT_SOURCE_DIR}/cmake/utils.cmake")


### PR DESCRIPTION
When building with `make` a default optimization level of `-O2` is used.
See:
https://github.com/xianyi/OpenBLAS/blob/00534523ad999d89945d23b7df0eafc69c31f1b3/Makefile.system#L1551-L1557

By default, `cmake` uses `-O3` for `Release` builds currently:
https://github.com/Kitware/CMake/blob/v3.24.1/Modules/Compiler/GNU.cmake#L59

This means binaries are built with different optimization levels depending on whether `make` or `cmake` is used.

Additionally, it is currently not possible to override the optimization level with, e.g., `-DCOMMON_OPT=-O2` because it appears before the `CMAKE_${Language}_FLAGS_RELEASE` flags (which effectively overrides the flag in `COMMON_OPT`).

See also: #3740

The proposed change sets the default compiler optimization level that is used with `cmake` to `-O2` (i.e., the same that is used by `make`).
Additionally, it allows overriding the compiler optimization level with flags in `COMMON_OPT`, `CCOMMON_OPT`, and `FCOMMON_OPT`.