### PR TITLE
Allow negative INCX in the ?NRM2 kernels

### DIFF
--- a/kernel/arm/nrm2.c
+++ b/kernel/arm/nrm2.c
@@ -57,7 +57,7 @@ FLOAT CNAME(BLASLONG n, FLOAT *x, BLASLONG inc_x)
 	FLOAT absxi = 0.0;
 
 
-	if (n <= 0 || inc_x <= 0) return(0.0);
+	if (n <= 0 || inc_x == 0) return(0.0);
 	if ( n == 1 ) return( ABS(x[0]) );
 
 	n *= inc_x;

--- a/kernel/arm/znrm2.c
+++ b/kernel/arm/znrm2.c
@@ -57,7 +57,7 @@ FLOAT CNAME(BLASLONG n, FLOAT *x, BLASLONG inc_x)
 	BLASLONG inc_x2;
 	FLOAT temp;
 
-	if (n <= 0 || inc_x <= 0) return(0.0);
+	if (n <= 0 || inc_x == 0) return(0.0);
 
 	inc_x2 = 2 * inc_x;
 

--- a/kernel/loongarch64/cnrm2.S
+++ b/kernel/loongarch64/cnrm2.S
@@ -61,7 +61,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
    fmov.d s2, s1
    bge $r0,    N, .L999
    slli.d INCX, INCX, ZBASE_SHIFT
-   bge $r0,    INCX, .L999
+   beq $r0,    INCX, .L999
    srai.d  I, N, 2
    bge $r0,    I, .L25
    LD a1,  X,   0 * SIZE

--- a/kernel/loongarch64/dnrm2.S
+++ b/kernel/loongarch64/dnrm2.S
@@ -70,7 +70,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
    MTC  s1, $r0
    bge $r0,    N, .L999
    slli.d INCX, INCX, BASE_SHIFT
-   bge $r0,    INCX, .L999
+   beq $r0,    INCX, .L999
    move    XX, X
    NOP
    LD a1,  X,   0 * SIZE

--- a/kernel/loongarch64/snrm2.S
+++ b/kernel/loongarch64/snrm2.S
@@ -61,7 +61,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
    fmov.d s2, s1
    bge $r0,    N, .L999
    slli.d INCX, INCX, BASE_SHIFT
-   bge $r0,    INCX, .L999
+   beq $r0,    INCX, .L999
    srai.d I, N, 3
    bne INCX, TEMP, .L20
    bge $r0,    I, .L15

--- a/kernel/loongarch64/znrm2.S
+++ b/kernel/loongarch64/znrm2.S
@@ -64,7 +64,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
    MTC  s1, $r0
    bge $r0,    N, .L999
    slli.d INCX, INCX, ZBASE_SHIFT
-   bge $r0,    INCX, .L999
+   beq $r0,    INCX, .L999
    move    XX, X
    MOV s2, s1
    srai.d  I, N, 2

--- a/kernel/mips/nrm2.c
+++ b/kernel/mips/nrm2.c
@@ -57,7 +57,7 @@ FLOAT CNAME(BLASLONG n, FLOAT *x, BLASLONG inc_x)
 	FLOAT absxi = 0.0;
 
 
-	if (n <= 0 || inc_x <= 0) return(0.0);
+	if (n <= 0 || inc_x == 0) return(0.0);
 	if ( n == 1 ) return( ABS(x[0]) );
 
 	n *= inc_x;

--- a/kernel/mips/znrm2.c
+++ b/kernel/mips/znrm2.c
@@ -48,7 +48,7 @@ FLOAT CNAME(BLASLONG n, FLOAT *x, BLASLONG inc_x)
 	BLASLONG inc_x2;
 	FLOAT temp;
 
-	if (n <= 0 || inc_x <= 0) return(0.0);
+	if (n <= 0 || inc_x == 0) return(0.0);
 
 	inc_x2 = 2 * inc_x;
 

