### PR TITLE
LoongArch64: Compatible with early internal toolchain

### DIFF
--- a/kernel/loongarch64/dgemv_n_8_lasx.S
+++ b/kernel/loongarch64/dgemv_n_8_lasx.S
@@ -386,8 +386,11 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #if __loongarch_grlen == 64
     GADD , d, PA0, PA0, K_LDA, PA1, PA1, K_LDA, PA2, PA2, K_LDA, PA3, PA3, K_LDA, \
               PA4, PA4, K_LDA, PA5, PA5, K_LDA, PA6, PA6, K_LDA, PA7, PA7, K_LDA
-#else
+#elif __loongarch_grlen == 32
     GADD , w, PA0, PA0, K_LDA, PA1, PA1, K_LDA, PA2, PA2, K_LDA, PA3, PA3, K_LDA, \
+              PA4, PA4, K_LDA, PA5, PA5, K_LDA, PA6, PA6, K_LDA, PA7, PA7, K_LDA
+#else
+    GADD , d, PA0, PA0, K_LDA, PA1, PA1, K_LDA, PA2, PA2, K_LDA, PA3, PA3, K_LDA, \
               PA4, PA4, K_LDA, PA5, PA5, K_LDA, PA6, PA6, K_LDA, PA7, PA7, K_LDA
 #endif
     PTR_ALSL    X,      INC_X,  X,  3
@@ -435,6 +438,8 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     PTR_SUB     K_LDA,  K_LDA,  M8
 #if __loongarch_grlen == 64
     GADD , d, PA0, PA0, K_LDA, PA1, PA1, K_LDA, PA2, PA2, K_LDA, PA3, PA3, K_LDA
+#elif __loongarch_grlen == 32
+    GADD , w, PA0, PA0, K_LDA, PA1, PA1, K_LDA, PA2, PA2, K_LDA, PA3, PA3, K_LDA
 #else
     GADD , d, PA0, PA0, K_LDA, PA1, PA1, K_LDA, PA2, PA2, K_LDA, PA3, PA3, K_LDA
 #endif
@@ -518,8 +523,11 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #if __loongarch_grlen == 64
     GADD , d, PA1, PA0, LDA, PA2, PA1, LDA, PA3, PA2, LDA, PA4, PA3, LDA, \
               PA5, PA4, LDA, PA6, PA5, LDA, PA7, PA6, LDA
-#else
+#elif __loongarch_grlen == 32
     GADD , w, PA1, PA0, LDA, PA2, PA1, LDA, PA3, PA2, LDA, PA4, PA3, LDA, \
+              PA5, PA4, LDA, PA6, PA5, LDA, PA7, PA6, LDA
+#else
+    GADD , d, PA1, PA0, LDA, PA2, PA1, LDA, PA3, PA2, LDA, PA4, PA3, LDA, \
               PA5, PA4, LDA, PA6, PA5, LDA, PA7, PA6, LDA
 #endif
     la.local    T0,     .L_GAP_TABLE

--- a/kernel/loongarch64/dgemv_t_8_lasx.S
+++ b/kernel/loongarch64/dgemv_t_8_lasx.S
@@ -263,8 +263,11 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #if __loongarch_grlen == 64
     GADDI , d, PA0, PA0, 0x08, PA1, PA1, 0x08, PA2, PA2, 0x08, PA3, PA3, 0x08, \
                PA4, PA4, 0x08, PA5, PA5, 0x08, PA6, PA6, 0x08, PA7, PA7, 0x08
-#else
+#elif __loongarch_grlen == 32
     GADDI , w, PA0, PA0, 0x08, PA1, PA1, 0x08, PA2, PA2, 0x08, PA3, PA3, 0x08, \
