### PR TITLE
Re-enable overriding the LAPACK SYMV,SYR,SPMV and SPR implementations

### DIFF
--- a/interface/Makefile
+++ b/interface/Makefile
@@ -92,7 +92,7 @@ CBLAS2OBJS    = \
 		cgemv.$(SUFFIX) cgeru.$(SUFFIX) cgerc.$(SUFFIX) \
 		ctrsv.$(SUFFIX) ctrmv.$(SUFFIX) \
 		csyr2.$(SUFFIX) cgbmv.$(SUFFIX) \
-		csbmv.$(SUFFIX) cspmv.$(SUFFIX) \ 
+		csbmv.$(SUFFIX) cspmv.$(SUFFIX) \
 		cspr.$(SUFFIX)  cspr2.$(SUFFIX) \
 		csymv.$(SUFFIX) csyr.$(SUFFIX)  \
 		ctbsv.$(SUFFIX) ctbmv.$(SUFFIX) \

--- a/interface/Makefile
+++ b/interface/Makefile
@@ -92,8 +92,9 @@ CBLAS2OBJS    = \
 		cgemv.$(SUFFIX) cgeru.$(SUFFIX) cgerc.$(SUFFIX) \
 		ctrsv.$(SUFFIX) ctrmv.$(SUFFIX) \
 		csyr2.$(SUFFIX) cgbmv.$(SUFFIX) \
-		csbmv.$(SUFFIX) \
-		cspr2.$(SUFFIX) \
+		csbmv.$(SUFFIX) cspmv.$(SUFFIX) \ 
+		cspr.$(SUFFIX)  cspr2.$(SUFFIX) \
+		csymv.$(SUFFIX) csyr.$(SUFFIX)  \
 		ctbsv.$(SUFFIX) ctbmv.$(SUFFIX) \
 		ctpsv.$(SUFFIX) ctpmv.$(SUFFIX) \
 		chemv.$(SUFFIX) chbmv.$(SUFFIX) \
@@ -121,8 +122,9 @@ ZBLAS2OBJS    = \
 		zgemv.$(SUFFIX) zgeru.$(SUFFIX) zgerc.$(SUFFIX) \
 		ztrsv.$(SUFFIX) ztrmv.$(SUFFIX) \
 		zsyr2.$(SUFFIX) zgbmv.$(SUFFIX) \
-		zsbmv.$(SUFFIX) \
-		zspr2.$(SUFFIX) \
+		zsbmv.$(SUFFIX) zspmv.$(SUFFIX) \
+		zspr.$(SUFFIX)  zspr2.$(SUFFIX) \
+		zsymv.$(SUFFIX) zsyr.$(SUFFIX)  \
 		ztbsv.$(SUFFIX) ztbmv.$(SUFFIX) \
 		ztpsv.$(SUFFIX) ztpmv.$(SUFFIX) \
 		zhemv.$(SUFFIX) zhbmv.$(SUFFIX) \

--- a/lapack-netlib/SRC/Makefile
+++ b/lapack-netlib/SRC/Makefile
@@ -572,22 +572,26 @@ ALL_AUX_OBJS = xerbla.o ../INSTALL/lsame.o
 SLAPACKOBJS     = \
         sgetrf.o sgetrs.o spotrf.o sgetf2.o \
         spotf2.o slaswp.o sgesv.o slauu2.o  \
-        slauum.o strti2.o strtri.o strtrs.o
+        slauum.o strti2.o strtri.o strtrs.o \
+	ssymv.o ssyr.o sspmv.o sspr.o
 
 DLAPACKOBJS     = \
         dgetrf.o dgetrs.o dpotrf.o dgetf2.o \
         dpotf2.o dlaswp.o dgesv.o dlauu2.o  \
-        dlauum.o dtrti2.o dtrtri.o dtrtrs.o
+        dlauum.o dtrti2.o dtrtri.o dtrtrs.o \
+	dsymv.o dsyr.o dspmv.o dspr.o
 
 CLAPACKOBJS     = \
         cgetrf.o cgetrs.o cpotrf.o cgetf2.o \
         cpotf2.o claswp.o cgesv.o clauu2.o \
-        clauum.o ctrti2.o ctrtri.o ctrtrs.o 
+        clauum.o ctrti2.o ctrtri.o ctrtrs.o \
+	csymv.o csyr.o cspmv.o cspr.o
 
 ZLAPACKOBJS     = \
         zgetrf.o zgetrs.o zpotrf.o zgetf2.o \
         zpotf2.o zlaswp.o zgesv.o  zlauu2.o \
-        zlauum.o ztrti2.o ztrtri.o ztrtrs.o
+        zlauum.o ztrti2.o ztrtri.o ztrtrs.o \
+	zsymv.o zsyr.o zspmv.o zspr.o
 
 ALLAUX = $(filter-out $(ALL_AUX_OBJS),$(ALLAUX_O))
 SLASRC = $(filter-out $(SLAPACKOBJS),$(SLASRC_O))


### PR DESCRIPTION
..in gmake builds - these were removed in #1046 with no explanation other than that Reference-Lapack 3.7.0 had adopted these former extensions. Still a cmake build would keep using the OpenBLAS versions of these functions, which are likely to offer performance advantages over the reference implementation.
fixes the last remaining defect from  #3856