### PR TITLE
powerpc: Fix build errors with Open XL C

### DIFF
--- a/Makefile.power
+++ b/Makefile.power
@@ -98,6 +98,9 @@ endif
 endif
 endif
 
+ifeq ($(C_COMPILER), CLANG)
+CCOMMON_OPT += -fno-integrated-as
+endif
 # workaround for C->FORTRAN ABI violation in LAPACKE
 ifeq ($(F_COMPILER), GFORTRAN)
 FCOMMON_OPT += -fno-optimize-sibling-calls
@@ -133,7 +136,11 @@ ifdef BINARY64
 
 
 ifeq ($(OSNAME), AIX)
+ifeq ($(C_COMPILER), GCC)
 CCOMMON_OPT	+= -mpowerpc64 -maix64
+else
+CCOMMON_OPT	+= -m64
+endif
 ifeq ($(COMPILER_F77), g77)
 FCOMMON_OPT	+= -mpowerpc64 -maix64
 endif

--- a/c_check
+++ b/c_check
@@ -96,11 +96,19 @@ esac
 defined=0
 
 if [ "$os" = "AIX" ]; then
-    case "$BINARY" in
-        32) compiler_name="$compiler_name -maix32" ;;
-        64) compiler_name="$compiler_name -maix64" ;;
-    esac
-    defined=1
+    if [ "$compiler" = "GCC" ]; then
+        case "$BINARY" in
+            32) compiler_name="$compiler_name -maix32" ;;
+            64) compiler_name="$compiler_name -maix64" ;;
+        esac
+        defined=1
+    else
+        case "$BINARY" in
+            32) compiler_name="$compiler_name -m32" ;;
+            64) compiler_name="$compiler_name -m64" ;;
+        esac
+        defined=1
+    fi
 fi
 
 case "$architecture" in

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -5,12 +5,6 @@ endif
 TOPDIR	= ..
 include $(TOPDIR)/Makefile.system
 
-ifeq ($(ARCH), power)
-ifeq ($(C_COMPILER), CLANG)
- override CFLAGS += -fno-integrated-as
-endif
-endif
-
 AVX2OPT = 
 ifeq ($(C_COMPILER), GCC)
 # AVX2 support was added in 4.7.0


### PR DESCRIPTION
This patch fixes errors when using Open XL C compiler on AIX. 
Tested with gcc/xlf and ibm-clang/xlf compiler combinations.