### PR TITLE
Do not change the global OMP_NUM_THREADS

### DIFF
--- a/driver/others/blas_server_omp.c
+++ b/driver/others/blas_server_omp.c
@@ -112,8 +112,6 @@ void goto_set_num_threads(int num_threads) {
 
   blas_cpu_number  = num_threads;
 
-  omp_set_num_threads(blas_cpu_number);
-
   adjust_thread_buffers();
 #if defined(ARCH_MIPS64)
   //set parameters for different number of threads.


### PR DESCRIPTION
... when the number of OpenMP threads (or cores) exceeds the maximum thread count OpenBLAS was built for - subsequent internal queries receive the reduced number even without it, and a library has no business changing parameters for the program that called it.
fixes #3940