--- a/kernel/mips64/cnrm2.S
+++ b/kernel/mips64/cnrm2.S
@@ -77,7 +77,7 @@
 	blez	N, .L999
 	mov.d	s2, s1
 
-	blez	INCX, .L999
+	beqz	INCX, .L999
 	dsll	INCX, INCX, ZBASE_SHIFT
 
 	dsra	I, N, 2

--- a/kernel/mips64/dnrm2.S
+++ b/kernel/mips64/dnrm2.S
@@ -81,7 +81,7 @@
 	blez	N, .L999
 	MTC	$0,  s1
 
-	blez	INCX, .L999
+	beqz	INCX, .L999
 	dsll	INCX, INCX, BASE_SHIFT
 
 	move	XX, X

--- a/kernel/mips64/snrm2.S
+++ b/kernel/mips64/snrm2.S
@@ -77,7 +77,7 @@
 	blez	N, .L999
 	mov.d	s2, s1
 
-	blez	INCX, .L999
+	beqz	INCX, .L999
 	dsll	INCX, INCX, BASE_SHIFT
 
 	bne	INCX, TEMP, .L20

--- a/kernel/mips64/znrm2.S
+++ b/kernel/mips64/znrm2.S
@@ -80,7 +80,7 @@
 	blez	N, .L999
 	MTC	$0,  s1
 
-	blez	INCX, .L999
+	beqz	INCX, .L999
 	dsll	INCX, INCX, ZBASE_SHIFT
 
 	move	XX, X

--- a/kernel/power/cnrm2.S
+++ b/kernel/power/cnrm2.S
@@ -99,7 +99,7 @@
 	cmpwi	cr0, N, 0
 	ble-	LL(9999)
 	cmpwi	cr0, INCX, 0
-	ble-	LL(9999)
+	beq-	LL(9999)
 
 	fmr	f0,  f1
 	fmr	f2,  f1

--- a/kernel/power/cnrm2_hummer.S
+++ b/kernel/power/cnrm2_hummer.S
@@ -119,7 +119,7 @@
 	cmpwi	cr0, N, 0
 	ble	LL(99)
 	cmpwi	cr0, INCX, 0
-	ble	LL(99)
+	beq	LL(99)
 
 	andi.	r0, X, 2 * SIZE - 1
 	bne	LL(100)

--- a/kernel/power/cnrm2_ppc440.S
+++ b/kernel/power/cnrm2_ppc440.S
@@ -104,7 +104,7 @@
 	cmpwi	cr0, N, 0
 	ble-	LL(999)
 	cmpwi	cr0, INCX, 0
-	ble-	LL(999)
+	beq-	LL(999)
 
 	fmr	f0,  f1
 	sub	X, X, INCX

--- a/kernel/power/dnrm2_hummer.S
+++ b/kernel/power/dnrm2_hummer.S
@@ -134,7 +134,7 @@
 	cmpwi	cr0, N, 0
 	ble	LL(99)
 	cmpwi	cr0, INCX, 0
-	ble	LL(99)
+	beq	LL(99)
 
 	mr	XX, X
 

--- a/kernel/power/dnrm2_ppc440.S
+++ b/kernel/power/dnrm2_ppc440.S
@@ -111,7 +111,7 @@
 	cmpwi	cr0, N, 0
 	ble-	LL(999)
 	cmpwi	cr0, INCX, 0
-	ble-	LL(999)
+	beq-	LL(999)
 
 	mr	NN, N
 	mr	XX, X

--- a/kernel/power/nrm2.S
+++ b/kernel/power/nrm2.S
@@ -113,7 +113,7 @@
 	cmpwi	cr0, N, 0
 	ble-	LL(9999)
 	cmpwi	cr0, INCX, 0
-	ble-	LL(9999)
+	beq-	LL(9999)
 
 	mr	NN, N
 	mr	XX, X

