### PR TITLE
remove unqualified ifndef's for NO_LAPACK(E)

### DIFF
--- a/Makefile.install
+++ b/Makefile.install
@@ -77,7 +77,7 @@ endif
 endif
 
 ifneq ($(OSNAME), AIX)
-ifndef NO_LAPACKE
+ifneq ($(NO_LAPACKE), 1)
 	@echo Copying LAPACKE header files to $(DESTDIR)$(OPENBLAS_INCLUDE_DIR)
 	@-install -m644 $(NETLIB_LAPACK_DIR)/LAPACKE/include/lapack.h "$(DESTDIR)$(OPENBLAS_INCLUDE_DIR)/lapack.h"
 	@-install -m644 $(NETLIB_LAPACK_DIR)/LAPACKE/include/lapacke.h "$(DESTDIR)$(OPENBLAS_INCLUDE_DIR)/lapacke.h"
@@ -127,7 +127,7 @@ endif
 
 else
 #install on AIX has different options syntax
-ifndef NO_LAPACKE
+ifneq ($(NO_LAPACKE), 1)
 	@echo Copying LAPACKE header files to $(DESTDIR)$(OPENBLAS_INCLUDE_DIR)
 	@-installbsd -c -m 644 $(NETLIB_LAPACK_DIR)/LAPACKE/include/lapack.h "$(DESTDIR)$(OPENBLAS_INCLUDE_DIR)/lapack.h"
 	@-installbsd -c -m 644 $(NETLIB_LAPACK_DIR)/LAPACKE/include/lapacke.h "$(DESTDIR)$(OPENBLAS_INCLUDE_DIR)/lapacke.h"

--- a/driver/level2/Makefile
+++ b/driver/level2/Makefile
@@ -92,7 +92,7 @@ CBLASOBJS += \
 	ctrsv_RUU.$(SUFFIX) ctrsv_RUN.$(SUFFIX) ctrsv_RLU.$(SUFFIX) ctrsv_RLN.$(SUFFIX) \
 	ctrsv_CUU.$(SUFFIX) ctrsv_CUN.$(SUFFIX) ctrsv_CLU.$(SUFFIX) ctrsv_CLN.$(SUFFIX)
 
-ifndef NO_LAPACK
+ifneq ($(NO_LAPACK), 1)
 CBLASOBJS += \
 	cspmv_U.$(SUFFIX) cspmv_L.$(SUFFIX) \
 	cspr_U.$(SUFFIX)  cspr_L.$(SUFFIX)  \

--- a/interface/Makefile
+++ b/interface/Makefile
@@ -1021,7 +1021,7 @@ dsymv.$(SUFFIX) dsymv.$(PSUFFIX) : symv.c
 qsymv.$(SUFFIX) qsymv.$(PSUFFIX) : symv.c
 	$(CC) -c $(CFLAGS) $< -o $(@F)
 
-ifndef NO_LAPACK
+ifneq ($(NO_LAPACK), 1)
 csymv.$(SUFFIX) csymv.$(PSUFFIX) : zsymv.c
 	$(CC) -c $(CFLAGS) $< -o $(@F)
 
@@ -1041,7 +1041,7 @@ dsyr.$(SUFFIX) dsyr.$(PSUFFIX) : syr.c
 qsyr.$(SUFFIX) qsyr.$(PSUFFIX) : syr.c
 	$(CC) -c $(CFLAGS) $< -o $(@F)
 
-ifndef NO_LAPACK
+ifneq ($(NO_LAPACK), 1)
 csyr.$(SUFFIX) csyr.$(PSUFFIX) : zsyr.c
 	$(CC) -c $(CFLAGS) $< -o $(@F)
 
@@ -1115,7 +1115,7 @@ dspmv.$(SUFFIX) dspmv.$(PSUFFIX) : spmv.c
 qspmv.$(SUFFIX) qspmv.$(PSUFFIX) : spmv.c
 	$(CC) -c $(CFLAGS) $< -o $(@F)
 
-ifndef NO_LAPACK
+ifneq ($(NO_LAPACK), 1)
 cspmv.$(SUFFIX) cspmv.$(PSUFFIX) : zspmv.c
 	$(CC) -c $(CFLAGS) $< -o $(@F)
 
@@ -1135,7 +1135,7 @@ dspr.$(SUFFIX) dspr.$(PSUFFIX) : spr.c
 qspr.$(SUFFIX) qspr.$(PSUFFIX) : spr.c
 	$(CC) -c $(CFLAGS) $< -o $(@F)
 
-ifndef NO_LAPACK
+ifneq ($(NO_LAPACK), 1)
 cspr.$(SUFFIX) cspr.$(PSUFFIX) : zspr.c
 	$(CC) -c $(CFLAGS) $< -o $(@F)
 


### PR DESCRIPTION
Came up in https://github.com/conda-forge/openblas-feedstock/pull/150. I did `git grep "ifndef NO_LAPACK"` and found/replaced these.

The ones in `exports/Makefile` are actually correct, and I didn't touch `kernel/setparam-ref.c` since it's a c-file, not a makefile.