### PR TITLE
Fix cooperlake and sapphire rapids march flags on clang

### DIFF
--- a/Makefile.system
+++ b/Makefile.system
@@ -384,6 +384,11 @@ GCCMINORVERSIONGTEQ4 := $(shell expr `$(CC) $(GCCDUMPVERSION_PARAM) | cut -f2 -d
 GCCMINORVERSIONGTEQ7 := $(shell expr `$(CC) $(GCCDUMPVERSION_PARAM) | cut -f2 -d.` \>= 7)
 endif
 
+ifeq ($(C_COMPILER), CLANG)
+CLANGVERSIONGTEQ9 := $(shell expr `$(CC) -dumpversion | cut -f1 -d.` \>= 9)
+CLANGVERSIONGTEQ12 := $(shell expr `$(CC) -dumpversion | cut -f1 -d.` \>= 12)
+endif
+
 #
 #  OS dependent settings
 #

--- a/Makefile.x86_64
+++ b/Makefile.x86_64
@@ -75,18 +75,31 @@ endif
 ifeq ($(CORE), COOPERLAKE)
 ifndef NO_AVX512
 ifeq ($(C_COMPILER), GCC)
-# cooperlake support was added in 10.1
-ifeq ($(GCCVERSIONGTEQ10)$(GCCMINORVERSIONGTEQ1), 11)
-CCOMMON_OPT += -march=cooperlake
-ifneq ($(F_COMPILER), NAG)
-FCOMMON_OPT += -march=cooperlake
-endif
-else  # gcc not support, fallback to avx512
-CCOMMON_OPT += -march=skylake-avx512
-ifneq ($(F_COMPILER), NAG)
-FCOMMON_OPT += -march=skylake-avx512
-endif
-endif
+ # cooperlake support was added in 10.1
+ ifeq ($(GCCVERSIONGTEQ10)$(GCCMINORVERSIONGTEQ1), 11)
+  CCOMMON_OPT += -march=cooperlake
+  ifneq ($(F_COMPILER), NAG)
+   FCOMMON_OPT += -march=cooperlake
+  endif
+ else  # gcc not support, fallback to avx512
+  CCOMMON_OPT += -march=skylake-avx512
+  ifneq ($(F_COMPILER), NAG)
+   FCOMMON_OPT += -march=skylake-avx512
+  endif
+ endif
+else ifeq ($(C_COMPILER), CLANG)
+ # cooperlake support was added in clang 9
+ ifeq ($(CLANGVERSIONGTEQ9), 1)
+  CCOMMON_OPT += -march=cooperlake
+  ifneq ($(F_COMPILER), NAG)
+   FCOMMON_OPT += -march=cooperlake
+  endif
+ else  # not supported in clang, fallback to avx512
+  CCOMMON_OPT += -march=skylake-avx512
+  ifneq ($(F_COMPILER), NAG)
+   FCOMMON_OPT += -march=skylake-avx512
+  endif
+ endif
 endif
 ifeq ($(OSNAME), CYGWIN_NT)
 CCOMMON_OPT += -fno-asynchronous-unwind-tables
@@ -104,18 +117,31 @@ endif
 ifeq ($(CORE), SAPPHIRERAPIDS)
 ifndef NO_AVX512
 ifeq ($(C_COMPILER), GCC)
-# sapphire rapids support was added in 11
-ifeq ($(GCCVERSIONGTEQ11), 1)
-CCOMMON_OPT += -march=sapphirerapids
-ifneq ($(F_COMPILER), NAG)
-FCOMMON_OPT += -march=sapphirerapids
-endif
-else  # gcc not support, fallback to avx512
-CCOMMON_OPT += -march=skylake-avx512
-ifneq ($(F_COMPILER), NAG)
-FCOMMON_OPT += -march=skylake-avx512
-endif
-endif
+ # sapphire rapids support was added in 11
+ ifeq ($(GCCVERSIONGTEQ11), 1)
+  CCOMMON_OPT += -march=sapphirerapids
+  ifneq ($(F_COMPILER), NAG)
+   FCOMMON_OPT += -march=sapphirerapids
+  endif
+ else  # gcc not support, fallback to avx512
+  CCOMMON_OPT += -march=skylake-avx512
+  ifneq ($(F_COMPILER), NAG)
+   FCOMMON_OPT += -march=skylake-avx512
+  endif
+ endif
+else ifeq ($(C_COMPILER), CLANG)
+ # cooperlake support was added in clang 12
+ ifeq ($(CLANGVERSIONGTEQ12), 1)
+  CCOMMON_OPT += -march=cooperlake
+  ifneq ($(F_COMPILER), NAG)
+   FCOMMON_OPT += -march=cooperlake
+  endif
+ else  # not supported in clang, fallback to avx512
+  CCOMMON_OPT += -march=skylake-avx512
+  ifneq ($(F_COMPILER), NAG)
+   FCOMMON_OPT += -march=skylake-avx512
+  endif
+ endif
 endif
 ifeq ($(OSNAME), CYGWIN_NT)
 CCOMMON_OPT += -fno-asynchronous-unwind-tables

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -33,7 +33,7 @@ endif
 ifdef TARGET_CORE
 ifeq ($(TARGET_CORE), SAPPHIRERAPIDS)
  override CFLAGS += -DBUILD_KERNEL -DTABLE_NAME=gotoblas_$(TARGET_CORE)
- ifeq ($(GCCVERSIONGTEQ11), 1) 
+ ifeq (1, $(filter 1,$(GCCVERSIONGTEQ11) $(CLANGVERSIONGTEQ12)))
   override CFLAGS += -march=sapphirerapids
  else 
   override CFLAGS += -march=skylake-avx512 -mavx512f
@@ -48,7 +48,7 @@ ifeq ($(TARGET_CORE), SAPPHIRERAPIDS)
  endif
 else ifeq ($(TARGET_CORE), COOPERLAKE)
  override CFLAGS += -DBUILD_KERNEL -DTABLE_NAME=gotoblas_$(TARGET_CORE)
- ifeq ($(GCCVERSIONGTEQ10), 1) 
+ ifeq (1, $(filter 1,$(GCCVERSIONGTEQ10) $(CLANGVERSIONGTEQ9)))
   override CFLAGS += -march=cooperlake
  else 
   override CFLAGS += -march=skylake-avx512 -mavx512f


### PR DESCRIPTION
The `march=cooperlake` and `march=sapphirerapids` flags were never getting added when building with Clang targetting those architectures. Instead it was falling back to the skylake AVX512 implementation. This was causing issues when building configurations such as
```
CC=clang make TARGET=COOPERLAKE BUILD_BFLOAT16=1
```
because there was either no `march` on the compiler command, or it was `march=skylake-avx512 -mavx512f`, neither of which would support the bfloat intrinsics needed, leading to errors like
```
../kernel/x86_64/stobf16_microk_cooperlake.c:49:20: error: ../kernel/x86_64/sbgemm_tcopy_4_cooperlake.calways_inline function '_mm512_maskz_loadu_ps' requires target feature 'avx512f', but would be inlined into function 'tobf16_accl_kernel' that is compiled without support for 'avx512f':106:21
        __m512 a = _mm512_maskz_loadu_ps(*((__mmask16*) &align_mask16), &in[0]);
                   ^: 
```
or
```
In file included from ../kernel/x86_64/tobf16.c:42:
../kernel/x86_64/stobf16_microk_cooperlake.c:46:84: error: always_inline function '_mm512_cvtneps_pbh' requires target feature 'avx512bf16', but would be inlined into function 'tobf16_accl_kernel' that is compiled without support for 'avx512bf16'
        _mm256_mask_storeu_epi16(&out[0], *((__mmask16*) &align_mask16), (__m256i) _mm512_cvtneps_pbh(a));
                                                                                   ^
```

Clang added support for these two architectures in Clang 9 and Clang 12, so introduce new checks for those versions to enable the appropriate march flag, and fallback to skylake otherwise.