### PR TITLE
CI (MinGW): Remove work-around needed for old versions of LLVM Flang

### DIFF
--- a/.github/workflows/dynamic_arch.yml
+++ b/.github/workflows/dynamic_arch.yml
@@ -174,9 +174,6 @@ jobs:
             idx: int32
             target-prefix: mingw-w64-clang-x86_64
             fc-pkg: fc
-            # Compiling with Flang 16 seems to cause test errors on machines
-            # with AVX512 instructions. Revisit after MSYS2 distributes Flang 17.
-            no-avx512-flags: -DNO_AVX512=1
           - msystem: CLANG32
             idx: int32
             target-prefix: mingw-w64-clang-i686
@@ -192,9 +189,6 @@ jobs:
             idx64-flags: -DBINARY=64 -DINTERFACE64=1
             target-prefix: mingw-w64-clang-x86_64
             fc-pkg: fc
-            # Compiling with Flang 16 seems to cause test errors on machines
-            # with AVX512 instructions. Revisit after MSYS2 distributes Flang 17.
-            no-avx512-flags: -DNO_AVX512=1
           - msystem: UCRT64
             idx: int32
             target-prefix: mingw-w64-ucrt-x86_64
@@ -281,7 +275,6 @@ jobs:
                 -DTARGET=CORE2 \
                 ${{ matrix.idx64-flags }} \
                 ${{ matrix.c-lapack-flags }} \
-                ${{ matrix.no-avx512-flags }} \
                 -DCMAKE_C_COMPILER_LAUNCHER=ccache \
                 -DCMAKE_Fortran_COMPILER_LAUNCHER=ccache \
                 ..


### PR DESCRIPTION
Some features either don't compile or don't work correctly with LLVM Flang before version 17.
This PR tries to help users to avoid these known-bad configurations by emitting a message and adapting the corresponding flags.

It's still unclear if both of these known-bad configurations will actually be fixed in LLVM Flang 17 or if one of them is actually an issue that is platform-dependent (i.e., only Windows or MinGW). In the latter case, the conditions could still be adapted in the future.

The flags need to be adapted early on. At least, before `system_check.cmake` is included via `system.cmake`. That required to move the check for the Fortran compiler to earlier in the configuration process.
