### PR TITLE
Drop extraneous escaping in the basename call

### DIFF
--- a/c_check
+++ b/c_check
@@ -35,12 +35,12 @@ if [ "`dirname \"$compiler_name\"`" != '.' ]; then
     cross_suffix="$cross_suffix`dirname \"$compiler_name\"`/"
 fi
 
-bn=`basename "$compiler_name"`
+cn= `echo $compiler_name | sed -e 's/ -.*//'`
+bn=`basename "$cn"`
 
 case "$bn" in
     *-*) if [ "$bn" != '-' ]; then
            cross_suffix="$cross_suffix${bn%-*}-"
-	   cross_suffix=`echo $cross_suffix|sed -e 's/ -$//'`
          fi
 esac
 

--- a/c_check
+++ b/c_check
@@ -35,7 +35,7 @@ if [ "`dirname \"$compiler_name\"`" != '.' ]; then
     cross_suffix="$cross_suffix`dirname \"$compiler_name\"`/"
 fi
 
-bn=`basename \"$compiler_name\"`
+bn=`basename "$compiler_name"`
 
 case "$bn" in
     *-*) if [ "$bn" != '-' ]; then


### PR DESCRIPTION
as suggested by Dirreke in #4011 - this is also expected to be the final one in the string of fixes for #3989 (tested compiler name with and without a compiler option appended, and both with a prepended command like ccache)