### PR TITLE
Fix info code returned for invalid ldb by IMATCOPY

### DIFF
--- a/interface/imatcopy.c
+++ b/interface/imatcopy.c
@@ -100,13 +100,13 @@ void CNAME( enum CBLAS_ORDER CORDER, enum CBLAS_TRANSPOSE CTRANS, blasint crows,
 
 	if ( order == BlasColMajor)
 	{
-        	if ( trans == BlasNoTrans  &&  *ldb < *rows ) info = 9;
-        	if ( trans == BlasTrans    &&  *ldb < *cols ) info = 9;
+        	if ( trans == BlasNoTrans  &&  *ldb < *rows ) info = 8;
+        	if ( trans == BlasTrans    &&  *ldb < *cols ) info = 8;
 	}
 	if ( order == BlasRowMajor)
 	{
-        	if ( trans == BlasNoTrans  &&  *ldb < *cols ) info = 9;
-        	if ( trans == BlasTrans    &&  *ldb < *rows ) info = 9;
+        	if ( trans == BlasNoTrans  &&  *ldb < *cols ) info = 8;
+        	if ( trans == BlasTrans    &&  *ldb < *rows ) info = 8;
 	}
 
 	if ( order == BlasColMajor &&  *lda < *rows ) info = 7;


### PR DESCRIPTION
fixes #4132 as suggested by angsch there