### PR TITLE
powerpc: Fix build errors with xlf

### DIFF
--- a/Makefile.power
+++ b/Makefile.power
@@ -70,7 +70,11 @@ else
 FCOMMON_OPT += -O1 -frecursive -mcpu=power8 -mtune=power8  -fno-fast-math 
 endif
 else
+ifeq ($(F_COMPILER), IBM)
+FCOMMON_OPT += -O2 -qrecur -qnosave
+else
 FCOMMON_OPT += -O2 -frecursive -mcpu=power8 -mtune=power8  -fno-fast-math 
+endif
 endif
 else
 FCOMMON_OPT += -O2 -Mrecursive

--- a/Makefile.system
+++ b/Makefile.system
@@ -1168,7 +1168,7 @@ endif
 ifeq ($(F_COMPILER), IBM)
 CCOMMON_OPT += -DF_INTERFACE_IBM
 FEXTRALIB += -lxlf90
-ifeq ($(C_COMPILER), GCC)
+ifeq ($(C_COMPILER), $(filter $(C_COMPILER),GCC CLANG))
 FCOMMON_OPT += -qextname
 endif
 # FCOMMON_OPT	+= -qarch=440

--- a/f_check
+++ b/f_check
@@ -117,6 +117,9 @@ else
                             vendor=PGI
                             openmp='-mp'
                             ;;
+                        *xlf*)
+                            vendor=IBM
+                            ;;
                         *)
                             vendor=G77
                             openmp=''


### PR DESCRIPTION
This patch fixes errors when using xlf as fortran compiler on Linux.
Tested with gcc/xlf and clang/xlf compiler combinations.