+               PA4, PA4, 0x08, PA5, PA5, 0x08, PA6, PA6, 0x08, PA7, PA7, 0x08
+#else
+    GADDI , d, PA0, PA0, 0x08, PA1, PA1, 0x08, PA2, PA2, 0x08, PA3, PA3, 0x08, \
                PA4, PA4, 0x08, PA5, PA5, 0x08, PA6, PA6, 0x08, PA7, PA7, 0x08
 #endif
     GMADD f, d, $f3, $f11, $f1, $f3, $f4, $f12, $f1, $f4, $f5, $f13, $f1, $f5, $f6, $f14, $f1, $f6, \
@@ -292,8 +295,11 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #if __loongarch_grlen == 64
     GADD , d, PA0, PA0, K_LDA, PA1, PA1, K_LDA, PA2, PA2, K_LDA, PA3, PA3, K_LDA, \
               PA4, PA4, K_LDA, PA5, PA5, K_LDA, PA6, PA6, K_LDA, PA7, PA7, K_LDA
-#else
+#elif __loongarch_grlen == 32
     GADD , w, PA0, PA0, K_LDA, PA1, PA1, K_LDA, PA2, PA2, K_LDA, PA3, PA3, K_LDA, \
+              PA4, PA4, K_LDA, PA5, PA5, K_LDA, PA6, PA6, K_LDA, PA7, PA7, K_LDA
+#else
+    GADD , d, PA0, PA0, K_LDA, PA1, PA1, K_LDA, PA2, PA2, K_LDA, PA3, PA3, K_LDA, \
               PA4, PA4, K_LDA, PA5, PA5, K_LDA, PA6, PA6, K_LDA, PA7, PA7, K_LDA
 #endif
     fst.d   $f11,   Y,      0x00
@@ -353,8 +359,10 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #if __loongarch_grlen == 64
     GADD , d, PA0, PA0, K_LDA, PA1, PA1, K_LDA, PA2, PA2, K_LDA, PA3, PA3, K_LDA
-#else
+#elif __loongarch_grlen == 32
     GADD , w, PA0, PA0, K_LDA, PA1, PA1, K_LDA, PA2, PA2, K_LDA, PA3, PA3, K_LDA
+#else
+    GADD , d, PA0, PA0, K_LDA, PA1, PA1, K_LDA, PA2, PA2, K_LDA, PA3, PA3, K_LDA
 #endif
     fst.d   $f11,   Y,      0x00
     fstx.d  $f12,   Y,      INC_Y
@@ -405,8 +413,10 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #if __loongarch_grlen == 64
     GADD , d, PA0, PA0, K_LDA, PA1, PA1, K_LDA
-#else
+#elif __loongarch_grlen == 32
     GADD , w, PA0, PA0, K_LDA, PA1, PA1, K_LDA
+#else
+    GADD , d, PA0, PA0, K_LDA, PA1, PA1, K_LDA
 #endif
     fst.d   $f11,   Y,      0x00
     fstx.d  $f12,   Y,      INC_Y
@@ -446,8 +456,11 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #if __loongarch_grlen == 64
     GADD , d, PA1, PA0, LDA, PA2, PA1, LDA, PA3, PA2, LDA, PA4, PA3, LDA, \
               PA5, PA4, LDA, PA6, PA5, LDA, PA7, PA6, LDA
-#else
+#elif __loongarch_grlen == 32
     GADD , w, PA1, PA0, LDA, PA2, PA1, LDA, PA3, PA2, LDA, PA4, PA3, LDA, \
+              PA5, PA4, LDA, PA6, PA5, LDA, PA7, PA6, LDA
+#else
+    GADD , d, PA1, PA0, LDA, PA2, PA1, LDA, PA3, PA2, LDA, PA4, PA3, LDA, \
               PA5, PA4, LDA, PA6, PA5, LDA, PA7, PA6, LDA
 #endif
     la.local    T0,     .L_GAP_TABLE

--- a/kernel/loongarch64/loongarch64_asm.S
+++ b/kernel/loongarch64/loongarch64_asm.S
@@ -39,7 +39,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define PTR_SRAI  srai.d
 #define PTR_MUL   mul.d
 #define PTR_ALSL  alsl.d
