### PR TITLE
Fix build with some clang installations when openmp is enabled

### DIFF
--- a/ctest/Makefile
+++ b/ctest/Makefile
@@ -208,7 +208,7 @@ FLDFLAGS = $(FFLAGS:-fPIC=) $(LDFLAGS)
 ifeq ($(USE_OPENMP), 1)
 ifeq ($(F_COMPILER), GFORTRAN)
 ifeq ($(C_COMPILER), CLANG)
-CEXTRALIB = -lomp
+CEXTRALIB += -lomp
 endif
 endif
 ifeq ($(F_COMPILER), NAG)

--- a/test/Makefile
+++ b/test/Makefile
@@ -265,7 +265,7 @@ FLDFLAGS = $(FFLAGS:-fPIC=) $(LDFLAGS)
 ifeq ($(USE_OPENMP), 1)
 ifeq ($(F_COMPILER), GFORTRAN)
 ifeq ($(C_COMPILER), CLANG)
-CEXTRALIB = -lomp
+CEXTRALIB += -lomp
 endif
 endif
 ifeq ($(F_COMPILER), NAG)


### PR DESCRIPTION
There are two instances when building the tests where OpenBLAS fails to build with OpenMP and clang due to library paths getting reset as flags are set rather than appended. This seems to only affect certain clang/libomp installations, but if it's already grabbing the correct library paths we might as well use them.