### PR TITLE
Correct INFO returned for too small lda in non-CBLAS s/dgeadd

### DIFF
--- a/interface/geadd.c
+++ b/interface/geadd.c
@@ -68,7 +68,7 @@ void NAME(blasint *M, blasint *N, FLOAT *ALPHA, FLOAT *a, blasint *LDA,
   info = 0;
 
 
-  if (lda < MAX(1, m))	info = 6;
+  if (lda < MAX(1, m))	info = 5;
   if (ldc < MAX(1, m))	info = 8;
 
   if (n < 0)		info = 2;


### PR DESCRIPTION
fixes #4197 as suggested by @angsch there