### PR TITLE
Export `ssyconvf` symbol

### DIFF
--- a/exports/gensymbol
+++ b/exports/gensymbol
@@ -716,6 +716,7 @@ lapackobjs2z="$lapackobjs2z
 # functions added for lapack-3.7.0
 lapackobjs2s="$lapackobjs2s
     slarfy
+    ssyconvf
     strevc3
     sgelqt
     sgelqt3


### PR DESCRIPTION
This was apparently missed in commit a836fe8ec when adding the LAPACK 3.7.0 symbols. We noticed when adding wrappers for 3.7.0 routines in SciPy. For more details, see https://github.com/rgommers/scipy/issues/143