### PR TITLE
Move clang/gfortran OpenMP dependency rewriting out of f_check

### DIFF
--- a/Makefile.system
+++ b/Makefile.system
@@ -608,6 +608,9 @@ endif
 
 ifeq ($(C_COMPILER), CLANG)
 CCOMMON_OPT    += -fopenmp
+ifeq ($(F_COMPILER), GFORTRAN)
+FEXTRALIB := $(subst -lgomp,-lomp,$(FEXTRALIB))
+endif
 endif
 
 ifeq ($(C_COMPILER), INTEL)

--- a/f_check
+++ b/f_check
@@ -373,13 +373,6 @@ if [ -n "$link" ]; then
     	    ;;
     	esac
 
-    	case "$flag" in *-lgomp*)
-    	    case "$CC" in *clang*)
-    	        flag="-lomp"
-    	        ;;
-    	    esac
-    	esac
-
         case "$flag" in -l*)
             case "$flag" in
                 *ibrary*|*gfortranbegin*|*flangmain*|*frtbegin*|*pathfstart*|\


### PR DESCRIPTION
the C compiler is not readily available to f_check, unless CC happens to be set in the environment. for #4277