### PR TITLE
Tweak LAPACK tests for SGS/DGS to avoid spurious errors resulting from FMA-induced inaccuracies

### DIFF
--- a/lapack-netlib/TESTING/dgd.in
+++ b/lapack-netlib/TESTING/dgd.in
@@ -1,6 +1,6 @@
 DGS               Data for the Real Nonsymmetric Schur Form Driver
 5                 Number of matrix dimensions
-2 6 10 12 20 30   Matrix dimensions
+2 10 12 20 30     Matrix dimensions
 1 1 1 2 1         Parameters NB, NBMIN, NXOVER, NS, NBCOL
 10                Threshold for test ratios
 .TRUE.            Put T to test the error exits

--- a/lapack-netlib/TESTING/sgd.in
+++ b/lapack-netlib/TESTING/sgd.in
@@ -1,6 +1,6 @@
 SGS               Data for the Real Nonsymmetric Schur Form Driver
 5                 Number of matrix dimensions
-2 6 10 12 20 30   Matrix dimensions
+2 10 12 20 30     Matrix dimensions
 1 1 1 2 1         Parameters NB, NBMIN, NXOVER, NS, NBCOL
 10                Threshold for test ratios
 .TRUE.            Put T to test the error exits


### PR DESCRIPTION
fixes #4415