### PR TITLE
Add `OPENBLAS_DEFAULT_NUM_THREADS`

### DIFF
--- a/driver/others/init.c
+++ b/driver/others/init.c
@@ -823,6 +823,8 @@ void gotoblas_affinity_init(void) {
 
   if (numprocs == 0) numprocs = readenv_atoi("OMP_NUM_THREADS");
 
+  if (numprocs == 0) numprocs = readenv_atoi("OPENBLAS_DEFAULT_NUM_THREADS");
+
   numnodes = 1;
 
   if (numprocs == 1) {

--- a/driver/others/openblas_env.c
+++ b/driver/others/openblas_env.c
@@ -67,9 +67,15 @@ void openblas_read_env() {
   openblas_env_thread_timeout=(unsigned int)ret;
 
   ret=0;
-  if (readenv(p,"OPENBLAS_NUM_THREADS")) ret = atoi(p);
+  if (readenv(p,"OPENBLAS_DEFAULT_NUM_THREADS")) ret = atoi(p);
   if(ret<0) ret=0;
   openblas_env_openblas_num_threads=ret;
+
+  ret=0;
+  if (readenv(p,"OPENBLAS_NUM_THREADS")) ret = atoi(p);
+  if(ret<0) ret=0;
+  if(ret != 0 || openblas_env_openblas_num_threads == 0)
+    openblas_env_openblas_num_threads=ret;
 
   ret=0;
   if (readenv(p,"GOTO_NUM_THREADS")) ret = atoi(p);


### PR DESCRIPTION
This allows Julia to set a default number of threads (usually `1`) to be used when no other thread counts are specified [0], to short-circuit the default OpenBLAS thread initialization routine that spins up a different number of threads than Julia would otherwise choose.

The reason to add a new environment variable is that we want to be able to configure OpenBLAS to avoid performing its initial memory allocation/thread startup, as that can consume significant amounts of memory, but we still want to be sensitive to legacy codebases that set things like `OMP_NUM_THREADS` or `GOTOBLAS_NUM_THREADS`.  Creating a new environment variable that is openblas-specific and is not already publicly used to control the overall number of threads of programs like Julia seems to be the best way forward.

[0] https://github.com/JuliaLang/julia/pull/46844