--- a/kernel/power/snrm2.S
+++ b/kernel/power/snrm2.S
@@ -97,7 +97,7 @@
 	cmpwi	cr0, N, 0
 	ble-	LL(9999)
 	cmpwi	cr0, INCX, 0
-	ble-	LL(9999)
+	beq-	LL(9999)
 
 	fmr	f0,  f1
 	fmr	f2,  f1

--- a/kernel/power/snrm2_hummer.S
+++ b/kernel/power/snrm2_hummer.S
@@ -119,7 +119,7 @@
 	cmpwi	cr0, N, 0
 	ble	LL(99)
 	cmpwi	cr0, INCX, 0
-	ble	LL(99)
+	beq	LL(99)
 
 	cmpwi	cr0, INCX, SIZE
 	bne	LL(100)

--- a/kernel/power/snrm2_ppc440.S
+++ b/kernel/power/snrm2_ppc440.S
@@ -105,7 +105,7 @@
 	cmpwi	cr0, N, 0
 	ble-	LL(999)
 	cmpwi	cr0, INCX, 0
-	ble-	LL(999)
+	beq-	LL(999)
 
 	fmr	f0,  f1
 	fmr	f2,  f1

--- a/kernel/power/znrm2.S
+++ b/kernel/power/znrm2.S
@@ -105,7 +105,7 @@
 	cmpwi	cr0, N, 0
 	ble-	LL(9999)
 	cmpwi	cr0, INCX, 0
-	ble-	LL(9999)
+	beq-	LL(9999)
 
 	mr	NN, N
 	mr	XX, X

--- a/kernel/power/znrm2_hummer.S
+++ b/kernel/power/znrm2_hummer.S
@@ -134,7 +134,7 @@
 	cmpwi	cr0, N, 0
 	ble	LL(99)
 	cmpwi	cr0, INCX, 0
-	ble	LL(99)
+	beq	LL(99)
 
 	mr	XX, X
 

--- a/kernel/power/znrm2_ppc440.S
+++ b/kernel/power/znrm2_ppc440.S
@@ -112,7 +112,7 @@
 	cmpwi	cr0, N, 0
 	ble-	LL(999)
 	cmpwi	cr0, INCX, 0
-	ble-	LL(999)
+	beq-	LL(999)
 
 	mr	NN, N
 	mr	XX, X

--- a/kernel/riscv64/nrm2.c
+++ b/kernel/riscv64/nrm2.c
@@ -57,7 +57,7 @@ FLOAT CNAME(BLASLONG n, FLOAT *x, BLASLONG inc_x)
 	FLOAT absxi = 0.0;
 
 
-	if (n <= 0 || inc_x <= 0) return(0.0);
+	if (n <= 0 || inc_x == 0) return(0.0);
 	if ( n == 1 ) return( ABS(x[0]) );
 
 	n *= inc_x;

--- a/kernel/riscv64/znrm2.c
+++ b/kernel/riscv64/znrm2.c
@@ -57,7 +57,7 @@ FLOAT CNAME(BLASLONG n, FLOAT *x, BLASLONG inc_x)
 	BLASLONG inc_x2;
 	FLOAT temp;
 
-	if (n <= 0 || inc_x <= 0) return(0.0);
+	if (n <= 0 || inc_x == 0) return(0.0);
 
 	inc_x2 = 2 * inc_x;
 

--- a/kernel/sparc/cnrm2.S
+++ b/kernel/sparc/cnrm2.S
@@ -76,7 +76,7 @@
 	FMOV	c1, t4
 
 	cmp	INCX, 0
-	ble	.LL20
+	beq	.LL20
 	sll	INCX, ZBASE_SHIFT, INCX
 
 	cmp	N, 0

--- a/kernel/sparc/dnrm2.S
+++ b/kernel/sparc/dnrm2.S
@@ -107,7 +107,7 @@
 	FMOV	fzero, c1
 
 	cmp	INCX, 0
