### PR TITLE
Do not build the tests when only the CBLAS interface is selected

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -321,7 +321,7 @@ if (NOT NOFORTRAN)
  if (NOT ONLY_CBLAS)
   # Build test and ctest
   add_subdirectory(test)
- endif 
+ endif() 
   if (BUILD_TESTING)
     add_subdirectory(lapack-netlib/TESTING)
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -311,19 +311,25 @@ endif()
 
 #if (MSVC OR NOT NOFORTRAN)
 if (NOT NO_CBLAS)
+  if (NOT ONLY_CBLAS)
   # Broken without fortran on unix
-  add_subdirectory(utest)
+    add_subdirectory(utest)
+endif()
 endif()
 
 if (NOT NOFORTRAN)
+ if (NOT ONLY_CBLAS)
   # Build test and ctest
   add_subdirectory(test)
+ endif 
   if (BUILD_TESTING)
     add_subdirectory(lapack-netlib/TESTING)
   endif()
 endif()
   if(NOT NO_CBLAS)
+   if (NOT ONLY_CBLAS)
     add_subdirectory(ctest)
+   endif()
   endif()
   if (CPP_THREAD_SAFETY_TEST OR CPP_THREAD_SAFETY_GEMV)
     add_subdirectory(cpp_thread_test)


### PR DESCRIPTION
fixes #4021 and aligns CMAKE build behavior with gmake