### PR TITLE
Fix FCOMMON_OPT for power.  Error out for certain C and Fortran compiler combos on AIX

### DIFF
--- a/Makefile.power
+++ b/Makefile.power
@@ -13,9 +13,9 @@ ifeq ($(CORE), POWER10)
 ifneq ($(C_COMPILER), PGI)
 CCOMMON_OPT += -Ofast -mcpu=power10 -mtune=power10 -mvsx -fno-fast-math
 ifeq ($(F_COMPILER), IBM)
-FCOMMON_OPT += -O2 -qrecur -qnosave
+FCOMMON_OPT += -O2 -qrecur -qnosave -qarch=pwr10 -qtune=pwr10 -qfloat=nomaf -qzerosize
 else
-FCOMMON_OPT += -O2 -frecursive -mcpu=power10 -mtune=power10  -fno-fast-math
+FCOMMON_OPT += -O2 -frecursive -mcpu=power10 -mtune=power10 -fno-fast-math
 endif
 endif
 endif
@@ -38,9 +38,9 @@ CCOMMON_OPT += -fast -Mvect=simd -Mcache_align
 endif
 ifneq ($(F_COMPILER), PGI)
 ifeq ($(F_COMPILER), IBM)
-FCOMMON_OPT += -O2 -qrecur -qnosave
+FCOMMON_OPT += -O2 -qrecur -qnosave -qarch=pwr9 -qtune=pwr9 -qfloat=nomaf -qzerosize
 else
-FCOMMON_OPT += -O2 -frecursive -fno-fast-math
+FCOMMON_OPT += -O2 -frecursive -fno-fast-math -mcpu=power9 -mtune=power9
 endif
 
 ifeq ($(F_COMPILER), GFORTRAN)
@@ -65,15 +65,15 @@ endif
 ifneq ($(F_COMPILER), PGI)
 ifeq ($(OSNAME), AIX)
 ifeq ($(F_COMPILER), IBM)
-FCOMMON_OPT += -O2 -qrecur -qnosave
+FCOMMON_OPT += -O2 -qrecur -qnosave -qarch=pwr8 -qtune=pwr8 -qfloat=nomaf -qzerosize
 else
-FCOMMON_OPT += -O1 -frecursive -mcpu=power8 -mtune=power8  -fno-fast-math 
+FCOMMON_OPT += -O1 -frecursive -mcpu=power8 -mtune=power8 -fno-fast-math
 endif
 else
 ifeq ($(F_COMPILER), IBM)
-FCOMMON_OPT += -O2 -qrecur -qnosave
+FCOMMON_OPT += -O2 -qrecur -qnosave -qarch=pwr8 -qtune=pwr8 -qfloat=nomaf -qzerosize
 else
-FCOMMON_OPT += -O2 -frecursive -mcpu=power8 -mtune=power8  -fno-fast-math 
+FCOMMON_OPT += -O2 -frecursive -mcpu=power8 -mtune=power8 -fno-fast-math
 endif
 endif
 else
@@ -134,6 +134,13 @@ endif
 
 ifdef BINARY64
 
+
+ifeq ($(C_COMPILER)$(F_COMPILER)$(OSNAME), GCCIBMAIX)
+$(error Using GCC and XLF on AIX is not a supported combination.)
+endif
+ifeq ($(C_COMPILER)$(F_COMPILER)$(OSNAME), CLANGGFORTRANAIX)
+$(error Using Clang and gFortran on AIX is not a supported combination.)
+endif
 
 ifeq ($(OSNAME), AIX)
 ifeq ($(C_COMPILER), GCC)

--- a/Makefile.system
+++ b/Makefile.system
@@ -1374,6 +1374,8 @@ ifeq ($(F_COMPILER), SUN)
 FCOMMON_OPT  += -pic
 else ifeq ($(F_COMPILER), NAG)
 FCOMMON_OPT += -PIC
+else ifeq ($(F_COMPILER), IBM)
+FCOMMON_OPT += -qpic=large
 else
 FCOMMON_OPT += -fPIC
 endif
@@ -1626,7 +1628,9 @@ override FPFLAGS    += $(FCOMMON_OPT) $(COMMON_PROF)
 
 ifeq ($(NEED_PIC), 1)
 ifeq (,$(findstring PIC,$(FFLAGS)))
+ifneq ($(F_COMPILER),IBM)
 override FFLAGS += -fPIC
+endif
 endif
 endif
 


### PR DESCRIPTION
Fix FCOMMON_OPT for power.  Error out for certain C and Fortran compiler combos in AIX.