### PR TITLE
Set SWITCH_RATIO for Arm(R) Neoverse(TM) V1 CPUs

### DIFF
--- a/param.h
+++ b/param.h
@@ -3367,6 +3367,8 @@ is a big desktop or server with abundant cache rather than a phone or embedded d
 
 #elif defined(NEOVERSEV1)
 
+#define SWITCH_RATIO  16
+
 #define SGEMM_DEFAULT_UNROLL_M  16
 #define SGEMM_DEFAULT_UNROLL_N  4
 


### PR DESCRIPTION
From testing this yields better results than the default of `2`.