### PR TITLE
Fix runtime detection in ARMV8 DYNAMIC_ARCH to check SVE capability

### DIFF
--- a/driver/others/dynamic_arm64.c
+++ b/driver/others/dynamic_arm64.c
@@ -137,6 +137,8 @@ extern gotoblas_t  gotoblas_CORTEXA55;
 #endif
 
 extern void openblas_warning(int verbose, const char * msg);
+#define FALLBACK_VERBOSE 1
+#define NEOVERSEN1_FALLBACK "OpenBLAS : Your OS does not support SVE instructions. OpenBLAS is using Neoverse N1 kernels as a fallback, which may give poorer performance.\n"
 
 #define NUM_CORETYPES   13
 
@@ -284,14 +286,16 @@ static gotoblas_t *get_coretype(void) {
           return &gotoblas_NEOVERSEN1;
 #ifndef NO_SVE
         case 0xd49:
-	  if (!(getauxval(AT_HWCAP) & HWCAP_SVE)) 
+	  if (!(getauxval(AT_HWCAP) & HWCAP_SVE)) {
+	    openblas_warning(FALLBACK_VERBOSE, NEOVERSEN1_FALLBACK);  
 	    return &gotoblas_NEOVERSEN1;
-	  else
+	  } else
             return &gotoblas_NEOVERSEN2;
 	case 0xd40:
-	  if (!(getauxval(AT_HWCAP) & HWCAP_SVE)) 
+	  if (!(getauxval(AT_HWCAP) & HWCAP_SVE)) {
+		  openblas_warning(FALLBACK_VERBOSE, NEOVERSEN1_FALLBACK);
 	    return &gotoblas_NEOVERSEN1;
-	  else
+      	  }else
 	    return &gotoblas_NEOVERSEV1;
 #endif
 	case 0xd05: // Cortex A55

--- a/driver/others/dynamic_arm64.c
+++ b/driver/others/dynamic_arm64.c
@@ -147,6 +147,9 @@ extern void openblas_warning(int verbose, const char * msg);
 #ifndef HWCAP_CPUID
 #define HWCAP_CPUID (1 << 11)
 #endif
+#ifndef HWCAP_SVE
+#define HWCAP_SVE (1 << 22)
+#endif
 
 #define get_cpu_ftr(id, var) ({					\
 		__asm__ __volatile__ ("mrs %0, "#id : "=r" (var));		\
@@ -281,9 +284,15 @@ static gotoblas_t *get_coretype(void) {
           return &gotoblas_NEOVERSEN1;
 #ifndef NO_SVE
         case 0xd49:
-          return &gotoblas_NEOVERSEN2;
+	  if (!(getauxval(AT_HWCAP) & HWCAP_SVE)) 
+	    return &gotoblas_NEOVERSEN1;
+	  else
+            return &gotoblas_NEOVERSEN2;
 	case 0xd40:
-	  return &gotoblas_NEOVERSEV1;
+	  if (!(getauxval(AT_HWCAP) & HWCAP_SVE)) 
+	    return &gotoblas_NEOVERSEN1;
+	  else
+	    return &gotoblas_NEOVERSEV1;
 #endif
 	case 0xd05: // Cortex A55
 	  return &gotoblas_CORTEXA55;


### PR DESCRIPTION
Detection of Neoverse V1/N2 was based on cpu part code only, but SVE can apparently be unavailable in certain container or cloud environments. Tentative fix for https://github.com/numpy/numpy/issues/24028