### PR TITLE
Release OpenMP resources in blas_thread_shutdown

### DIFF
--- a/c_check
+++ b/c_check
@@ -412,6 +412,14 @@ fi
 
 [ "$USE_OPENMP" != 1 ] && openmp=''
 
+have_omp_pause_resource_all=0
+if [ "$USE_OPENMP" = 1 ]; then
+    if $compiler_name $flags $openmp -o ctest3 ctest3.c; then
+        have_omp_pause_resource_all=1
+    fi
+    rm -f ctest3.o ctest3 ctest3.exe
+fi
+
 linker_L=""
 linker_l=""
 linker_a=""
@@ -501,6 +509,7 @@ done
     [ "$oldgcc" -eq 1 ] && printf "OLDGCC=1\n"
     [ "$no_lsx" -eq 1 ] && printf "NO_LSX=1\n"
     [ "$no_lasx" -eq 1 ] && printf "NO_LASX=1\n"
+    [ "$have_omp_pause_resource_all" -eq 1 ] && printf "HAVE_OMP_PAUSE_RESOURCE_ALL=1\n"
 } >> "$makefile"
 
 os=`echo "$os" | tr '[[:lower:]]' '[[:upper:]]'/ `
@@ -518,6 +527,7 @@ compiler=`echo "$compiler" | tr '[[:lower:]]' '[[:upper:]]' `
     [ "$c11_atomics" -eq 1 ] && printf "#define HAVE_C11\t1\n"
     [ "$no_lsx" -eq 1 ] && printf "#define NO_LSX\t1\n"
     [ "$no_lasx" -eq 1 ] && printf "#define NO_LASX\t1\n"
+    [ "$have_omp_pause_resource_all" -eq 1 ] && printf "#define HAVE_OMP_PAUSE_RESOURCE_ALL\t1\n"
 } >> "$config"
 
 

--- a/c_check.pl
+++ b/c_check.pl
@@ -394,6 +394,14 @@ $cross = 0 if (($os eq "Android") && ($hostos eq "Linux") && ($ENV{TERMUX_APP_PI
 
 $openmp = "" if $ENV{USE_OPENMP} != 1;
 
+$have_omp_pause_resource_all=0;
+if ($ENV{USE_OPENMP} == 1) {
+    if (system("$compiler_name $flags $openmp -o ctest3 ctest3.c") == 0) {
+        $have_omp_pause_resource_all=1;
+    }
+    unlink "ctest3.o", "ctest3", "ctest3.exe";
+}
+
 $linker_L = "";
 $linker_l = "";
 $linker_a = "";
@@ -472,6 +480,7 @@ print MAKEFILE "NO_AVX2=1\n" if $no_avx2 eq 1;
 print MAKEFILE "OLDGCC=1\n" if $oldgcc eq 1;
 print MAKEFILE "NO_LSX=1\n" if $no_lsx eq 1;
 print MAKEFILE "NO_LASX=1\n" if $no_lasx eq 1;
+print MAKEFILE "HAVE_OMP_PAUSE_RESOURCE_ALL=1\n" if $have_omp_pause_resource_all eq 1;
 
 $os           =~ tr/[a-z]/[A-Z]/;
 $architecture =~ tr/[a-z]/[A-Z]/;
@@ -487,6 +496,7 @@ print CONFFILE "#define HAVE_MSA\t1\n"  if $have_msa eq 1;
 print CONFFILE "#define HAVE_C11\t1\n" if $c11_atomics eq 1;
 print CONFFILE "#define NO_LSX\t1\n" if $no_lsx eq 1;
 print CONFFILE "#define NO_LASX\t1\n" if $no_lasx eq 1;
+print CONFFILE "#define HAVE_OMP_PAUSE_RESOURCE_ALL\t1\n" if $have_omp_pause_resource_all eq 1;
 
 
 if ($os eq "LINUX") {

--- a/ctest3.c
+++ b/ctest3.c
@@ -1,0 +1,2 @@
+#include <omp.h>
+int main(void) { return omp_pause_resource_all(omp_pause_hard); }

--- a/driver/others/blas_server_omp.c
+++ b/driver/others/blas_server_omp.c
@@ -48,6 +48,7 @@
 
 #else
 
+#include <omp.h>
 #ifndef likely
 #ifdef __GNUC__
 #define likely(x) __builtin_expect(!!(x), 1)
@@ -172,6 +173,9 @@ int BLASFUNC(blas_thread_shutdown)(void){
       }
     }
   }
+#if HAVE_OMP_PAUSE_RESOURCE_ALL
+  omp_pause_resource_all(omp_pause_hard);
+#endif
 
   return 0;
 }

--- a/utest/Makefile
+++ b/utest/Makefile
@@ -44,10 +44,14 @@ endif
 #this does not work with OpenMP nor with native Windows or Android threads
 # FIXME TBD if this works on OSX, SunOS, POWER and zarch
 ifeq ($(OSNAME), $(filter $(OSNAME),Linux CYGWIN_NT))
-ifneq ($(USE_OPENMP), 1)
-OBJS += test_fork.o
+ifeq ($(USE_OPENMP), 1)
+ifeq ($(HAVE_OMP_PAUSE_RESOURCE_ALL), 1)
+   OBJS += test_fork.o
 endif
-OBJS += test_post_fork.o
+else
+  OBJS += test_fork.o
+endif
+ OBJS += test_post_fork.o
 endif
 
 ifeq ($(C_COMPILER), PGI)


### PR DESCRIPTION
OpenMP 5.0 gained an [`omp_pause_resource_all`](https://www.openmp.org/spec-html/5.0/openmpsu153.html) function designed to release the locks before `fork`ing the process. The parameters are described in the [`omp_pause_resource`](https://www.openmp.org/spec-html/5.0/openmpsu152.html) function. Using this function makes it possible for OpenMP builds of OpenBLAS to pass `fork` safety tests.

An important detail is that there exist OpenMP implementations that only claim OpenMP 4.5 compatibility (i.e. they `#define _OPENMP 201511`) while they do have the `omp_pause_resource_all`. We currently don't have a way to use `omp_pause_resource_all` with such implementations (e.g. GCC 10 on Debian 11).

The [first commit](43e81c3891cfb52a798dc9209b364c7f21c7f99a) adds the `omp_pause_resource_all` call to `blas_thread_shutdown`. You may want not to merge this if you'd like `blas_thread_shutdown` to be safe to call while other OpenMP operations are in progress.

The [second commit](570d6ba11700504202c3ca395e2e2b8c5cb7a272) adds a convoluted way to test `fork` safety of the resulting build on OpenMP ≥ 5.0 in addition to non-OpenMP builds. I'd be glad to see a better way of testing for OpenMP ≥ 5.0 in a Makefile.