### PR TITLE
Fix Clang sapphire rapids march flag

### DIFF
--- a/Makefile.x86_64
+++ b/Makefile.x86_64
@@ -130,11 +130,11 @@ ifeq ($(C_COMPILER), GCC)
   endif
  endif
 else ifeq ($(C_COMPILER), CLANG)
- # cooperlake support was added in clang 12
+ # sapphire rapids support was added in clang 12
  ifeq ($(CLANGVERSIONGTEQ12), 1)
-  CCOMMON_OPT += -march=cooperlake
+  CCOMMON_OPT += -march=sapphirerapids
   ifneq ($(F_COMPILER), NAG)
-   FCOMMON_OPT += -march=cooperlake
+   FCOMMON_OPT += -march=sapphirerapids
   endif
  else  # not supported in clang, fallback to avx512
   CCOMMON_OPT += -march=skylake-avx512


### PR DESCRIPTION
A copy-paste error slipped in during the changes to how the Sapphire Rapids architecture flags were guarded in https://github.com/OpenMathLib/OpenBLAS/pull/4192, so it turns out Clang was never being told to use the Sapphire Rapids, and instead was just using Cooperlake instead.