### PR TITLE
Avoid overflow from division in GETF2 potentially causing NaN 

### DIFF
--- a/lapack/getf2/getf2_k.c
+++ b/lapack/getf2/getf2_k.c
@@ -99,7 +99,8 @@ blasint CNAME(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, FLOAT *sa,
       jp--;
       temp1 = *(b + jp);
 
-      if (temp1 != ZERO) {
+      //if (temp1 != ZERO) {
+	if (fabs(temp1) > 1.e-305) {    
 	temp1 = dp1 / temp1;
 
 	if (jp != j) {

--- a/lapack/getf2/zgetf2_k.c
+++ b/lapack/getf2/zgetf2_k.c
@@ -105,8 +105,9 @@ blasint CNAME(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, FLOAT *sa,
       temp1 = *(b + jp * 2 + 0);
       temp2 = *(b + jp * 2 + 1);
 
-      if ((temp1 != ZERO) || (temp2 != ZERO)) {
-
+  //    if ((temp1 != ZERO) || (temp2 != ZERO)) {
+	if ((fabs(temp1) > 1.e-305) || (fabs(temp2) > 1.e-305)) {
+		
 	if (jp != j) {
 	  SWAP_K(j + 1, 0, 0, ZERO, ZERO, a + j * 2, lda,
 		 a + jp * 2, lda, NULL, 0);


### PR DESCRIPTION
for fault seen in https://github.com/numpy/numpy/issues/22025