### PR TITLE
Use defined variable for riscv64 in arch.cmake

### DIFF
--- a/cmake/arch.cmake
+++ b/cmake/arch.cmake
@@ -135,7 +135,7 @@ if (ARM64)
   set(BINARY_DEFINED 1)
 endif ()
 
-if (${ARCH} STREQUAL "riscv64")
+if (RISCV64)
   set(NO_BINARY_MODE 1)
   set(BINARY_DEFINED 1)
 endif ()


### PR DESCRIPTION
It's defined in #4137