### PR TITLE
Update nightly-Homebrew-build.yml

### DIFF
--- a/.github/workflows/nightly-Homebrew-build.yml
+++ b/.github/workflows/nightly-Homebrew-build.yml
@@ -33,6 +33,7 @@ jobs:
       HOMEBREW_NO_BOTTLE_SOURCE_FALLBACK: "ON"
       HOMEBREW_NO_INSTALL_CLEANUP: "ON"
       HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: "ON"
+      HOMEBREW_NO_INSTALL_FROM_API: "ON"      
 
     steps:
       - name: Random delay for cron job


### PR DESCRIPTION
add NO_INSTALL_FROM_API to re-enable --HEAD