### PR TITLE
dot.c early bail fix

### DIFF
--- a/kernel/generic/dot.c
+++ b/kernel/generic/dot.c
@@ -43,7 +43,7 @@ FLOAT CNAME(BLASLONG n, FLOAT *x, BLASLONG inc_x, FLOAT *y, BLASLONG inc_y)
 	FLOAT  dot = 0.0 ;
 #endif
 
-	if ( n < 0 )  return(dot);
+	if ( n < 1 )  return(dot);
 
 	if ( (inc_x == 1) && (inc_y == 1) )
 	{

--- a/kernel/riscv64/dot.c
+++ b/kernel/riscv64/dot.c
@@ -46,7 +46,7 @@ FLOAT CNAME(BLASLONG n, FLOAT *x, BLASLONG inc_x, FLOAT *y, BLASLONG inc_y)
 	BLASLONG ix=0,iy=0;
 	double dot = 0.0 ;
 
-	if ( n < 0 )  return(dot);
+	if ( n < 1 )  return(dot);
 
 	while(i < n)
 	{


### PR DESCRIPTION
The dot kernel should return 0 for N=0. An existing early bail checks for N<0 and returns 0 in this case. Adjust this to N<1 to simplify maintenance: with this change we don't have to reason through subsequent code to confirm it handles that corner case correctly, and future platform ports have a slightly more pleasant baseline to begin from.