-#else
+#elif __loongarch_grlen == 32
 #define LA_REG    int32_t
 #define REG_SIZE  4
 #define REG_LOG   2
@@ -53,6 +53,22 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define PTR_SRAI  srai.w
 #define PTR_MUL   mul.w
 #define PTR_ALSL  alsl.w
+#else
+// If neither of the above two conditions is supported, it means this is an early
+// internal toolchain. To ensure maximum compatibility, the following approach is taken:
+#define LA_REG    int64_t
+#define REG_SIZE  8
+#define REG_LOG   3
+#define PTR_ADDI  addi.d
+#define PTR_ADD   add.d
+#define PTR_SUB   sub.d
+#define PTR_LD    ld.d
+#define PTR_ST    st.d
+#define PTR_SLLI  slli.d
+#define PTR_SRLI  srli.d
+#define PTR_SRAI  srai.d
+#define PTR_MUL   mul.d
+#define PTR_ALSL  alsl.d
 #endif
 
 #if __loongarch_frlen == 64
@@ -60,11 +76,18 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define FREG_LOG  3
 #define PTR_FLD   fld.d
 #define PTR_FST   fst.d
-#else
+#elif __loongarch_frlen == 32
 #define FREG_SIZE 4
 #define FREG_LOG  2
 #define PTR_FLD   fld.s
 #define PTR_FST   fst.s
+#else
+// If neither of the above two conditions is supported, it means this is an early
+// internal toolchain. To ensure maximum compatibility, the following approach is taken:
+#define FREG_SIZE 8
+#define FREG_LOG  3
+#define PTR_FLD   fld.d
+#define PTR_FST   fst.d
 #endif
 
 // The max registers available to the user which

--- a/kernel/loongarch64/sgemm_kernel_16x8_lasx.S
+++ b/kernel/loongarch64/sgemm_kernel_16x8_lasx.S
@@ -335,8 +335,11 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #if __loongarch_grlen == 64
     GADDI , d, C0, C0, 0x40, C1, C1, 0x40, C2, C2, 0x40, C3, C3, 0x40, \
                C4, C4, 0x40, C5, C5, 0x40, C6, C6, 0x40, C7, C7, 0x40
-#else
+#elif __loongarch_grlen == 32
     GADDI , w, C0, C0, 0x40, C1, C1, 0x40, C2, C2, 0x40, C3, C3, 0x40, \
+               C4, C4, 0x40, C5, C5, 0x40, C6, C6, 0x40, C7, C7, 0x40
+#else
+    GADDI , d, C0, C0, 0x40, C1, C1, 0x40, C2, C2, 0x40, C3, C3, 0x40, \
                C4, C4, 0x40, C5, C5, 0x40, C6, C6, 0x40, C7, C7, 0x40
 #endif
 .endm
@@ -445,8 +448,11 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #if __loongarch_grlen == 64
     GADDI , d, C0, C0, \stride, C1, C1, \stride, C2, C2, \stride, C3, C3, \stride, \
                C4, C4, \stride, C5, C5, \stride, C6, C6, \stride, C7, C7, \stride
-#else
+#elif __loongarch_grlen == 32
     GADDI , w, C0, C0, \stride, C1, C1, \stride, C2, C2, \stride, C3, C3, \stride, \
+               C4, C4, \stride, C5, C5, \stride, C6, C6, \stride, C7, C7, \stride
+#else
+    GADDI , d, C0, C0, \stride, C1, C1, \stride, C2, C2, \stride, C3, C3, \stride, \
                C4, C4, \stride, C5, C5, \stride, C6, C6, \stride, C7, C7, \stride
 #endif
 .endm
@@ -505,8 +511,10 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
               D6,  C3, 0x00, D7,  C3, 0x20
 #if __loongarch_grlen == 64
     GADDI , d, C0, C0, 0x40, C1, C1, 0x40, C2, C2, 0x40, C3, C3, 0x40
-#else
+#elif __loongarch_grlen == 32
     GADDI , w, C0, C0, 0x40, C1, C1, 0x40, C2, C2, 0x40, C3, C3, 0x40
