### PR TITLE
Copy XCode15-specific workaround for Apple M to Fortran flags to fix build of tests

### DIFF
--- a/Makefile.system
+++ b/Makefile.system
@@ -407,6 +407,7 @@ XCVER = $(shell pkgutil --pkg-info=com.apple.pkg.CLTools_Executables |awk '/vers
 endif
 ifeq (x$(XCVER), x 15)
 CCOMMON_OPT += -Wl,-ld_classic
+FCOMMON_OPT += -Wl,-ld_classic
 endif
 endif
 


### PR DESCRIPTION
fixes #4239 (hopefully for good this time)