### PR TITLE
fix wrong vr = VFMVVF_FLOAT(0, vl); in symv_L_rvv.c and symv_U_rvv.c

### DIFF
--- a/Makefile.riscv64
+++ b/Makefile.riscv64
@@ -3,7 +3,7 @@ CCOMMON_OPT += -march=rv64imafdcv0p7_zfh_xtheadc -mabi=lp64d -mtune=c920
 FCOMMON_OPT += -march=rv64imafdcv0p7_zfh_xtheadc -mabi=lp64d -mtune=c920 -static
 endif
 ifeq ($(CORE), x280)
-CCOMMON_OPT += -march=rv64imafdcv_zba_zbb_zfh -mabi=lp64d -mllvm --riscv-v-vector-bits-min=512 -ffast-math
+CCOMMON_OPT += -march=rv64imafdcv_zba_zbb_zfh_zvl512b -mabi=lp64d -ffast-math
 FCOMMON_OPT += -march=rv64imafdcv_zba_zbb_zfh -mabi=lp64d -static
 endif
 ifeq ($(CORE), RISCV64_GENERIC)

--- a/kernel/riscv64/symv_L_rvv.c
+++ b/kernel/riscv64/symv_L_rvv.c
@@ -94,7 +94,6 @@ int CNAME(BLASLONG m, BLASLONG offset, FLOAT alpha, FLOAT *a, BLASLONG lda, FLOA
                         for (k = (m-i); k > 0; k -= vl, i += vl)
                         {
                                 vl = VSETVL(k);
-                                vr = VFMVVF_FLOAT(0, vl);
                                 va = VLEV_FLOAT(&a_ptr[i], vl);
                                 vy = VLEV_FLOAT(&y[i], vl);
                                 vy = VFMACCVF_FLOAT(vy, temp1, va, vl);
@@ -125,7 +124,6 @@ int CNAME(BLASLONG m, BLASLONG offset, FLOAT alpha, FLOAT *a, BLASLONG lda, FLOA
                         {
                                 vl = VSETVL(k);
                                 inc_yv = inc_y * vl;
-                                vr = VFMVVF_FLOAT(0, vl);
                                 va = VLEV_FLOAT(&a_ptr[i], vl);
                                 vy = VLSEV_FLOAT(&y[iy], stride_y, vl);
                                 vy = VFMACCVF_FLOAT(vy, temp1, va, vl);
@@ -157,7 +155,6 @@ int CNAME(BLASLONG m, BLASLONG offset, FLOAT alpha, FLOAT *a, BLASLONG lda, FLOA
                         for (k = (m-i); k > 0; k -= vl, i += vl)
                         {
                                 vl = VSETVL(k);
-                                vr = VFMVVF_FLOAT(0, vl);
                                 inc_xv = inc_x * vl;
 
                                 va = VLEV_FLOAT(&a_ptr[i], vl);
@@ -197,7 +194,6 @@ int CNAME(BLASLONG m, BLASLONG offset, FLOAT alpha, FLOAT *a, BLASLONG lda, FLOA
                                 vl = VSETVL(k);
                                 inc_xv = inc_x * vl;
                                 inc_yv = inc_y * vl;
-                                vr = VFMVVF_FLOAT(0, vl);
                                 
                                 va = VLEV_FLOAT(&a_ptr[i], vl);
                                 vy = VLSEV_FLOAT(&y[iy], stride_y, vl);

--- a/kernel/riscv64/symv_U_rvv.c
+++ b/kernel/riscv64/symv_U_rvv.c
@@ -95,7 +95,6 @@ int CNAME(BLASLONG m, BLASLONG offset, FLOAT alpha, FLOAT *a, BLASLONG lda, FLOA
                         for (k = j; k > 0; k -= vl, i += vl)
                         {
                                 vl = VSETVL(k);
-                                vr = VFMVVF_FLOAT(0, vl);
                                 vy = VLEV_FLOAT(&y[i], vl);
                                 va = VLEV_FLOAT(&a_ptr[i], vl);
                                 vy = VFMACCVF_FLOAT(vy, temp1, va, vl);
@@ -125,7 +124,6 @@ int CNAME(BLASLONG m, BLASLONG offset, FLOAT alpha, FLOAT *a, BLASLONG lda, FLOA
                         {
                                 vl = VSETVL(k);
                                 inc_yv = inc_y * vl;
-                                vr = VFMVVF_FLOAT(0, vl);
                                 vy = VLSEV_FLOAT(&y[iy], stride_y, vl);
                                 va = VLEV_FLOAT(&a_ptr[i], vl);
                                 vy = VFMACCVF_FLOAT(vy, temp1, va, vl);
@@ -158,7 +156,6 @@ int CNAME(BLASLONG m, BLASLONG offset, FLOAT alpha, FLOAT *a, BLASLONG lda, FLOA
                         {
                                 vl = VSETVL(k);
                                 inc_xv = inc_x * vl;
-                                vr = VFMVVF_FLOAT(0, vl);
 
                                 vy = VLEV_FLOAT(&y[i], vl);
                                 va = VLEV_FLOAT(&a_ptr[i], vl);
@@ -197,7 +194,6 @@ int CNAME(BLASLONG m, BLASLONG offset, FLOAT alpha, FLOAT *a, BLASLONG lda, FLOA
                                 vl = VSETVL(k);
                                 inc_xv = inc_x * vl;
                                 inc_yv = inc_y * vl;
-                                vr = VFMVVF_FLOAT(0, vl);
                                 vy = VLSEV_FLOAT(&y[iy], stride_y, vl);
                                 va = VLEV_FLOAT(&a_ptr[i], vl);
                                 vy = VFMACCVF_FLOAT(vy, temp1, va, vl);


### PR DESCRIPTION
As @sh-zheng found https://github.com/xianyi/OpenBLAS/pull/4049#issuecomment-1556213660, thanks.
fix wrong vr = VFMVVF_FLOAT(0, vl); in symv_L_rvv.c and symv_U_rvv.c
remove argument unused during compilation.
