### PR TITLE
LoongArch64: Add ABI detection for loongarch64

### DIFF
--- a/Makefile.system
+++ b/Makefile.system
@@ -932,8 +932,12 @@ BINARY_DEFINED = 1
 endif
 
 ifeq ($(ARCH), loongarch64)
-CCOMMON_OPT += -march=loongarch64 -mabi=lp64
-FCOMMON_OPT += -march=loongarch64 -mabi=lp64
+LA64_ABI=$(shell $(CC) -mabi=lp64d -c $(TOPDIR)/cpuid_loongarch64.c -o /dev/null > /dev/null 2> /dev/null && echo lp64d)
+ifneq ($(LA64_ABI), lp64d)
+LA64_ABI=lp64
+endif
+CCOMMON_OPT += -march=loongarch64 -mabi=$(LA64_ABI)
+FCOMMON_OPT += -march=loongarch64 -mabi=$(LA64_ABI)
 endif
 
 endif


### PR DESCRIPTION
According to the latest [documentation](https://loongson.github.io/LoongArch-Documentation/LoongArch-ELF-ABI-EN.html) from Loongson, the lp64 ABI is no longer supported and has been replaced with lp64d. It has been confirmed by consulting relevant staff members at Loongson that lp64 and lp64d are equivalent. Initially, only lp64 was available in the early stages, but lp64d was later introduced to align with broader community standards. Starting from GCC 12, LoongArch64 is supported with only lp64d being [retained](https://gcc.gnu.org/onlinedocs/gcc-12.1.0/gcc/LoongArch-Options.html#LoongArch-Options). However, some systems like UOS/Kylin may still be using outdated compilers that only support lp64. The same issue was discussed in #3626. To maximize compatibility, ABI detection was added.