### PR TITLE
Only define __builtin_cpu_is and __builtin_cpu_supports if not present.

### DIFF
--- a/driver/others/dynamic_power.c
+++ b/driver/others/dynamic_power.c
@@ -202,7 +202,7 @@ static int cpuid(void)
 #ifndef __BUILTIN_CPU_SUPPORTS__
 #include <string.h>
 
-#if defined(__has_builtin) && !__has_builtin(__builtin_cpu_is)
+#if defined(_AIX) || (defined(__has_builtin) && !__has_builtin(__builtin_cpu_is))
 static int __builtin_cpu_is(const char *arg)
 {
     static int ipinfo = -1;
@@ -227,7 +227,7 @@ static int __builtin_cpu_is(const char *arg)
 }
 #endif
 
-#if defined(__has_builtin) && !__has_builtin(__builtin_cpu_supports)
+#if defined(_AIX) || (defined(__has_builtin) && !__has_builtin(__builtin_cpu_supports))
 static int __builtin_cpu_supports(const char *arg)
 {
     return 0;

--- a/driver/others/dynamic_power.c
+++ b/driver/others/dynamic_power.c
@@ -202,6 +202,7 @@ static int cpuid(void)
 #ifndef __BUILTIN_CPU_SUPPORTS__
 #include <string.h>
 
+#if defined(__has_builtin) && !__has_builtin(__builtin_cpu_is)
 static int __builtin_cpu_is(const char *arg)
 {
     static int ipinfo = -1;
@@ -224,11 +225,14 @@ static int __builtin_cpu_is(const char *arg)
     }
     return 0;
 }
+#endif
 
+#if defined(__has_builtin) && !__has_builtin(__builtin_cpu_supports)
 static int __builtin_cpu_supports(const char *arg)
 {
     return 0;
 }
+#endif
 #endif
 
 static gotoblas_t *get_coretype(void) {


### PR DESCRIPTION
Fixes instances where __builtin_cpu_is and __builtin_cpu_supports are already defined.

[4297](https://github.com/OpenMathLib/OpenBLAS/issues/4297)
