### PR TITLE
Don't gate reading of Makefile.conf

### DIFF
--- a/Makefile.system
+++ b/Makefile.system
@@ -283,6 +283,7 @@ GETARCH_FLAGS += -DHAVE_GAS=$(HAVE_GAS)
 
 # Generating Makefile.conf and config.h
 DUMMY := $(shell $(MAKE) -C $(TOPDIR) -f Makefile.prebuild CC="$(CC)" FC="$(FC)" HOSTCC="$(HOSTCC)" HOST_CFLAGS="$(GETARCH_FLAGS)" CFLAGS="$(CFLAGS)" BINARY=$(BINARY) USE_OPENMP=$(USE_OPENMP) DYNAMIC_ARCH=$(DYNAMIC_ARCH) TARGET_CORE=$(TARGET_CORE) ONLY_CBLAS=$(ONLY_CBLAS) TARGET=$(TARGET) all)
+endif
 
 ifndef TARGET_CORE
 include $(TOPDIR)/Makefile.conf
@@ -304,8 +305,6 @@ HAVE_AVX=
 HAVE_AVX2=
 HAVE_FMA3=
 include $(TOPDIR)/Makefile_kernel.conf
-endif
-
 endif
 
 ifndef NUM_PARALLEL

--- a/Makefile.system
+++ b/Makefile.system
@@ -1742,6 +1742,9 @@ export HAVE_NEON
 ifndef NO_MSA
   export HAVE_MSA
   export MSA_FLAGS
+else
+HAVE_MSA =
+MSA_FLAGS =
 endif
 export KERNELDIR
 export FUNCTION_PROFILE


### PR DESCRIPTION
This was gated behind GOTOBLAS_MAKEFILE, which looks like it's intended to stop the much more expensive run of `Makefile.prebuild` rather than prevent reading the configuration. Moving this `endif` means that things such as `dynamic_<X>.c` correctly get the architecture flags.

You can then end up in a situation where the HAVE_x/NO_x flags are used for compiling param.h but not
Makefile.conf which leads to further inconsistencies. This uses the existing logic to parse ARCHCONFIG and ensures it ends up in the eventual Makefile.conf whenever FORCE is enabled.