### PR TITLE
PPC970: drop -mcpu=970 which seems to produce faulty code

### DIFF
--- a/cmake/cc.cmake
+++ b/cmake/cc.cmake
@@ -282,18 +282,21 @@ if (${CORE} STREQUAL POWER8)
   endif ()
 endif ()
 
+# With -mcpu=970 added it compiles, but library is broken, at least on macOS. If someone
+# tests on *BSD or Linux and adds this flag, please make sure it is not used for macOS case.
 if (${CORE} STREQUAL PPC970)
   if (NOT DYNAMIC_ARCH)
-    set (CCOMMON_OPT  "${CCOMMON_OPT} -mcpu=970 -mtune=970 -maltivec -fno-fast-math")
+    set (CCOMMON_OPT  "${CCOMMON_OPT} -mtune=970 -maltivec -fno-fast-math")
   endif ()
   if (APPLE)
     set (CCOMMON_OPT  "${CCOMMON_OPT} -force_cpusubtype_ALL")
   endif ()
 endif ()
 
+# -mcpu=G4 seems to work fine, but perhaps avoid it for the sake of consistency?
 if (${CORE} STREQUAL PPCG4)
   if (NOT DYNAMIC_ARCH)
-    set (CCOMMON_OPT  "${CCOMMON_OPT} -mcpu=G4 -mtune=G4 -maltivec -fno-fast-math")
+    set (CCOMMON_OPT  "${CCOMMON_OPT} -mtune=G4 -maltivec -fno-fast-math")
   endif ()
   if (APPLE)
     set (CCOMMON_OPT  "${CCOMMON_OPT} -force_cpusubtype_ALL")


### PR DESCRIPTION
Fixes: https://github.com/OpenMathLib/OpenBLAS/issues/4376

For a reason yet unknown, using `-mcpu=` [may] produce a broken library on macOS PowerPC when building for G5 cpu (PPC970 kernel).
Drop the flag for now, also for PPCG4 for the sake of consistency and safety.

P. S. Testing on *BSD and Linux is encouraged, but I have no set-up for that. If someone does it later on, please make sure not to use `-mcpu` for macOS case, unless it is well-tested.

@martin-frbg Hopefully this is the final fix for this issue :) 
I have verified that both cases which failed before now work (`R-float` launches without a failure and `flexiblas` finds OpenBLAS).

UPD. By Iain’s (he is from GCC upstream) response in the issue, looks like dropping `-mcpu` is the right thing.