### PR TITLE
Improve matcopy interface

### DIFF
--- a/interface/imatcopy.c
+++ b/interface/imatcopy.c
@@ -100,26 +100,28 @@ void CNAME( enum CBLAS_ORDER CORDER, enum CBLAS_TRANSPOSE CTRANS, blasint crows,
 
 	if ( order == BlasColMajor)
 	{
-        	if ( trans == BlasNoTrans  &&  *ldb < *rows ) info = 8;
-        	if ( trans == BlasTrans    &&  *ldb < *cols ) info = 8;
+        	if ( trans == BlasNoTrans  &&  *ldb < MAX(1,*rows) ) info = 8;
+        	if ( trans == BlasTrans    &&  *ldb < MAX(1,*cols) ) info = 8;
 	}
 	if ( order == BlasRowMajor)
 	{
-        	if ( trans == BlasNoTrans  &&  *ldb < *cols ) info = 8;
-        	if ( trans == BlasTrans    &&  *ldb < *rows ) info = 8;
+        	if ( trans == BlasNoTrans  &&  *ldb < MAX(1,*cols) ) info = 8;
+        	if ( trans == BlasTrans    &&  *ldb < MAX(1,*rows) ) info = 8;
 	}
 
-	if ( order == BlasColMajor &&  *lda < *rows ) info = 7;
-	if ( order == BlasRowMajor &&  *lda < *cols ) info = 7;
-	if ( *cols <= 0 ) info = 4;
-	if ( *rows <= 0 ) info = 3;
-	if ( trans < 0  ) info = 2;
-	if ( order < 0  ) info = 1;
+	if ( order == BlasColMajor &&  *lda < MAX(1,*rows) ) info = 7;
+	if ( order == BlasRowMajor &&  *lda < MAX(1,*cols) ) info = 7;
+	if ( *cols < 0 ) info = 4;
+	if ( *rows < 0 ) info = 3;
+	if ( trans < 0 ) info = 2;
+	if ( order < 0 ) info = 1;
 
 	if (info >= 0) {
     		BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME));
     		return;
   	}
+
+	if ((*rows == 0) || (*cols == 0)) return;
 
 #ifdef NEW_IMATCOPY
     if ( *lda == *ldb ) {

--- a/interface/omatcopy.c
+++ b/interface/omatcopy.c
@@ -90,26 +90,28 @@ void CNAME(enum CBLAS_ORDER CORDER, enum CBLAS_TRANSPOSE CTRANS, blasint crows, 
 #endif
 	if ( order == BlasColMajor)
 	{
-        	if ( trans == BlasNoTrans  &&  *ldb < *rows ) info = 9;
-        	if ( trans == BlasTrans    &&  *ldb < *cols ) info = 9;
+        	if ( trans == BlasNoTrans  &&  *ldb < MAX(1,*rows) ) info = 9;
+        	if ( trans == BlasTrans    &&  *ldb < MAX(1,*cols) ) info = 9;
 	}
 	if ( order == BlasRowMajor)
 	{
-        	if ( trans == BlasNoTrans  &&  *ldb < *cols ) info = 9;
-        	if ( trans == BlasTrans    &&  *ldb < *rows ) info = 9;
+        	if ( trans == BlasNoTrans  &&  *ldb < MAX(1,*cols) ) info = 9;
+        	if ( trans == BlasTrans    &&  *ldb < MAX(1,*rows) ) info = 9;
 	}
 
-	if ( order == BlasColMajor &&  *lda < *rows ) info = 7;
-	if ( order == BlasRowMajor &&  *lda < *cols ) info = 7;
-	if ( *cols <= 0 ) info = 4;
-	if ( *rows <= 0 ) info = 3;
-	if ( trans < 0  ) info = 2;
-	if ( order < 0  ) info = 1;
+	if ( order == BlasColMajor &&  *lda < MAX(1,*rows) ) info = 7;
+	if ( order == BlasRowMajor &&  *lda < MAX(1,*cols) ) info = 7;
+	if ( *cols < 0 ) info = 4;
+	if ( *rows < 0 ) info = 3;
+	if ( trans < 0 ) info = 2;
+	if ( order < 0 ) info = 1;
 
 	if (info >= 0) {
     		BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME));
     		return;
   	}
