### PR TITLE
Fix instabilities in CGEMM/CTRMM/DNRM2 on Apple M1/M2 under OSX

### DIFF
--- a/cpuid_arm64.c
+++ b/cpuid_arm64.c
@@ -267,9 +267,9 @@ int detect(void)
 	}
 #else
 #ifdef __APPLE__
-	sysctlbyname("hw.cpufamily",&value,&length,NULL,0);
-	if (value ==131287967|| value == 458787763 ) return CPU_VORTEX; //A12/M1
-	if (value == 3660830781) return CPU_VORTEX; //A15/M2
+	sysctlbyname("hw.cpufamily",&value64,&length64,NULL,0);
+	if (value64 ==131287967|| value64 == 458787763 ) return CPU_VORTEX; //A12/M1
+	if (value64 == 3660830781) return CPU_VORTEX; //A15/M2
 #endif
 	return CPU_ARMV8;	
 #endif

--- a/kernel/arm64/cgemm_kernel_8x4.S
+++ b/kernel/arm64/cgemm_kernel_8x4.S
@@ -49,7 +49,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define pCRow3		x15
 #define pA		x16
 #define alphaR		w17
-#define alphaI		w18
+#define alphaI		w19
 
 #define alpha0_R	s10
 #define alphaV0_R	v10.s[0]

--- a/kernel/arm64/cgemm_kernel_8x4_thunderx2t99.S
+++ b/kernel/arm64/cgemm_kernel_8x4_thunderx2t99.S
@@ -49,7 +49,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define pCRow3		x15
 #define pA		x16
 #define alphaR		w17
-#define alphaI		w18
+#define alphaI		w19
 
 #define alpha0_R	s10
 #define alphaV0_R	v10.s[0]

--- a/kernel/arm64/ctrmm_kernel_8x4.S
+++ b/kernel/arm64/ctrmm_kernel_8x4.S
@@ -49,10 +49,10 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define pCRow3		x15
 #define pA		x16
 #define alphaR		w17
-#define alphaI		w18
-#define temp		x19
-#define tempOffset	x20
-#define tempK		x21
+#define alphaI		w19
+#define temp		x20
+#define tempOffset	x21
+#define tempK		x22
 
 #define alpha0_R	s10
 #define alphaV0_R	v10.s[0]

--- a/kernel/arm64/dznrm2_thunderx2t99.c
+++ b/kernel/arm64/dznrm2_thunderx2t99.c
@@ -344,7 +344,6 @@ FLOAT CNAME(BLASLONG n, FLOAT *x, BLASLONG inc_x)
 	FLOAT dummy_alpha[2];
 #endif
 	FLOAT ssq, scale;
-	volatile FLOAT sca;
 
 	if (n <= 0 || inc_x <= 0) return 0.0;
 
@@ -405,7 +404,7 @@ FLOAT CNAME(BLASLONG n, FLOAT *x, BLASLONG inc_x)
 #else
 	nrm2_compute(n, x, inc_x, &ssq, &scale);
 #endif
-	sca = fabs(scale);
+	volatile FLOAT sca = fabs(scale);
 	if (sca < DBL_MIN) return 0.;
 	ssq = sqrt(ssq) * scale;
 

--- a/kernel/arm64/dznrm2_thunderx2t99.c
+++ b/kernel/arm64/dznrm2_thunderx2t99.c
@@ -27,7 +27,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 #include "common.h"
-
+#include <float.h>
 #include <arm_neon.h>
 
 #if defined(SMP)
@@ -344,6 +344,7 @@ FLOAT CNAME(BLASLONG n, FLOAT *x, BLASLONG inc_x)
 	FLOAT dummy_alpha[2];
 #endif
 	FLOAT ssq, scale;
+	volatile FLOAT sca;
 
 	if (n <= 0 || inc_x <= 0) return 0.0;
 
@@ -404,7 +405,8 @@ FLOAT CNAME(BLASLONG n, FLOAT *x, BLASLONG inc_x)
 #else
 	nrm2_compute(n, x, inc_x, &ssq, &scale);
 #endif
-	if (fabs(scale) <1.e-300) return 0.;
+	sca = fabs(scale);
+	if (sca < DBL_MIN) return 0.;
 	ssq = sqrt(ssq) * scale;
 
 	return ssq;

--- a/kernel/arm64/sgemm_kernel_sve_v2x8.S
+++ b/kernel/arm64/sgemm_kernel_sve_v2x8.S
@@ -55,8 +55,8 @@ With this approach, we can reuse sgemm_n|tcopy_sve_v1.c packing functions. */
 #define lanes		x15
 #define pA1	    	x16
 #define pA2	    	x17
-#define alpha		w19
-#define vec_len		x20
+#define alpha		w18
+#define vec_len		x19
 #define vec_lenx2   x20
 
 #define alpha0		s10

--- a/kernel/arm64/sgemm_kernel_sve_v2x8.S
+++ b/kernel/arm64/sgemm_kernel_sve_v2x8.S
@@ -55,8 +55,8 @@ With this approach, we can reuse sgemm_n|tcopy_sve_v1.c packing functions. */
 #define lanes		x15
 #define pA1	    	x16
 #define pA2	    	x17
-#define alpha		w18
-#define vec_len		x19
+#define alpha		w19
+#define vec_len		x20
 #define vec_lenx2   x20
 
 #define alpha0		s10


### PR DESCRIPTION
for #3995 - M2 cpuid was still not matched correctly, the workaround for a corner case in DNRM2 could be optimized out by the compiler, and most importantly several ARM64 assembly kernels were still using (half of) register 18 that is reserved on OSX (as the previous round of fixes had only matched on x18, not w18)