### PR TITLE
Override the C910V DSDOT with generic code to get rid of the qemu precision error in CI

### DIFF
--- a/kernel/riscv64/KERNEL.C910V
+++ b/kernel/riscv64/KERNEL.C910V
@@ -59,6 +59,7 @@ SDOTKERNEL   = dot_vector.c
 DDOTKERNEL   = dot_vector.c
 CDOTKERNEL   = zdot_vector.c
 ZDOTKERNEL   = zdot_vector.c
+DSDOTKERNEL  = ../generic/dot.c
 
 SNRM2KERNEL  = nrm2_vector.c
 DNRM2KERNEL  = nrm2_vector.c


### PR DESCRIPTION
closes #4098