### PR TITLE
GitHub-CI: Add MSVC runners

### DIFF
--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -1,0 +1,147 @@
+name: msvc
+
+on: [push, pull_request]
+
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
+jobs:
+  msvc:
+    runs-on: windows-latest
+
+    strategy:
+      # Allow other runners in the matrix to continue if some fail
+      fail-fast: false
+
+      matrix:
+        library: [shared, static]
+        include:
+          - library: shared
+            library-flags: -DBUILD_SHARED_LIBS=ON -DBUILD_STATIC_LIBS=OFF
+          - library: static
+            library-flags: -DBUILD_SHARED_LIBS=OFF -DBUILD_STATIC_LIBS=ON
+
+    defaults:
+      run:
+        # Use bash as default shell
+        shell: bash -el {0}
+
+    env:
+      CHERE_INVOKING: 1
+
+    steps:
+      - name: get CPU name
+        shell: pwsh
+        run : |
+          Get-CIMInstance -Class Win32_Processor | Select-Object -Property Name
+
+      - name: checkout repository
+        uses: actions/checkout@v3
+
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: true
+
+      - name: cache conda packages
+        id: conda-cache
+        uses: actions/cache/restore@v3
+        with:
+          path: C:/Miniconda/envs/test
+          key: conda:msvc
+
+      - name: install packages with conda
+        if: ${{ steps.conda-cache.outputs.cache-hit != 'true' }}
+        run: |
+          echo ${{ steps.conda-cache.outputs.cache-hit }}
+          conda info
+          conda list
+          conda install -y -c conda-forge --override-channels ccache
+
+      - name: save conda cache
+        if: ${{ steps.conda-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v3
+        with:
+          path: C:/Miniconda/envs/test
+          key: ${{ steps.conda-cache.outputs.cache-primary-key }}
+
+      - name: Prepare ccache
+        # Get cache location of ccache
+        # Create key that is used in action/cache/restore and action/cache/save steps
+        id: ccache-prepare
+        run: |
+          echo "ccachedir=$(cygpath -m $(ccache -k cache_dir))" >> $GITHUB_OUTPUT
+          # We include the commit sha in the cache key, as new cache entries are
+          # only created if there is no existing entry for the key yet.
+          echo "key=ccache-msvc-${{ matrix.library }}-${{ github.ref }}-${{ github.sha }}" >> $GITHUB_OUTPUT
+
+      - name: Restore ccache
+        uses: actions/cache/restore@v3
+        with:
+          path: ${{ steps.ccache-prepare.outputs.ccachedir }}
+          key: ${{ steps.ccache-prepare.outputs.key }}
+          # Restore a matching ccache cache entry. Prefer same branch.
+          restore-keys: |
+            ccache-msvc-${{ matrix.library }}-${{ github.ref }}
+            ccache-msvc-${{ matrix.library }}
+            ccache-msvc
+
+      - name: Configure ccache
+        # Limit the maximum size and switch on compression to avoid exceeding the total disk or cache quota.
+        run: |
+          which ccache
+          test -d ${{ steps.ccache-prepare.outputs.ccachedir }} || mkdir -p ${{ steps.ccache-prepare.outputs.ccachedir }}
+          echo "max_size = 250M" > ${{ steps.ccache-prepare.outputs.ccachedir }}/ccache.conf
+          echo "compression = true" >> ${{ steps.ccache-prepare.outputs.ccachedir }}/ccache.conf
+          ccache -p
+          ccache -s
+          echo $HOME
+          cygpath -w $HOME
+
+      - name: setup MSVC toolchain
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Configure OpenBLAS
+        run: |
+          mkdir build && cd build
+          cmake -G"Ninja Multi-Config" \
+                -DCMAKE_BUILD_TYPE=Release \
+                ${{ matrix.library-flags }} \
+                -DNOFORTRAN=ON \
+                -DC_LAPACK=ON \
+                -DUSE_OPENMP=ON \
+                -DNUM_THREADS=64 \
+                -DTARGET=CORE2 \
+                -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+                -DCMAKE_Fortran_COMPILER_LAUNCHER=ccache \
+                ..
+
+      - name: Build OpenBLAS
+        run: cd build && cmake --build . --config Release
+
+      - name: Show ccache status
+        continue-on-error: true
+        run: ccache -s
+
+      - name: Save ccache
+        # Save the cache after we are done (successfully) building
+        uses: actions/cache/save@v3
+        with:
+          path: ${{ steps.ccache-prepare.outputs.ccachedir }}
+          key: ${{ steps.ccache-prepare.outputs.key }}
+
+      - name: Run tests
+        id: run-ctest
+        timeout-minutes: 60
+        run: cd build && PATH="${GITHUB_WORKSPACE}/build/lib/RELEASE;${PATH}" ctest -C Release
+
+      - name: Re-run tests
+        if: always() && (steps.run-ctest.outcome == 'failure')
+        timeout-minutes: 60
+        run: |
+          cd build
+          echo "::group::Re-run ctest"
+          PATH="${GITHUB_WORKSPACE}/build/lib/RELEASE;${PATH}" ctest -C Release --rerun-failed --output-on-failure || true
+          echo "::endgroup::"
+          echo "::group::Log from these tests"
+          [ ! -f Testing/Temporary/LastTest.log ] || cat Testing/Temporary/LastTest.log
+          echo "::endgroup::"


### PR DESCRIPTION
This adds GitHub hosted runners using the MSVC compiler on Windows.

I tried to build with `-DDYNAMIC_ARCH=ON`. But that failed with:
```
C:\PROGRA~1\MICROS~2\2022\ENTERP~1\VC\Tools\MSVC\1435~1.322\bin\HostX64\x64\cl.exe  /nologo -DCMAKE_INTDIR=\"Debug\" -ID:/a/OpenBLAS/OpenBLAS -ID:/a/OpenBLAS/OpenBLAS/build /DWIN32 /D_WINDOWS /W3  -openmp -DUSE_OPENMP -DF_INTERFACE_GFORT -DSMALL_MATRIX_OPT -DDYNAMIC_ARCH -DNO_AVX512 -DSMP_SERVER -DNO_WARMUP -DMAX_CPU_NUMBER=64 -DMAX_PARALLEL_NUMBER=1 -DNO_AFFINITY -DVERSION="\"0.3.24.dev\"" -DBUILD_SINGLE -DBUILD_DOUBLE -DBUILD_COMPLEX -DBUILD_COMPLEX16 /MDd /Zi /Ob0 /Od /RTC1 /showIncludes /Fodriver/level3/CMakeFiles/driver_level3.dir/Debug/CMakeFiles/csyrk_kernel_U.c.obj /Fddriver\level3\CMakeFiles\driver_level3.dir\Debug\ /FS -c D:/a/OpenBLAS/OpenBLAS/build/driver/level3/CMakeFiles/csyrk_kernel_U.c
D:/a/OpenBLAS/OpenBLAS/driver/level3/syrk_kernel.c(65): error C2057: expected constant expression
D:/a/OpenBLAS/OpenBLAS/driver/level3/syrk_kernel.c(65): error C2466: cannot allocate an array of constant size 0
D:/a/OpenBLAS/OpenBLAS/driver/level3/syrk_kernel.c(65): error C2133: 'subbuffer': unknown size
```

I don't know if that means that there is an issue with DYNAMIC_ARCH in general for that compiler or if that is caused by something else.
I also don't know if `-DTARGET=CORE2` is a good choice in that case. Please, let me know if that should be changed.

Since I ended up not building with DYNAMIC_ARCH, I didn't add these rules to `dynamic_arch.yaml`.

CMake warned during configure that building shared and static libraries at the same time is unsupported. So, I opted for building both separately in a matrix. (Do you know why that is unsupported?)

I didn't try yet to figure out how to bring a Fortran compiler into this mix. It's building with `-DC_LAPACK=ON` instead.

I see a different test is run on Azure for `Windows_cl` (`openblas_utest.exe`). Should that be run here, too?