+#else
+    GADDI , d, C0, C0, 0x40, C1, C1, 0x40, C2, C2, 0x40, C3, C3, 0x40
 #endif
 .endm
 
@@ -585,8 +593,10 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 .endif
 #if __loongarch_grlen == 64
     GADDI , d, C0, C0, \stride, C1, C1, \stride, C2, C2, \stride, C3, C3, \stride
-#else
+#elif __loongarch_grlen == 32
     GADDI , w, C0, C0, \stride, C1, C1, \stride, C2, C2, \stride, C3, C3, \stride
+#else
+    GADDI , d, C0, C0, \stride, C1, C1, \stride, C2, C2, \stride, C3, C3, \stride
 #endif
 .endm
 
@@ -631,8 +641,10 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
               D2,  C1, 0x00, D3,  C1, 0x20
 #if __loongarch_grlen == 64
     GADDI , d, C0, C0, 0x40, C1, C1, 0x40
-#else
+#elif __loongarch_grlen == 32
     GADDI , w, C0, C0, 0x40, C1, C1, 0x40
+#else
+    GADDI , d, C0, C0, 0x40, C1, C1, 0x40
 #endif
 .endm
 
@@ -703,8 +715,10 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 .endif
 #if __loongarch_grlen == 64
     GADDI , d, C0, C0, \stride, C1, C1, \stride
-#else
+#elif __loongarch_grlen == 32
     GADDI , w, C0, C0, \stride, C1, C1, \stride
+#else
+    GADDI , d, C0, C0, \stride, C1, C1, \stride
 #endif
 .endm
 
@@ -741,8 +755,10 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     GST xv, , D0,  C0, 0x00, D1,  C0, 0x20
 #if __loongarch_grlen == 64
     GADDI , d, C0, C0, 0x40
-#else
+#elif __loongarch_grlen == 32
     GADDI , w, C0, C0, 0x40
+#else
+    GADDI , d, C0, C0, 0x40
 #endif
 .endm
 
@@ -813,8 +829,10 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 .endif
 #if __loongarch_grlen == 64
     GADDI , d, C0, C0, \stride
-#else
+#elif __loongarch_grlen == 32
     GADDI , w, C0, C0, \stride
+#else
+    GADDI , d, C0, C0, \stride
 #endif
 .endm
 
@@ -838,8 +856,11 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #if __loongarch_grlen == 64
     GADD , d, C1, C0, T0, C2, C1, T0, C3, C2, T0, C4, C3, T0, C5, C4, T0, \
               C6, C5, T0, C7, C6, T0
-#else
+#elif __loongarch_grlen == 32
     GADD , w, C1, C0, T0, C2, C1, T0, C3, C2, T0, C4, C3, T0, C5, C4, T0, \
+              C6, C5, T0, C7, C6, T0
+#else
+    GADD , d, C1, C0, T0, C2, C1, T0, C3, C2, T0, C4, C3, T0, C5, C4, T0, \
               C6, C5, T0, C7, C6, T0
 #endif
 #if defined(TRMMKERNEL) && defined(LEFT)
@@ -1222,8 +1243,10 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     PTR_SLLI   T0,    LDC,   2
 #if __loongarch_grlen == 64
     GADD , d, C1, C0, T0, C2, C1, T0, C3, C2, T0
-#else
+#elif __loongarch_grlen == 32
     GADD , w, C1, C0, T0, C2, C1, T0, C3, C2, T0
+#else
+    GADD , d, C1, C0, T0, C2, C1, T0, C3, C2, T0
 #endif
 
 #if defined(TRMMKERNEL) && defined(LEFT)


### PR DESCRIPTION
__loongarch_grlen and __loongarch_frlen were introduced in gcc version 8.3.0 (Loongnix 8.3.0-6.lnd.vec.31) internally within Loongson to standardize the general and floating-point register widths. However, previous versions did not have them, requiring additional checks to be added.