### PR TITLE
POWER: Fixing Makefile error

### DIFF
--- a/Makefile.power
+++ b/Makefile.power
@@ -11,7 +11,7 @@ endif
 
 ifeq ($(CORE), POWER10)
 ifneq ($(C_COMPILER), PGI)
-ifeq ($(C_COMPILER), GCC))
+ifeq ($(C_COMPILER), GCC)
 ifeq ($(GCCVERSIONGTEQ10), 1)
 CCOMMON_OPT += -Ofast -mcpu=power10 -mtune=power10 -mvsx -fno-fast-math
 else ifneq ($(GCCVERSIONGT4), 1)


### PR DESCRIPTION
Recent commit d99aad8ee308600832da39105a6511275cfe32ad added extra `)`.
This patch fixes the warning from Makefile.