### PR TITLE
Increase S/D GEMM PQ parameters for Neoverse N1

### DIFF
--- a/param.h
+++ b/param.h
@@ -3359,13 +3359,13 @@ is a big desktop or server with abundant cache rather than a phone or embedded d
 #define ZGEMM_DEFAULT_UNROLL_M  4
 #define ZGEMM_DEFAULT_UNROLL_N  4
 
-#define SGEMM_DEFAULT_P	128
-#define DGEMM_DEFAULT_P	160
+#define SGEMM_DEFAULT_P	240
+#define DGEMM_DEFAULT_P	240
 #define CGEMM_DEFAULT_P 128
 #define ZGEMM_DEFAULT_P 128
 
-#define SGEMM_DEFAULT_Q 352
-#define DGEMM_DEFAULT_Q 128
+#define SGEMM_DEFAULT_Q 640
+#define DGEMM_DEFAULT_Q 320
 #define CGEMM_DEFAULT_Q 224
 #define ZGEMM_DEFAULT_Q 112
 


### PR DESCRIPTION
same rationale and similar benchmark results as for the V1 in #4381. fixes #3291 (to the extent that is can be easily addressed in the BLAS part of OpenBLAS, also the specific marketing page with the DGEMM benchmark graph that prompted the creation of the ticket appears to be long gone)