### PR TITLE
Fix division by zero in [z]rotg

### DIFF
--- a/interface/rotg.c
+++ b/interface/rotg.c
@@ -66,13 +66,8 @@ void CNAME(FLOAT *DA, FLOAT *DB, FLOAT *C, FLOAT *S){
     c = da / r;
     s = db / r;
     z = ONE;
-    if (da != ZERO) {
-      if (ada > adb){
-	z = s;
-      } else {
-	z = ONE / c;
-      }
-    }
+    if (ada > adb) z = s;
+    if ((ada <= adb) && (c != ZERO)) z = ONE / c;
 
     *C = c;
     *S = s;

--- a/interface/zrotg.c
+++ b/interface/zrotg.c
@@ -61,16 +61,16 @@ void CNAME(void *VDA, void *VDB, FLOAT *C, void *VS) {
 		*(S1 + 0) = *(DB + 0);
 		*(S1 + 1) = *(DB + 1) *-1;
 	if (da_r == ZERO && da_i == ZERO) {
-	    *C = ZERO;	  
+	    *C = ZERO;
 	    if (db_r == ZERO) {
 		    (*DA) = fabsl(db_i);
-		*S = *S1 /da_r;
-		*(S+1) = *(S1+1) /da_r;
+		*S = *S1 /(*DA);
+		*(S+1) = *(S1+1) /(*DA);
 		return;
 	    } else if ( db_i == ZERO) {
 		    *DA = fabsl(db_r);
-		*S = *S1 /da_r;
-		*(S+1) = *(S1+1) /da_r;
+		*S = *S1 /(*DA);
+		*(S+1) = *(S1+1) /(*DA);
 		return;
 	    } else {
 	        long double g1 = MAX( fabsl(db_r), fabsl(db_i));


### PR DESCRIPTION
<details>
<summary> Fix division by zero.</summary>

With that `if` condition, the division by `da_r` corresponds to a division by zero.
https://github.com/OpenMathLib/OpenBLAS/blob/bb2f1ec3b01d76c44017bb65cdbf03b05e644cb4/interface/zrotg.c#L63-L68

Fixed to such that `S = conjg(db)/|db|`
</details>

<details>
<summary>  Remove redundant branch. </summary>

With the algorithm change in reference LAPACK, the case `da == ZERO` is a special branch.
https://github.com/OpenMathLib/OpenBLAS/blob/bb2f1ec3b01d76c44017bb65cdbf03b05e644cb4/interface/rotg.c#L34
https://github.com/OpenMathLib/OpenBLAS/blob/bb2f1ec3b01d76c44017bb65cdbf03b05e644cb4/interface/rotg.c#L51-L56
Consequently, there is no longer the need to check. 
https://github.com/OpenMathLib/OpenBLAS/blob/bb2f1ec3b01d76c44017bb65cdbf03b05e644cb4/interface/rotg.c#L69
The commit removes the branch.
</details>

<details>
<summary>Add missing check for zero. </summary>

https://github.com/OpenMathLib/OpenBLAS/blob/bb2f1ec3b01d76c44017bb65cdbf03b05e644cb4/interface/rotg.c#L72-L73
does not have a check `c != 0` in the long double code. The float/double version does have this check. The new code is essentially identical to the float/double version

</details>