### PR TITLE
Add missing RISC-V architecture in arch.cmake

### DIFF
--- a/cmake/arch.cmake
+++ b/cmake/arch.cmake
@@ -135,3 +135,8 @@ if (ARM64)
   set(BINARY_DEFINED 1)
 endif ()
 
+if (${ARCH} STREQUAL "riscv64")
+  set(NO_BINARY_MODE 1)
+  set(BINARY_DEFINED 1)
+endif ()
+


### PR DESCRIPTION
RISC-V support exists in Makefile.system but is missing in arch.cmake. This patch adds riscv64 platform support to cmake building system just like https://github.com/xianyi/OpenBLAS/blob/039e27545f93fd54f9a04113f6883ee47a690004/Makefile.system#L830-L832 