### PR TITLE
Fix detection of Cray CCE after recent detection changes for gfortran on Cray

### DIFF
--- a/f_check
+++ b/f_check
@@ -82,6 +82,10 @@ else
                 vendor=FUJITSU
                 openmp='-Kopenmp'
                 ;;
+	    *Hewlett*)
+		vendor=CRAY
+		openmp='-fopenmp'
+		;;		
             *GNU*|*GCC*)
 
                 v="${data#*GCC: *\) }"


### PR DESCRIPTION
Having both "GNU" and "Cray" identifiers in the assembly output  was no causing the opposite misdetection to what #3778 tried to fix. Also version 15 of the Cray compiler apparently does not produce an .ident line at all anymore, so  look for the name "Hewlett Packard Enterprise" in a note section as well
fixes #3954