### PR TITLE
Improve function prototypes to fix strict-prototype warnings

### DIFF
--- a/common_thread.h
+++ b/common_thread.h
@@ -141,14 +141,14 @@ static __inline int num_cpu_avail(int level) {
 
 #ifdef USE_OPENMP
 int openmp_nthreads;
-	openmp_nthreads=omp_get_max_threads();
+	openmp_nthreads=omp_get_max_threads(void);
 #endif
 
 #ifndef USE_OPENMP 
   if (blas_cpu_number == 1
 #endif
 #ifdef USE_OPENMP
-     if (openmp_nthreads == 1 || omp_in_parallel()
+     if (openmp_nthreads == 1 || omp_in_parallel(void)
 #endif
       ) return 1;        
 
@@ -192,27 +192,27 @@ int exec_blas(BLASLONG num_cpu, blas_param_t *param, void *buffer);
 int blas_level1_thread(int mode, BLASLONG m, BLASLONG n, BLASLONG k, void *alpha,
 		       void *a, BLASLONG lda,
 		       void *b, BLASLONG ldb,
-		       void *c, BLASLONG ldc, int (*function)(), int threads);
+		       void *c, BLASLONG ldc, int (*function)(void), int threads);
 
-int gemm_thread_m (int mode, blas_arg_t *, BLASLONG *, BLASLONG *, int (*function)(), void *, void *, BLASLONG);
+int gemm_thread_m (int mode, blas_arg_t *, BLASLONG *, BLASLONG *, int (*function)(blas_arg_t*, BLASLONG*, BLASLONG*,FLOAT *, FLOAT *, BLASLONG ), void *, void *, BLASLONG);
 
-int gemm_thread_n (int mode, blas_arg_t *, BLASLONG *, BLASLONG *, int (*function)(), void *, void *, BLASLONG);
+int gemm_thread_n (int mode, blas_arg_t *, BLASLONG *, BLASLONG *, int (*function)(blas_arg_t*, BLASLONG*, BLASLONG*,FLOAT*, FLOAT*, BLASLONG), void *, void *, BLASLONG);
 
-int gemm_thread_mn(int mode, blas_arg_t *, BLASLONG *, BLASLONG *, int (*function)(), void *, void *, BLASLONG);
+int gemm_thread_mn(int mode, blas_arg_t *, BLASLONG *, BLASLONG *, int (*function)(blas_arg_t*, BLASLONG*, BLASLONG*,FLOAT *, FLOAT *, BLASLONG), void *, void *, BLASLONG);
 
-int gemm_thread_variable(int mode, blas_arg_t *, BLASLONG *, BLASLONG *, int (*function)(), void *, void *, BLASLONG, BLASLONG);
+int gemm_thread_variable(int mode, blas_arg_t *, BLASLONG *, BLASLONG *, int (*function)(blas_arg_t*, BLASLONG*, BLASLONG*,FLOAT *, FLOAT *, BLASLONG), void *, void *, BLASLONG, BLASLONG);
 
 int trsm_thread(int mode, BLASLONG m, BLASLONG n,
 		double alpha_r, double alpha_i,
 		void *a, BLASLONG lda,
-		void *c, BLASLONG ldc, int (*function)(), void *buffer);
+		void *c, BLASLONG ldc, int (*function)(void), void *buffer);
 
-int syrk_thread(int mode, blas_arg_t *, BLASLONG *, BLASLONG *, int (*function)(), void *, void *, BLASLONG);
+int syrk_thread(int mode, blas_arg_t *, BLASLONG *, BLASLONG *, int (*function)(blas_arg_t*, BLASLONG*, BLASLONG*, FLOAT *, FLOAT *, BLASLONG), void*, void*, BLASLONG);
 
 int getrf_thread(int mode, BLASLONG m, BLASLONG n, BLASLONG k,
 		 void *offsetA, BLASLONG lda,
 		 void *offsetB, BLASLONG jb,
-		 void *ipiv, BLASLONG offset, int (*function)(), void *buffer);
+		 void *ipiv, BLASLONG offset, int (*function)(void), void *buffer);
 
 #endif  /* ENDIF ASSEMBLER */
 

