### PR TITLE
add target for mips xbuild

### DIFF
--- a/.github/workflows/dynamic_arch.yml
+++ b/.github/workflows/dynamic_arch.yml
@@ -267,7 +267,7 @@ jobs:
         include:
           - target: mips64el
             triple: mips64el-linux-gnuabi64
-            opts: DYNAMIC_ARCH=1
+            opts: DYNAMIC_ARCH=1 TARGET=GENERIC
           - target: riscv64
             triple: riscv64-linux-gnu
             opts: TARGET=RISCV64_GENERIC


### PR DESCRIPTION
fixes spurious errors when the job happened to run on AVX512 hardware and cpu autodetection triggered the x86 SGEMM_DIRECT branch