### PR TITLE
Patch for Intel Fortran compiler

### DIFF
--- a/f_check
+++ b/f_check
@@ -98,7 +98,7 @@ else
                             vendor=FLANG
                             openmp='-fopenmp'
                             ;;
-                        *ifx*)
+                        *ifort*|*ifx*)
                             vendor=INTEL
                             openmp='-fopenmp'
                             ;;

--- a/f_check.pl
+++ b/f_check.pl
@@ -90,7 +90,7 @@ if ($compiler eq "") {
 		if ($compiler =~ /flang/) {
 		    $vendor = FLANG;
 		    $openmp = "-fopenmp";
-	    } elsif ($compiler =~ /ifx/) {
+	    } elsif ($compiler =~ /ifort/ || $compiler =~ /ifx/) {
 		    $vendor = INTEL;
 		    $openmp = "-fopenmp";
 	    } elsif ($compiler =~ /pgf/ || $compiler =~ /nvf/) {


### PR DESCRIPTION
This PR patches the f_check scripts to detect the ifort compiler. With out this, the value of F_COMPILER is G77 which causes the link phase to use icc rather than ifort, resulting in missing libifcore.