### PR TITLE
Update GEMM param for NEOVERSEV1

### DIFF
--- a/param.h
+++ b/param.h
@@ -3396,13 +3396,13 @@ is a big desktop or server with abundant cache rather than a phone or embedded d
 #define ZGEMM_DEFAULT_UNROLL_N  4
 #define ZGEMM_DEFAULT_UNROLL_MN 16
 
-#define SGEMM_DEFAULT_P 128
-#define DGEMM_DEFAULT_P 160
+#define SGEMM_DEFAULT_P 240
+#define DGEMM_DEFAULT_P 240
 #define CGEMM_DEFAULT_P 128
 #define ZGEMM_DEFAULT_P 128
 
-#define SGEMM_DEFAULT_Q 352
-#define DGEMM_DEFAULT_Q 128
+#define SGEMM_DEFAULT_Q 640
+#define DGEMM_DEFAULT_Q 320
 #define CGEMM_DEFAULT_Q 224
 #define ZGEMM_DEFAULT_Q 112
 


### PR DESCRIPTION
For issue [dgemm performance degradation on ARM NEOVERSEV1 with lower P*Q #4323](https://github.com/OpenMathLib/OpenBLAS/issues/4323) updated the SGEMM and DGEMM PQ param as per the configuration of NEOVERSEV1 cache size. Not keeping too big but enough to get better performance and close enough to half of the cache size.
Below is OpenBLAS/gemm.c benchmark on single core ( also seen on multicore) of graviton3 machine. Performance for SGEMM improved by ~ 2-5% and **DGEMM improved by ~2-12%**

![image](https://github.com/OpenMathLib/OpenBLAS/assets/129051745/176de207-7c00-4178-81ec-909b9a1536cb)



[@martin-frbg](https://github.com/martin-frbg) please help to get it review and merge.