### PR TITLE
Add ARMv6 support to cmake/prebuild.cmake

### DIFF
--- a/cmake/prebuild.cmake
+++ b/cmake/prebuild.cmake
@@ -823,6 +823,24 @@ if (DEFINED CORE AND CMAKE_CROSSCOMPILING AND NOT (${HOST_OS} STREQUAL "WINDOWSS
       set(CGEMM3M_UNROLL_N 4)
       set(ZGEMM3M_UNROLL_M 4)
       set(ZGEMM3M_UNROLL_N 4)
+  elseif ("${TCORE}" STREQUAL "ARMV6")
+    file(APPEND ${TARGET_CONF_TEMP}
+      "#define L1_DATA_SIZE\t65536\n"
+      "#define L1_DATA_LINESIZE\t32\n"
+      "#define L2_SIZE\t512488\n"
+      "#define L2_LINESIZE\t32\n"
+      "#define DTB_DEFAULT_ENTRIES\t64\n"
+      "#define DTB_SIZE\t4096\n"
+      "#define L2_ASSOCIATIVE\t4\n"
+      "#define HAVE_VFP\n")
+    set(SGEMM_UNROLL_M 4)
+    set(SGEMM_UNROLL_N 2)
+    set(DGEMM_UNROLL_M 4)
+    set(DGEMM_UNROLL_N 2)
+    set(CGEMM_UNROLL_M 2)
+    set(CGEMM_UNROLL_N 2)
+    set(ZGEMM_UNROLL_M 2)
+    set(ZGEMM_UNROLL_N 2)
   elseif ("${TCORE}" STREQUAL "ARMV7")
     file(APPEND ${TARGET_CONF_TEMP}
       "#define L1_DATA_SIZE\t65536\n"


### PR DESCRIPTION
This pull request adds the ARMV6 target to `cmake/prebuild.cmake` based on `cpuid_arm.c` and `param.h`.

Without this fix, it was not possible to (cross-)compile for ARMv6 using CMake:

```sh
tar xzf download/OpenBLAS-0.3.21.tar.gz -C build/armv6-rpi-linux-gnueabihf
cd build/armv6-rpi-linux-gnueabihf/OpenBLAS-0.3.21
cmake -S. -Bbuild \
	-G "Ninja Multi-Config" \
	-D CMAKE_STAGING_PREFIX=/home/runner/work/cross-python/cross-python/staging/armv6-rpi-linux-gnueabihf/openblas-0.3.21/usr/local \
	-D CMAKE_TOOLCHAIN_FILE=/home/runner/work/cross-python/cross-python/staging/armv6-rpi-linux-gnueabihf/cmake/armv6-rpi-linux-gnueabihf.toolchain.cmake \
	-D Python3_EXECUTABLE=/home/runner/work/cross-python/cross-python/build-python-3.11/usr/local/bin/python3 \
	-D CMAKE_C_COMPILER_LAUNCHER=ccache \
	-D CMAKE_CXX_COMPILER_LAUNCHER=ccache \
	-D BUILD_SHARED_LIBS=Off \
	-D BUILD_STATIC_LIBS=On \
	-D CMAKE_POSITION_INDEPENDENT_CODE=On \
	-D TARGET="ARMV6"
cmake --build build --config Release -j2
```
```c
FAILED: interface/CMakeFiles/interface.dir/Release/CMakeFiles/ctrmv.c.o 
ccache /home/runner/work/cross-python/cross-python/staging/armv6-rpi-linux-gnueabihf/cmake/../x-tools/armv6-rpi-linux-gnueabihf/bin/armv6-rpi-linux-gnueabihf-gcc --sysroot=/home/runner/work/cross-python/cross-python/staging/armv6-rpi-linux-gnueabihf/cmake/../x-tools/armv6-rpi-linux-gnueabihf/armv6-rpi-linux-gnueabihf/sysroot -DCMAKE_INTDIR=\"Release\" -I/home/runner/work/cross-python/cross-python/build/armv6-rpi-linux-gnueabihf/OpenBLAS-0.3.21 -I/home/runner/work/cross-python/cross-python/build/armv6-rpi-linux-gnueabihf/OpenBLAS-0.3.21/build -mcpu=arm1176jzf-s -mfpu=vfp -mfloat-abi=hard  -DHAVE_C11 -Wall -fPIC -DNO_AVX -DMAX_CPU_NUMBER=0 -DMAX_PARALLEL_NUMBER=1 -DMAX_STACK_ALLOC=2048 -DNO_AFFINITY -DVERSION="\"0.3.21\"" -DBUILD_SINGLE -DBUILD_DOUBLE -DBUILD_COMPLEX -DBUILD_COMPLEX16 -O3 -DNDEBUG -fPIC -MD -MT interface/CMakeFiles/interface.dir/Release/CMakeFiles/ctrmv.c.o -MF interface/CMakeFiles/interface.dir/Release/CMakeFiles/ctrmv.c.o.d -o interface/CMakeFiles/interface.dir/Release/CMakeFiles/ctrmv.c.o -c /home/runner/work/cross-python/cross-python/build/armv6-rpi-linux-gnueabihf/OpenBLAS-0.3.21/build/interface/CMakeFiles/ctrmv.c
In file included from /home/runner/work/cross-python/cross-python/build/armv6-rpi-linux-gnueabihf/OpenBLAS-0.3.21/common.h:586,
                 from /home/runner/work/cross-python/cross-python/build/armv6-rpi-linux-gnueabihf/OpenBLAS-0.3.21/interface/ztrmv.c:41,
                 from /home/runner/work/cross-python/cross-python/build/armv6-rpi-linux-gnueabihf/OpenBLAS-0.3.21/build/interface/CMakeFiles/ctrmv.c:8:
/home/runner/work/cross-python/cross-python/build/armv6-rpi-linux-gnueabihf/OpenBLAS-0.3.21/interface/ztrmv.c: In function 'ctrmv_':
/home/runner/work/cross-python/cross-python/build/armv6-rpi-linux-gnueabihf/OpenBLAS-0.3.21/common_param.h:1309:22: error: 'DTB_DEFAULT_ENTRIES' undeclared (first use in this function)
 1309 | #define DTB_ENTRIES  DTB_DEFAULT_ENTRIES
      |                      ^~~~~~~~~~~~~~~~~~~
/home/runner/work/cross-python/cross-python/build/armv6-rpi-linux-gnueabihf/OpenBLAS-0.3.21/interface/ztrmv.c:248:30: note: in expansion of macro 'DTB_ENTRIES'
  248 |     buffer_size = ((n - 1) / DTB_ENTRIES) * 2 * DTB_ENTRIES + 32 / sizeof(FLOAT);
      |                              ^~~~~~~~~~~
/home/runner/work/cross-python/cross-python/build/armv6-rpi-linux-gnueabihf/OpenBLAS-0.3.21/common_param.h:1309:22: note: each undeclared identifier is reported only once for each function it appears in
 1309 | #define DTB_ENTRIES  DTB_DEFAULT_ENTRIES
      |                      ^~~~~~~~~~~~~~~~~~~
/home/runner/work/cross-python/cross-python/build/armv6-rpi-linux-gnueabihf/OpenBLAS-0.3.21/interface/ztrmv.c:248:30: note: in expansion of macro 'DTB_ENTRIES'
  248 |     buffer_size = ((n - 1) / DTB_ENTRIES) * 2 * DTB_ENTRIES + 32 / sizeof(FLOAT);
      |                              ^~~~~~~~~~~
ninja: build stopped: subcommand failed.
```
