### PR TITLE
Retire the GotoBLAS gemv_t kernel still used as fallback on x86_64

### DIFF
--- a/kernel/x86_64/KERNEL
+++ b/kernel/x86_64/KERNEL
@@ -405,7 +405,7 @@ DGEMVNKERNEL = dgemv_n.S
 endif
 
 ifndef DGEMVTKERNEL
-DGEMVTKERNEL = dgemv_t.S
+DGEMVTKERNEL = dgemv_t_4.c
 endif
 
 ifndef CGEMVNKERNEL


### PR DESCRIPTION
fixes #4352