### PR TITLE
fix shared and tests prereqs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ endif
 	@echo "To install the library, you can run \"make PREFIX=/path/to/your/installation install\"."
 	@echo
 
-shared :
+shared : libs netlib $(RELA)
 ifneq ($(NO_SHARED), 1)
 ifeq ($(OSNAME), $(filter $(OSNAME),Linux SunOS Android Haiku))
 	@$(MAKE) -C exports so
@@ -134,7 +134,7 @@ ifeq ($(OSNAME), CYGWIN_NT)
 endif
 endif
 
-tests :
+tests : libs netlib $(RELA) shared
 ifeq ($(NOFORTRAN), $(filter 0,$(NOFORTRAN)))
 	touch $(LIBNAME)
 ifndef NO_FBLAS


### PR DESCRIPTION
Closes #3899

Generally `make shared` did not work.

In the past `make -j... libs netlib shared` worked probably by accident, my working
hypothesis is GNU make didn't parallelize over command line targets before v4.4.
In v4.4 it is consistently an error.

Maybe it's worth using GNU make 4.4 in CI with the `--shuffle=random` feature
enabled, in case you want to catch make races in the future; it dumps the random
seed on build errors for reproducibility (although parallel builds make it not
entirely reproducible)