--- a/common_thread.h
+++ b/common_thread.h
@@ -141,14 +141,14 @@ static __inline int num_cpu_avail(int level) {
 
 #ifdef USE_OPENMP
 int openmp_nthreads;
-	openmp_nthreads=omp_get_max_threads(void);
+	openmp_nthreads=omp_get_max_threads();
 #endif
 
 #ifndef USE_OPENMP 
   if (blas_cpu_number == 1
 #endif
 #ifdef USE_OPENMP
-     if (openmp_nthreads == 1 || omp_in_parallel(void)
+     if (openmp_nthreads == 1 || omp_in_parallel()
 #endif
       ) return 1;        
 

--- a/cpuid_x86.c
+++ b/cpuid_x86.c
@@ -194,7 +194,7 @@ static C_INLINE void xgetbv(int op, int * eax, int * edx){
 }
 #endif
 
-int support_avx(){
+int support_avx(void){
 #ifndef NO_AVX
   int eax, ebx, ecx, edx;
   int ret=0;
@@ -212,7 +212,7 @@ int support_avx(){
 #endif
 }
 
-int support_avx2(){
+int support_avx2(void){
 #ifndef NO_AVX2
   int eax, ebx, ecx=0, edx;
   int ret=0;
@@ -228,7 +228,7 @@ int support_avx2(){
 #endif
 }
 
-int support_avx512(){
+int support_avx512(void){
 #if !defined(NO_AVX) && !defined(NO_AVX512)
   int eax, ebx, ecx, edx;
   int ret=0;
@@ -250,7 +250,7 @@ int support_avx512(){
 #endif
 }
 
-int support_avx512_bf16(){
+int support_avx512_bf16(void){
 #if !defined(NO_AVX) && !defined(NO_AVX512)
   int eax, ebx, ecx, edx;
   int ret=0;
@@ -271,7 +271,7 @@ int support_avx512_bf16(){
 #define BIT_AMX_BF16	0x00400000
 #define BIT_AMX_ENBD	0x00060000
 
-int support_amx_bf16() {
+int support_amx_bf16(void) {
 #if !defined(NO_AVX) && !defined(NO_AVX512)
   int eax, ebx, ecx, edx;
   int ret=0;

--- a/driver/level3/gemm_thread_m.c
+++ b/driver/level3/gemm_thread_m.c
@@ -40,7 +40,7 @@
 #include <stdlib.h>
 #include "common.h"
 
-int CNAME(int mode, blas_arg_t *arg, BLASLONG *range_m, BLASLONG *range_n, int (*function)(), void *sa, void *sb, BLASLONG nthreads) {
+int CNAME(int mode, blas_arg_t *arg, BLASLONG *range_m, BLASLONG *range_n, int (*function)(blas_arg_t*, BLASLONG*, BLASLONG*,FLOAT *, FLOAT *, BLASLONG ), void *sa, void *sb, BLASLONG nthreads) {
 
   blas_queue_t queue[MAX_CPU_NUMBER];
   BLASLONG range[MAX_CPU_NUMBER + 1];

--- a/driver/level3/gemm_thread_mn.c
+++ b/driver/level3/gemm_thread_mn.c
@@ -60,7 +60,7 @@ static const int divide_rule[][2] =
    { 1, 61}, { 2, 31}, { 7,  9}, { 8,  8},
 };
 
-int CNAME(int mode, blas_arg_t *arg, BLASLONG *range_m, BLASLONG *range_n, int (*function)(), void *sa, void *sb, BLASLONG nthreads) {
+int CNAME(int mode, blas_arg_t *arg, BLASLONG *range_m, BLASLONG *range_n, int (*function)(blas_arg_t*, BLASLONG*, BLASLONG*,FLOAT *, FLOAT *, BLASLONG ), void *sa, void *sb, BLASLONG nthreads) {
 
   blas_queue_t queue[MAX_CPU_NUMBER];
 

--- a/driver/level3/gemm_thread_n.c
+++ b/driver/level3/gemm_thread_n.c
@@ -40,7 +40,7 @@
 #include <stdlib.h>
 #include "common.h"
 
-int CNAME(int mode, blas_arg_t *arg, BLASLONG *range_m, BLASLONG *range_n, int (*function)(), void *sa, void *sb, BLASLONG nthreads) {
+int CNAME(int mode, blas_arg_t *arg, BLASLONG *range_m, BLASLONG *range_n, int (*function)(blas_arg_t*, BLASLONG*, BLASLONG*,FLOAT *, FLOAT *, BLASLONG), void *sa, void *sb, BLASLONG nthreads) {
 
   blas_queue_t queue[MAX_CPU_NUMBER];
   BLASLONG range[MAX_CPU_NUMBER + 1];

--- a/driver/level3/gemm_thread_variable.c
+++ b/driver/level3/gemm_thread_variable.c
@@ -42,7 +42,7 @@
 
 int CNAME(int mode,
 	  blas_arg_t *arg, BLASLONG *range_m, BLASLONG *range_n,
-	  int (*function)(), void *sa, void *sb, BLASLONG divM, BLASLONG divN) {
+	  int (*function)(blas_arg_t*, BLASLONG*, BLASLONG*,FLOAT *, FLOAT *, BLASLONG ), void *sa, void *sb, BLASLONG divM, BLASLONG divN) {
 
   blas_queue_t queue[MAX_CPU_NUMBER];
 

--- a/driver/level3/syrk_thread.c
+++ b/driver/level3/syrk_thread.c
@@ -41,7 +41,7 @@
 #include <math.h>
 #include "common.h"
 
-int CNAME(int mode, blas_arg_t *arg, BLASLONG *range_m, BLASLONG *range_n, int (*function)(), void *sa, void *sb, BLASLONG nthreads) {
+int CNAME(int mode, blas_arg_t *arg, BLASLONG *range_m, BLASLONG *range_n, int (*function)(blas_arg_t*, BLASLONG*, BLASLONG*, FLOAT *, FLOAT *, BLASLONG), void *sa, void *sb, BLASLONG nthreads) {
 
   blas_queue_t queue[MAX_CPU_NUMBER];
   BLASLONG range[MAX_CPU_NUMBER + 1];

--- a/driver/others/blas_l1_thread.c
+++ b/driver/others/blas_l1_thread.c
@@ -43,7 +43,7 @@
 int blas_level1_thread(int mode, BLASLONG m, BLASLONG n, BLASLONG k, void *alpha,
 		       void *a, BLASLONG lda,
 		       void *b, BLASLONG ldb,
-		       void *c, BLASLONG ldc, int (*function)(), int nthreads){
+		       void *c, BLASLONG ldc, int (*function)(void), int nthreads){
 
   blas_queue_t queue[MAX_CPU_NUMBER];
   blas_arg_t   args [MAX_CPU_NUMBER];
@@ -141,7 +141,7 @@ int blas_level1_thread(int mode, BLASLONG m, BLASLONG n, BLASLONG k, void *alpha
 int blas_level1_thread_with_return_value(int mode, BLASLONG m, BLASLONG n, BLASLONG k, void *alpha,
 		       void *a, BLASLONG lda,
 		       void *b, BLASLONG ldb,
-		       void *c, BLASLONG ldc, int (*function)(), int nthreads){
+		       void *c, BLASLONG ldc, int (*function)(void), int nthreads){
 
   blas_queue_t queue[MAX_CPU_NUMBER];
   blas_arg_t   args [MAX_CPU_NUMBER];

--- a/driver/others/blas_server.c
+++ b/driver/others/blas_server.c
@@ -93,7 +93,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endif
 #endif
 
-extern unsigned int openblas_thread_timeout();
+extern unsigned int openblas_thread_timeout(void);
 
 #ifdef SMP_SERVER
 

--- a/driver/others/blas_server_omp.c
+++ b/driver/others/blas_server_omp.c
@@ -70,7 +70,7 @@
 int blas_server_avail = 0;
 int blas_omp_number_max = 0;
 
-extern int openblas_omp_adaptive_env();
+extern int openblas_omp_adaptive_env(void);
 
 static void * blas_thread_buffer[MAX_PARALLEL_NUMBER][MAX_CPU_NUMBER];
 #ifdef HAVE_C11
@@ -79,7 +79,7 @@ static atomic_bool blas_buffer_inuse[MAX_PARALLEL_NUMBER];
 static _Bool blas_buffer_inuse[MAX_PARALLEL_NUMBER];
 #endif
 
-static void adjust_thread_buffers() {
+static void adjust_thread_buffers(void) {
 
   int i=0, j=0;
 
@@ -124,9 +124,9 @@ void openblas_set_num_threads(int num_threads) {
 }
 
 int blas_thread_init(void){
-if(blas_omp_number_max <= 0)
-  blas_omp_number_max = omp_get_max_threads();
-
+  if(blas_omp_number_max <= 0)
+    blas_omp_number_max = omp_get_max_threads();
+	
   blas_get_cpu_number();
 
   adjust_thread_buffers();

--- a/driver/others/memory.c
+++ b/driver/others/memory.c
@@ -1999,7 +1999,7 @@ int  goto_get_num_procs  (void) {
   return blas_cpu_number;
 }
 
-void openblas_fork_handler()
+void openblas_fork_handler(void)
 {
   // This handler shuts down the OpenBLAS-managed PTHREAD pool when OpenBLAS is
   // built with "make USE_OPENMP=0".
@@ -2016,9 +2016,9 @@ void openblas_fork_handler()
 #endif
 }
 
-extern int openblas_num_threads_env();
-extern int openblas_goto_num_threads_env();
-extern int openblas_omp_num_threads_env();
+extern int openblas_num_threads_env(void);
+extern int openblas_goto_num_threads_env(void);
+extern int openblas_omp_num_threads_env(void);
 
 int blas_get_cpu_number(void){
 #if defined(OS_LINUX) || defined(OS_WINDOWS) || defined(OS_FREEBSD) || defined(OS_OPENBSD) || defined(OS_NETBSD) || defined(OS_DRAGONFLY) || defined(OS_DARWIN) || defined(OS_ANDROID) || defined(OS_HAIKU)
@@ -3339,7 +3339,7 @@ static void gotoblas_memory_init(void) {
 /* Initialization for all function; this function should be called before main */
 
 static int gotoblas_initialized = 0;
-extern void openblas_read_env();
+extern void openblas_read_env(void);
 
 void CONSTRUCTOR gotoblas_init(void) {
 

--- a/driver/others/memory.c
+++ b/driver/others/memory.c
@@ -427,9 +427,9 @@ int  goto_get_num_procs  (void) {
   return blas_cpu_number;
 }
 
-static void blas_memory_init();
+static void blas_memory_init(void);
 
-void openblas_fork_handler()
+void openblas_fork_handler(void)
 {
   // This handler shuts down the OpenBLAS-managed PTHREAD pool when OpenBLAS is
   // built with "make USE_OPENMP=0".
@@ -446,9 +446,9 @@ void openblas_fork_handler()
 #endif
 }
 
-extern int openblas_num_threads_env();
-extern int openblas_goto_num_threads_env();
-extern int openblas_omp_num_threads_env();
+extern int openblas_num_threads_env(void);
+extern int openblas_goto_num_threads_env(void);
+extern int openblas_omp_num_threads_env(void);
 
 int blas_get_cpu_number(void){
 #if defined(OS_LINUX) || defined(OS_WINDOWS) || defined(OS_FREEBSD) || defined(OS_OPENBSD) || defined(OS_NETBSD) || defined(OS_DRAGONFLY) || defined(OS_DARWIN) || defined(OS_ANDROID) || defined(OS_HAIKU)
@@ -592,7 +592,7 @@ static BLASULONG  key_lock = 0UL;
 #endif
 
 /* Returns a pointer to the start of the per-thread memory allocation data */
-static __inline struct alloc_t ** get_memory_table() {
+static __inline struct alloc_t ** get_memory_table(void) {
 #if defined(SMP)
 LOCK_COMMAND(&key_lock);
 lsk=local_storage_key;
@@ -1145,7 +1145,7 @@ static void blas_memory_cleanup(void* ptr){
   }
 }
 
-static void blas_memory_init(){
+static void blas_memory_init(void){
 #if defined(SMP)
 #  if defined(OS_WINDOWS)
   local_storage_key = TlsAlloc();
@@ -1502,7 +1502,7 @@ static void gotoblas_memory_init(void) {
 /* Initialization for all function; this function should be called before main */
 
 static int gotoblas_initialized = 0;
-extern void openblas_read_env();
+extern void openblas_read_env(void);
 
 void CONSTRUCTOR gotoblas_init(void) {
 

--- a/driver/others/openblas_env.c
+++ b/driver/others/openblas_env.c
@@ -41,15 +41,15 @@ static int openblas_env_goto_num_threads=0;
 static int openblas_env_omp_num_threads=0;
 static int openblas_env_omp_adaptive=0;
 
-int openblas_verbose() { return openblas_env_verbose;}
-unsigned int openblas_thread_timeout() { return openblas_env_thread_timeout;}
-int openblas_block_factor() { return openblas_env_block_factor;}
-int openblas_num_threads_env() { return openblas_env_openblas_num_threads;}
-int openblas_goto_num_threads_env() { return openblas_env_goto_num_threads;}
-int openblas_omp_num_threads_env() { return openblas_env_omp_num_threads;}
-int openblas_omp_adaptive_env() { return openblas_env_omp_adaptive;}
+int openblas_verbose(void) { return openblas_env_verbose;}
+unsigned int openblas_thread_timeout(void) { return openblas_env_thread_timeout;}
+int openblas_block_factor(void) { return openblas_env_block_factor;}
+int openblas_num_threads_env(void) { return openblas_env_openblas_num_threads;}
+int openblas_goto_num_threads_env(void) { return openblas_env_goto_num_threads;}
+int openblas_omp_num_threads_env(void) { return openblas_env_omp_num_threads;}
+int openblas_omp_adaptive_env(void) { return openblas_env_omp_adaptive;}
 
-void openblas_read_env() {
+void openblas_read_env(void) {
   int ret=0;
   env_var_t p;
   if (readenv(p,"OPENBLAS_VERBOSE")) ret = atoi(p);

--- a/driver/others/openblas_error_handle.c
+++ b/driver/others/openblas_error_handle.c
@@ -33,7 +33,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "common.h"
 
-extern int openblas_verbose();
+extern int openblas_verbose(void);
 
 void openblas_warning(int verbose, const char * msg) {
   int current_verbose;

--- a/driver/others/openblas_get_config.c
+++ b/driver/others/openblas_get_config.c
@@ -69,13 +69,13 @@ static char* openblas_config_str=""
   ;
 
 #ifdef DYNAMIC_ARCH
-char *gotoblas_corename();
+char *gotoblas_corename(void);
 #endif
 
 static char tmp_config_str[256];
-int openblas_get_parallel();
+int openblas_get_parallel(void);
 
-char* CNAME() {
+char* CNAME(void) {
 char tmpstr[20];
   strcpy(tmp_config_str, openblas_config_str);
 #ifdef DYNAMIC_ARCH
@@ -90,7 +90,7 @@ char tmpstr[20];
 }
 
 
-char* openblas_get_corename() {
+char* openblas_get_corename(void) {
 #ifndef DYNAMIC_ARCH 
   return CHAR_CORENAME;
 #else

--- a/driver/others/openblas_get_parallel.c
+++ b/driver/others/openblas_get_parallel.c
@@ -42,17 +42,17 @@ static int parallel = 0;
 
 
 #ifdef NEEDBUNDERSCORE
-int CNAME() {
+int CNAME(void) {
   return parallel;
 }
 
-int NAME() {
+int NAME(void) {
   return parallel;
 }
 
 #else
 //The CNAME and NAME are the same.
-int NAME() {
+int NAME(void) {
   return parallel;
 }
 #endif

--- a/driver/others/parameter.c
+++ b/driver/others/parameter.c
@@ -40,7 +40,7 @@
 #include <string.h>
 #include "common.h"
 
-extern int openblas_block_factor();
+extern int openblas_block_factor(void);
 int get_L2_size(void);
 
 #define DEFAULT_GEMM_P 128

--- a/interface/lapack/laswp.c
+++ b/interface/lapack/laswp.c
@@ -97,7 +97,7 @@ int NAME(blasint *N, FLOAT *a, blasint *LDA, blasint *K1, blasint *K2, blasint *
 
   blas_level1_thread(mode, n, k1, k2, dummyalpha,
 		     a, lda, NULL, 0, ipiv, incx,
-		     (int(*)())laswp[flag], nthreads);
+		     (int(*)(void))laswp[flag], nthreads);
   }
 #endif
 

--- a/interface/lapack/zlaswp.c
+++ b/interface/lapack/zlaswp.c
@@ -96,7 +96,7 @@ int NAME(blasint *N, FLOAT *a, blasint *LDA, blasint *K1, blasint *K2, blasint *
   mode  =  BLAS_SINGLE  | BLAS_COMPLEX;
 #endif
 
-  blas_level1_thread(mode, n, k1, k2, dummyalpha, a, lda, NULL, 0, ipiv, incx, (int(*)())laswp[flag], nthreads);
+  blas_level1_thread(mode, n, k1, k2, dummyalpha, a, lda, NULL, 0, ipiv, incx, (int(*)(void))laswp[flag], nthreads);
   }
 #endif
 

--- a/kernel/x86_64/ddot.c
+++ b/kernel/x86_64/ddot.c
@@ -159,7 +159,7 @@ static int dot_thread_function(BLASLONG n, BLASLONG dummy0,
 
 extern int blas_level1_thread_with_return_value(int mode, BLASLONG m, BLASLONG n,
         BLASLONG k, void *alpha, void *a, BLASLONG lda, void *b, BLASLONG ldb,
-        void *c, BLASLONG ldc, int (*function)(), int nthreads);
+        void *c, BLASLONG ldc, int (*function)(void), int nthreads);
 #endif
 
 FLOAT CNAME(BLASLONG n, FLOAT *x, BLASLONG inc_x, FLOAT *y, BLASLONG inc_y)

--- a/kernel/x86_64/drot.c
+++ b/kernel/x86_64/drot.c
@@ -169,7 +169,7 @@ static int rot_thread_function(blas_arg_t *args)
     return 0;
 }
 
-extern int blas_level1_thread(int mode, BLASLONG m, BLASLONG n, BLASLONG k, void *alpha, void *a, BLASLONG lda, void *b, BLASLONG ldb, void *c, BLASLONG ldc, int (*function)(), int nthreads);
+extern int blas_level1_thread(int mode, BLASLONG m, BLASLONG n, BLASLONG k, void *alpha, void *a, BLASLONG lda, void *b, BLASLONG ldb, void *c, BLASLONG ldc, int (*function)(void), int nthreads);
 #endif
 int CNAME(BLASLONG n, FLOAT *x, BLASLONG inc_x, FLOAT *y, BLASLONG inc_y, FLOAT c, FLOAT s)
 {

--- a/kernel/x86_64/srot.c
+++ b/kernel/x86_64/srot.c
@@ -171,7 +171,7 @@ static int rot_thread_function(blas_arg_t *args)
     return 0;
 }
 
-extern int blas_level1_thread(int mode, BLASLONG m, BLASLONG n, BLASLONG k, void *alpha, void *a, BLASLONG lda, void *b, BLASLONG ldb, void *c, BLASLONG ldc, int (*function)(), int nthreads);
+extern int blas_level1_thread(int mode, BLASLONG m, BLASLONG n, BLASLONG k, void *alpha, void *a, BLASLONG lda, void *b, BLASLONG ldb, void *c, BLASLONG ldc, int (*function)(void), int nthreads);
 #endif
 int CNAME(BLASLONG n, FLOAT *x, BLASLONG inc_x, FLOAT *y, BLASLONG inc_y, FLOAT c, FLOAT s)
 {

--- a/kernel/x86_64/zdot.c
+++ b/kernel/x86_64/zdot.c
@@ -92,7 +92,7 @@ static void zdot_kernel_8(BLASLONG n, FLOAT *x, FLOAT *y, FLOAT *d)
 #if defined(SMP)
 extern int blas_level1_thread_with_return_value(int mode, BLASLONG m, BLASLONG n,
         BLASLONG k, void *alpha, void *a, BLASLONG lda, void *b, BLASLONG ldb,
-        void *c, BLASLONG ldc, int (*function)(), int nthreads);
+        void *c, BLASLONG ldc, int (*function)(void), int nthreads);
 #endif
                 
                 

--- a/lapack-netlib/LAPACKE/src/lapacke_nancheck.c
+++ b/lapack-netlib/LAPACKE/src/lapacke_nancheck.c
@@ -39,7 +39,7 @@ void LAPACKE_set_nancheck( int flag )
     nancheck_flag = ( flag ) ? 1 : 0;
 }
 
-int LAPACKE_get_nancheck( )
+int LAPACKE_get_nancheck( void )
 {
     char* env;
     if ( nancheck_flag != -1 ) {

--- a/lapack/lauum/lauum_L_parallel.c
+++ b/lapack/lauum/lauum_L_parallel.c
@@ -102,7 +102,7 @@ blasint CNAME(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, FLOAT *sa,
     newarg.c = a;
 
     syrk_thread(mode | BLAS_TRANSA_T | BLAS_TRANSB_N | BLAS_UPLO,
-		&newarg, NULL, NULL, (int (*)(void))HERK_LC, sa, sb, args -> nthreads);
+		&newarg, NULL, NULL, (int (*)(blas_arg_t *, BLASLONG *, BLASLONG *, FLOAT *, FLOAT *, BLASLONG))HERK_LC, sa, sb, args -> nthreads);
 
     newarg.m = bk;
     newarg.n = i;
@@ -110,7 +110,7 @@ blasint CNAME(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, FLOAT *sa,
     newarg.b = a + (i          ) * COMPSIZE;
 
     gemm_thread_n(mode | BLAS_TRANSA_T,
-		  &newarg, NULL, NULL, (int (*)(void))TRMM_LCLN, sa, sb, args -> nthreads);
+		  &newarg, NULL, NULL, (int (*)(blas_arg_t*, BLASLONG*, BLASLONG*,FLOAT*, FLOAT*, BLASLONG))TRMM_LCLN, sa, sb, args -> nthreads);
 
     newarg.m = bk;
     newarg.n = bk;

--- a/lapack/lauum/lauum_U_parallel.c
+++ b/lapack/lauum/lauum_U_parallel.c
@@ -102,7 +102,7 @@ blasint CNAME(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, FLOAT *sa,
     newarg.c = a;
 
     syrk_thread(mode | BLAS_TRANSA_N | BLAS_TRANSB_T,
-		&newarg, NULL, NULL, (int (*)(void))HERK_UN, sa, sb, args -> nthreads);
+		&newarg, NULL, NULL, (int (*)(blas_arg_t *, BLASLONG *, BLASLONG *, FLOAT *, FLOAT *, BLASLONG))HERK_UN, sa, sb, args -> nthreads);
 
     newarg.m = i;
     newarg.n = bk;
@@ -110,7 +110,7 @@ blasint CNAME(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, FLOAT *sa,
     newarg.b = a + (    i * lda) * COMPSIZE;
 
     gemm_thread_m(mode | BLAS_TRANSA_T | BLAS_RSIDE,
-		  &newarg, NULL, NULL, (int (*)(void))TRMM_RCUN, sa, sb, args -> nthreads);
+		  &newarg, NULL, NULL, (int (*)(blas_arg_t*, BLASLONG*, BLASLONG*,FLOAT*, FLOAT*, BLASLONG))TRMM_RCUN, sa, sb, args -> nthreads);
 
     newarg.m = bk;
     newarg.n = bk;

--- a/lapack/potrf/potrf_L_parallel.c
+++ b/lapack/potrf/potrf_L_parallel.c
@@ -110,7 +110,7 @@ blasint CNAME(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, FLOAT *sa,
       newarg.b = a + (i + bk + i * lda) * COMPSIZE;
 
       gemm_thread_m(mode | BLAS_RSIDE | BLAS_TRANSA_T | BLAS_UPLO,
-		    &newarg, NULL, NULL, (int (*)(void))TRSM_RCLN, sa, sb, args -> nthreads);
+		    &newarg, NULL, NULL, (int (*)(blas_arg_t *, BLASLONG *, BLASLONG *, FLOAT *, FLOAT *, BLASLONG))TRSM_RCLN, sa, sb, args -> nthreads);
 
       newarg.n = n - i - bk;
       newarg.k = bk;

--- a/lapack/potrf/potrf_U_parallel.c
+++ b/lapack/potrf/potrf_U_parallel.c
@@ -110,7 +110,7 @@ blasint CNAME(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, FLOAT *sa,
       newarg.b = a + (i + (i + bk) * lda) * COMPSIZE;
 
       gemm_thread_n(mode | BLAS_TRANSA_T,
-		    &newarg, NULL, NULL, (int (*)(void))TRSM_LCUN, sa, sb, args -> nthreads);
+		    &newarg, NULL, NULL, (int (*)(blas_arg_t *, BLASLONG *, BLASLONG *, FLOAT *, FLOAT *, BLASLONG))TRSM_LCUN, sa, sb, args -> nthreads);
 
       newarg.n = n - i - bk;
       newarg.k = bk;

--- a/utest/ctest.h
+++ b/utest/ctest.h
@@ -41,7 +41,7 @@ typedef void (*RunWithDataFunc)(void*);
 struct ctest {
     const char* ssname;  // suite name
     const char* ttname;  // test name
-    void (*run)();
+    void (*run)(void);
     int skip;
 
     void* data;
@@ -159,9 +159,9 @@ struct ctest {
     void WEAK sname##_teardown(struct sname##_data* data)
 
 #define __CTEST_INTERNAL(sname, tname, _skip) \
-    void __FNAME(sname, tname)(); \
+    void __FNAME(sname, tname)(void); \
     __CTEST_STRUCT(sname, tname, _skip, NULL, NULL, NULL) \
-    void __FNAME(sname, tname)()
+    void __FNAME(sname, tname)(void)
 
 #ifdef __CTEST_APPLE
 #define SETUP_FNAME(sname) NULL
@@ -366,7 +366,7 @@ void __ctest_addTest(struct ctest *test)
 #ifndef __CTEST_MSVC
 /* Add all tests to linked list automatically.
  */
-static void __ctest_linkTests()
+static void __ctest_linkTests(void)
 {
     struct ctest ** test;
     struct ctest ** ctest_begin = (struct ctest **)__PNAME(suite, test);
@@ -401,7 +401,7 @@ static void __ctest_linkTests()
     __ctest_head_p = ctest_begin;
 }
 #else //for msvc
-static void __ctest_linkTests()
+static void __ctest_linkTests(void)
 {
     struct ctest ** ctest_start = __ctest_head_p;
     struct ctest ** test;
@@ -450,7 +450,7 @@ static void msg_start(const char* color, const char* title) {
     print_errormsg("  %s: ", title);
 }
 
-static void msg_end() {
+static void msg_end(void) {
     if (color_output) {
     	print_errormsg(ANSI_NORMAL);
     }
@@ -634,7 +634,7 @@ static int suite_test_filter(struct ctest* t) {
 
 
 #ifndef __CTEST_NO_TIME
-static uint64_t getCurrentTime() {
+static uint64_t getCurrentTime(void) {
     struct timeval now;
     gettimeofday(&now, NULL);
     uint64_t now64 = (uint64_t) now.tv_sec;


### PR DESCRIPTION
for #4241 (this part does not address the f2c-converted LAPACK parts used when NOFORTRAN=1)