### PR TITLE
Temporarily disable the AVX512 CASUM/ZASUM microkernels for any version of NVIDIA HPC

### DIFF
--- a/kernel/x86_64/casum_microk_skylakex-2.c
+++ b/kernel/x86_64/casum_microk_skylakex-2.c
@@ -4,7 +4,8 @@
 #endif
 #if ((( defined(__GNUC__)  && __GNUC__   > 6 && defined(__AVX512CD__)) || (defined(__clang__) && (__clang_major__ >= 9 &&__clang_major__ !=17)) || ( defined(__NVCOMPILER) && NVCOMPVERS >= 2309)))
 
-#if (!(defined(__NVCOMPILER) && NVCOMPVERS < 2309))
+#if (!(defined(__NVCOMPILER) )
+//&& NVCOMPVERS < 2309))
 
 #define HAVE_CASUM_KERNEL 1
 

--- a/kernel/x86_64/casum_microk_skylakex-2.c
+++ b/kernel/x86_64/casum_microk_skylakex-2.c
@@ -4,7 +4,7 @@
 #endif
 #if ((( defined(__GNUC__)  && __GNUC__   > 6 && defined(__AVX512CD__)) || (defined(__clang__) && (__clang_major__ >= 9 &&__clang_major__ !=17)) || ( defined(__NVCOMPILER) && NVCOMPVERS >= 2309)))
 
-#if (!(defined(__NVCOMPILER) )
+#if (!(defined(__NVCOMPILER) ))
 //&& NVCOMPVERS < 2309))
 
 #define HAVE_CASUM_KERNEL 1

--- a/kernel/x86_64/zasum_microk_skylakex-2.c
+++ b/kernel/x86_64/zasum_microk_skylakex-2.c
@@ -4,7 +4,8 @@
 #endif
 #if ((( defined(__GNUC__)  && __GNUC__   > 6 && defined(__AVX512CD__)) || (defined(__clang__) && ( __clang_major__ >= 9 && __clang_major__ != 17)) || (defined(__NVCOMPILER) && NVCOMPVERS >= 2309)))
 
-#if (!(defined(__NVCOMPILER) && NVCOMPVERS < 2309))
+#if (!(defined(__NVCOMPILER) )
+//&& NVCOMPVERS < 2309))
 
 #define HAVE_ZASUM_KERNEL 1
 

--- a/kernel/x86_64/zasum_microk_skylakex-2.c
+++ b/kernel/x86_64/zasum_microk_skylakex-2.c
@@ -4,7 +4,7 @@
 #endif
 #if ((( defined(__GNUC__)  && __GNUC__   > 6 && defined(__AVX512CD__)) || (defined(__clang__) && ( __clang_major__ >= 9 && __clang_major__ != 17)) || (defined(__NVCOMPILER) && NVCOMPVERS >= 2309)))
 
-#if (!(defined(__NVCOMPILER) )
+#if (!(defined(__NVCOMPILER) ))
 //&& NVCOMPVERS < 2309))
 
 #define HAVE_ZASUM_KERNEL 1


### PR DESCRIPTION
as the apparent compiler bug discussed in #4162 was not fixed in release 23.9 as anticipated, nor in the most recent version 23.11 