-	ble	.LL99
+	beq	.LL99
 	sll	INCX, BASE_SHIFT, INCX
 
 	add	%sp, -8, %sp

--- a/kernel/sparc/snrm2.S
+++ b/kernel/sparc/snrm2.S
@@ -76,7 +76,7 @@
 	FMOV	c1, t4
 
 	cmp	INCX, 0
-	ble	.LL20
+	beq	.LL20
 	sll	INCX, BASE_SHIFT, INCX
 
 	cmp	N, 0

--- a/kernel/sparc/znrm2.S
+++ b/kernel/sparc/znrm2.S
@@ -107,7 +107,7 @@
 	FMOV	fzero, c1
 
 	cmp	INCX, 0
-	ble	.LL99
+	beq	.LL99
 	sll	INCX, ZBASE_SHIFT, INCX
 
 	add	%sp, -8, %sp

--- a/kernel/x86/nrm2.S
+++ b/kernel/x86/nrm2.S
@@ -78,7 +78,7 @@
 	testl	M, M
 	jle	.L999
 	testl	INCX, INCX
-	jle	.L999
+	je	.L999
 
 	sall	$BASE_SHIFT, INCX
 	fldz

--- a/kernel/x86/nrm2_sse.S
+++ b/kernel/x86/nrm2_sse.S
@@ -69,7 +69,7 @@
 	jle	.L999
 	pxor	%xmm1, %xmm1
 	testl	INCX, INCX
-	jle	.L999
+	je	.L999
 
 	leal	(, INCX, SIZE), INCX
 	cmpl	$SIZE, INCX

--- a/kernel/x86/znrm2.S
+++ b/kernel/x86/znrm2.S
@@ -78,7 +78,7 @@
 	testl	M, M
 	jle	.L999
 	testl	INCX, INCX
-	jle	.L999
+	je	.L999
 
 	sall	$ZBASE_SHIFT, INCX
 	fldz

--- a/kernel/x86/znrm2_sse.S
+++ b/kernel/x86/znrm2_sse.S
@@ -69,7 +69,7 @@
 	jle	.L999
 	pxor	%xmm1, %xmm1
 	testl	INCX, INCX
-	jle	.L999
+	je	.L999
 
 	sall	$ZBASE_SHIFT, INCX
 

--- a/kernel/x86_64/nrm2.S
+++ b/kernel/x86_64/nrm2.S
@@ -58,7 +58,7 @@
 	testq	M, M
 	jle	.L999
 	testq	INCX, INCX
-	jle	.L999
+	je	.L999
 
 	salq	$BASE_SHIFT, INCX
 

--- a/kernel/x86_64/nrm2_sse.S
+++ b/kernel/x86_64/nrm2_sse.S
@@ -57,7 +57,7 @@
 	jle	.L999
 	pxor	%xmm1, %xmm1
 	testq	INCX, INCX
-	jle	.L999
+	je	.L999
 
 	pxor	%xmm2, %xmm2
 	leaq	(, INCX, SIZE), INCX

--- a/kernel/x86_64/znrm2.S
+++ b/kernel/x86_64/znrm2.S
@@ -58,7 +58,7 @@
 	testq	M, M
 	jle	.L999
 	testq	INCX, INCX
-	jle	.L999
+	je	.L999
 
 	salq	$ZBASE_SHIFT, INCX
 

--- a/kernel/x86_64/znrm2_sse.S
+++ b/kernel/x86_64/znrm2_sse.S
@@ -58,7 +58,7 @@
 	jle	.L999
 	pxor	%xmm1, %xmm1
 	testq	INCX, INCX
-	jle	.L999
+	je	.L999
 
 	xorq	FLAG, FLAG
 


### PR DESCRIPTION
fixes #4186 by applying the near-trivial part of the ?NRM2 changes from Reference-LAPACK 3.10 to all existing C and assembly kernels - without applying the algorithmic changes for now.