### PR TITLE
Ensure that early calls to blas_set_num_threads will not overwrite unrelated memory

### DIFF
--- a/driver/others/blas_server.c
+++ b/driver/others/blas_server.c
@@ -973,7 +973,7 @@ void goto_set_num_threads(int num_threads) {
 
     increased_threads = 1;
 
-    for(i = blas_num_threads - 1; i < num_threads - 1; i++){
+    for(i = (blas_num_threads > 0) ? blas_num_threads - 1 : 0; i < num_threads - 1; i++){
 
       atomic_store_queue(&thread_status[i].queue, (blas_queue_t *)0);
       thread_status[i].status = THREAD_STATUS_WAKEUP;

--- a/driver/others/blas_server_win32.c
+++ b/driver/others/blas_server_win32.c
@@ -568,7 +568,7 @@ void goto_set_num_threads(int num_threads)
 			blas_server_avail = 1;
 		}
 
-		for(i = blas_num_threads - 1; i < num_threads - 1; i++){
+		for(i = (blas_num_threads > 0) ? blas_num_threads - 1 : 0; i < num_threads - 1; i++){
 
 			blas_threads[i] = CreateThread(NULL, 0,
 				     blas_thread_server, (void *)i,


### PR DESCRIPTION
minimal fix for #4101 , as the original proposal from #4102 had been unintentionally included in the now reverted #4103
(fixes #4101)