+
+	if ((*rows == 0) || (*cols == 0)) return;
 
 	if ( order == BlasColMajor )
 	{

--- a/interface/zimatcopy.c
+++ b/interface/zimatcopy.c
@@ -101,30 +101,32 @@ void CNAME( enum CBLAS_ORDER CORDER, enum CBLAS_TRANSPOSE CTRANS, blasint crows,
 
 	if ( order == BlasColMajor)
 	{
-        	if ( trans == BlasNoTrans      &&  *ldb < *rows ) info = 9;
-        	if ( trans == BlasConj         &&  *ldb < *rows ) info = 9;
-        	if ( trans == BlasTrans        &&  *ldb < *cols ) info = 9;
-        	if ( trans == BlasTransConj    &&  *ldb < *cols ) info = 9;
+        	if ( trans == BlasNoTrans      &&  *ldb < MAX(1,*rows) ) info = 9;
+        	if ( trans == BlasConj         &&  *ldb < MAX(1,*rows) ) info = 9;
+        	if ( trans == BlasTrans        &&  *ldb < MAX(1,*cols) ) info = 9;
+        	if ( trans == BlasTransConj    &&  *ldb < MAX(1,*cols) ) info = 9;
 	}
 	if ( order == BlasRowMajor)
 	{
-        	if ( trans == BlasNoTrans    &&  *ldb < *cols ) info = 9;
-        	if ( trans == BlasConj       &&  *ldb < *cols ) info = 9;
-        	if ( trans == BlasTrans      &&  *ldb < *rows ) info = 9;
-        	if ( trans == BlasTransConj  &&  *ldb < *rows ) info = 9;
+        	if ( trans == BlasNoTrans    &&  *ldb < MAX(1,*cols) ) info = 9;
+        	if ( trans == BlasConj       &&  *ldb < MAX(1,*cols) ) info = 9;
+        	if ( trans == BlasTrans      &&  *ldb < MAX(1,*rows) ) info = 9;
+        	if ( trans == BlasTransConj  &&  *ldb < MAX(1,*rows) ) info = 9;
 	}
 
-	if ( order == BlasColMajor &&  *lda < *rows ) info = 7;
-	if ( order == BlasRowMajor &&  *lda < *cols ) info = 7;
-	if ( *cols <= 0 ) info = 4;
-	if ( *rows <= 0 ) info = 3;
-	if ( trans < 0  ) info = 2;
-	if ( order < 0  ) info = 1;
+	if ( order == BlasColMajor &&  *lda < MAX(1,*rows) ) info = 7;
+	if ( order == BlasRowMajor &&  *lda < MAX(1,*cols) ) info = 7;
+	if ( *cols < 0 ) info = 4;
+	if ( *rows < 0 ) info = 3;
+	if ( trans < 0 ) info = 2;
+	if ( order < 0 ) info = 1;
 
 	if (info >= 0) {
     		BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME));
     		return;
   	}
+
+	if ((*rows == 0) || (*cols == 0)) return;
 
 #ifdef NEW_IMATCOPY
     if (*lda == *ldb ) {

--- a/interface/zomatcopy.c
+++ b/interface/zomatcopy.c
@@ -92,30 +92,32 @@ void CNAME(enum CBLAS_ORDER CORDER, enum CBLAS_TRANSPOSE CTRANS, blasint crows, 
 #endif
 	if ( order == BlasColMajor)
 	{
-        	if ( trans == BlasNoTrans      &&  *ldb < *rows ) info = 9;
-        	if ( trans == BlasConj         &&  *ldb < *rows ) info = 9;
-        	if ( trans == BlasTrans        &&  *ldb < *cols ) info = 9;
-        	if ( trans == BlasTransConj    &&  *ldb < *cols ) info = 9;
+        	if ( trans == BlasNoTrans      &&  *ldb < MAX(1,*rows) ) info = 9;
+        	if ( trans == BlasConj         &&  *ldb < MAX(1,*rows) ) info = 9;
+        	if ( trans == BlasTrans        &&  *ldb < MAX(1,*cols) ) info = 9;
+        	if ( trans == BlasTransConj    &&  *ldb < MAX(1,*cols) ) info = 9;
 	}
 	if ( order == BlasRowMajor)
 	{
-        	if ( trans == BlasNoTrans    &&  *ldb < *cols ) info = 9;
-        	if ( trans == BlasConj       &&  *ldb < *cols ) info = 9;
-        	if ( trans == BlasTrans      &&  *ldb < *rows ) info = 9;
-        	if ( trans == BlasTransConj  &&  *ldb < *rows ) info = 9;
+        	if ( trans == BlasNoTrans    &&  *ldb < MAX(1,*cols) ) info = 9;
+        	if ( trans == BlasConj       &&  *ldb < MAX(1,*cols) ) info = 9;
+        	if ( trans == BlasTrans      &&  *ldb < MAX(1,*rows) ) info = 9;
+        	if ( trans == BlasTransConj  &&  *ldb < MAX(1,*rows) ) info = 9;
 	}
 
-	if ( order == BlasColMajor &&  *lda < *rows ) info = 7;
-	if ( order == BlasRowMajor &&  *lda < *cols ) info = 7;
-	if ( *cols <= 0 ) info = 4;
-	if ( *rows <= 0 ) info = 3;
-	if ( trans < 0  ) info = 2;
-	if ( order < 0  ) info = 1;
+	if ( order == BlasColMajor &&  *lda < MAX(1,*rows) ) info = 7;
+	if ( order == BlasRowMajor &&  *lda < MAX(1,*cols) ) info = 7;
+	if ( *cols < 0 ) info = 4;
+	if ( *rows < 0 ) info = 3;
+	if ( trans < 0 ) info = 2;
+	if ( order < 0 ) info = 1;
 
 	if (info >= 0) {
     		BLASFUNC(xerbla)(ERROR_NAME, &info, sizeof(ERROR_NAME));
     		return;
   	}
+
+	if ((*rows == 0) || (*cols == 0)) return;
 
 	if ( order == BlasColMajor )
 	{


### PR DESCRIPTION
For most (all?) BLAS routines, matrices with zero-sized dimensions are valid inputs. `[i,o]matcopy`, however, stops with _parameter number X has an illegal value_ when `rows = 0` or `cols = 0`. This commit 
* allows matrices where the row or column count is zero (xerbla/info is no longer triggered)
* adds a quick return path when at least one matrix dimension is zero
* introduces the BLAS/LAPACK convention that the leading dimensions must be at least 1 (ie lda = 0, rows = 0 is illegal)