### PR TITLE
Add workaround for omp_get_max_threads hanging on FreeBSD/LLVM14

### DIFF
--- a/driver/others/blas_server_omp.c
+++ b/driver/others/blas_server_omp.c
@@ -124,9 +124,18 @@ void openblas_set_num_threads(int num_threads) {
 }
 
 int blas_thread_init(void){
-  if(blas_omp_number_max <= 0)
-    blas_omp_number_max = omp_get_max_threads();
-	
+
+#if defined(__FreeBSD__) && defined(__clang__)
+extern int openblas_omp_num_threads_env();
+
+   if(blas_omp_number_max <= 0)
+	   blas_omp_number_max= openblas_omp_num_threads_env();
+   if (blas_omp_number_max <= 0) 
+	   blas_omp_number_max=MAX_CPU_NUMBER;
+#else
+    blas_omp_number_max = /omp_get_max_threads();
+#endif
+
   blas_get_cpu_number();
 
   adjust_thread_buffers();

--- a/driver/others/blas_server_omp.c
+++ b/driver/others/blas_server_omp.c
@@ -133,7 +133,7 @@ extern int openblas_omp_num_threads_env();
    if (blas_omp_number_max <= 0) 
 	   blas_omp_number_max=MAX_CPU_NUMBER;
 #else
-    blas_omp_number_max = /omp_get_max_threads();
+    blas_omp_number_max = omp_get_max_threads();
 #endif
 
   blas_get_cpu_number();


### PR DESCRIPTION
presumably fixes #4277