### PR TITLE
Limit CI runs to pushes and pull requests on main repo

### DIFF
--- a/.github/workflows/arm64_graviton.yml
+++ b/.github/workflows/arm64_graviton.yml
@@ -1,6 +1,14 @@
 name: arm64 graviton cirun
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - develop
+      - release-**
+  pull_request:
+    branches:
+      - develop
+      - release-**
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/arm64_graviton.yml
+++ b/.github/workflows/arm64_graviton.yml
@@ -2,6 +2,10 @@ name: arm64 graviton cirun
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 permissions:
   contents: read # to fetch code (actions/checkout)
 

--- a/.github/workflows/arm64_graviton.yml
+++ b/.github/workflows/arm64_graviton.yml
@@ -7,6 +7,7 @@ permissions:
 
 jobs:
   build:
+    if: "github.repository == 'OpenMathLib/OpenBLAS'"
     runs-on: "cirun-aws-runner-graviton--${{ github.run_id }}"
 
     strategy:

--- a/.github/workflows/c910v.yml
+++ b/.github/workflows/c910v.yml
@@ -7,6 +7,7 @@ permissions:
 
 jobs:
   TEST:
+    if: "github.repository == 'OpenMathLib/OpenBLAS'"
     runs-on: ubuntu-latest
     env:
       xuetie_toolchain: https://occ-oss-prod.oss-cn-hangzhou.aliyuncs.com/resource//1663142514282

--- a/.github/workflows/c910v.yml
+++ b/.github/workflows/c910v.yml
@@ -2,6 +2,10 @@ name: c910v qemu test
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 permissions:
   contents: read # to fetch code (actions/checkout)
 

--- a/.github/workflows/dynamic_arch.yml
+++ b/.github/workflows/dynamic_arch.yml
@@ -7,6 +7,7 @@ permissions:
 
 jobs:
   build:
+    if: "github.repository == 'OpenMathLib/OpenBLAS'"
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -146,6 +147,7 @@ jobs:
 
 
   msys2:
+    if: "github.repository == 'OpenMathLib/OpenBLAS'"
     runs-on: windows-latest
 
     strategy:
@@ -312,6 +314,7 @@ jobs:
 
 
   cross_build:
+    if: "github.repository == 'OpenMathLib/OpenBLAS'"
     runs-on: ubuntu-22.04
 
     strategy:

--- a/.github/workflows/dynamic_arch.yml
+++ b/.github/workflows/dynamic_arch.yml
@@ -2,6 +2,10 @@ name: continuous build
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 permissions:
   contents: read # to fetch code (actions/checkout)
 

--- a/.github/workflows/loongarch64.yml
+++ b/.github/workflows/loongarch64.yml
@@ -2,6 +2,10 @@ name: loongarch64 qemu test
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   TEST:
     if: "github.repository == 'OpenMathLib/OpenBLAS'"

--- a/.github/workflows/loongarch64.yml
+++ b/.github/workflows/loongarch64.yml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 
 jobs:
   TEST:
+    if: "github.repository == 'OpenMathLib/OpenBLAS'"
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/mips64.yml
+++ b/.github/workflows/mips64.yml
@@ -2,6 +2,10 @@ name: mips64 qemu test
 
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 permissions:
   contents: read # to fetch code (actions/checkout)
 

--- a/.github/workflows/mips64.yml
+++ b/.github/workflows/mips64.yml
@@ -7,6 +7,7 @@ permissions:
 
 jobs:
   TEST:
+    if: "github.repository == 'OpenMathLib/OpenBLAS'"
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/nightly-Homebrew-build.yml
+++ b/.github/workflows/nightly-Homebrew-build.yml
@@ -18,6 +18,10 @@ on:
 
 name: Nightly-Homebrew-Build
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 permissions:
   contents: read # to fetch code (actions/checkout)
 


### PR DESCRIPTION
This is a follow-up to gh-4271. 

- Add conditions to all CI jobs to only run on main repo by default
- Cancel running CI jobs when new changes are pushed to a PR
- Only trigger AWS Graviton 3 job on `develop` and `release-**` branches

At the moment, when a contributor pushes the latest `develop` to their own branch to bring their own fork in sync with `main`, or if they push another branch, this triggers 30 CI jobs to run. Most will complete silently and only burn CPU time unnecessarily. If there's a failure, this may result in unexpected failure notifications. And the AWS Graviton3 run won't complete at all and time out, since the Cirun hook will only work when triggered from the main repo.

The `group` expression ensures that the cancel-in-progress behavior is to only cancel if a new commit is pushed to the PR for which the job is running, not other PRs. This is a fairly standard snippet, used also in CI jobs for NumPy and other projects.

For the last change, triggering only on `develop` and `release-**` branches, that could make sense to apply to all jobs as well (it's what we do in NumPy/SciPy). But I wasn't sure, that's more a personal preference. The difference is that that prevents the job from triggering to begin with, and hence it avoids the few seconds needed to start an instance, evaluate the `if: github.repository ==` snippet, and shut down again. That process generates actions in the log on your own fork (note that `arm64 graviton cirun` is not visible here, because of the third commit):

<img width="676" alt="image" src="https://github.com/OpenMathLib/OpenBLAS/assets/98330/df828681-9365-4ecd-9b3f-c8ec45acfad1">

If you want me to add that to all CI jobs, please let me know @martin-frbg.