### PR TITLE
Remove SVE from Arm(R) Neoverse(TM) N1 CPU in Makefile

### DIFF
--- a/Makefile.arm64
+++ b/Makefile.arm64
@@ -70,12 +70,12 @@ endif
 ifeq ($(CORE), NEOVERSEN1)
 ifeq (1, $(filter 1,$(GCCVERSIONGTEQ7) $(ISCLANG)))
 ifeq ($(GCCVERSIONGTEQ9), 1)
-CCOMMON_OPT += -march=armv8.2-a+sve -mtune=neoverse-n1
+CCOMMON_OPT += -march=armv8.2-a -mtune=neoverse-n1
 ifneq ($(F_COMPILER), NAG)
 FCOMMON_OPT += -march=armv8.2-a -mtune=neoverse-n1
 endif
 else
-CCOMMON_OPT += -march=armv8.2-a+sve -mtune=cortex-a72
+CCOMMON_OPT += -march=armv8.2-a -mtune=cortex-a72
 ifneq ($(F_COMPILER), NAG)
 FCOMMON_OPT += -march=armv8.2-a -mtune=cortex-a72
 endif


### PR DESCRIPTION
I incorrectly added `+sve` to the Neoverse(TM) N1 CPU GCC parameters, which doesn't support SVE - this results in failed builds when using a compiler that doesn't support `-mtune=neoverse-n1` which appears to hide the mistake.