### PR TITLE
Fix bfloat16_bits union so that it always the sizeof unsigned short for AIX.

### DIFF
--- a/test/compare_sgemm_sbgemm.c
+++ b/test/compare_sgemm_sbgemm.c
@@ -32,7 +32,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 typedef union
 {
   unsigned short v;
-  struct
+  struct __attribute__((packed))
   {
 #if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
     unsigned short s:1;

--- a/test/compare_sgemm_sbgemm.c
+++ b/test/compare_sgemm_sbgemm.c
@@ -49,7 +49,7 @@ typedef union
 typedef union
 {
   float v;
-  struct
+  struct __attribute__((packed))
   {
 #if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
     uint32_t s:1;

--- a/test/compare_sgemm_sbgemm.c
+++ b/test/compare_sgemm_sbgemm.c
@@ -32,7 +32,11 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 typedef union
 {
   unsigned short v;
+#if defined(_AIX)
   struct __attribute__((packed))
+#else
+  struct
+#endif
   {
 #if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
     unsigned short s:1;
@@ -49,7 +53,11 @@ typedef union
 typedef union
 {
   float v;
+#if defined(_AIX)
   struct __attribute__((packed))
+#else
+  struct
+#endif
   {
 #if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
     uint32_t s:1;


### PR DESCRIPTION
Fix bfloat16_bits union so that it always the sizeof unsigned short for AIX.