### PR TITLE
Fix utest compilation

### DIFF
--- a/utest/utest_main2.c
+++ b/utest/utest_main2.c
@@ -38,6 +38,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define CTEST_SEGFAULT
 #define CTEST_ADD_TESTS_MANUALLY
 
+#include "cblas.h"
 #include "openblas_utest.h"
 
 CTEST(amax, samax){
@@ -623,10 +624,10 @@ CTEST(zscal, i_nan)
     double i[] = {0,1, 0,1, 0,1, 0,1, 0,1, 0,1, 0,1, 0,1, 0,1 };
     double nan[] = {NAN,0, NAN,0, NAN,0, NAN,0, NAN,0, NAN,0, NAN,0, NAN,0, NAN,0, NAN,0};
     cblas_zscal(9, i, &nan, 1);
-    ASSERT(isnan(nan[0]);
-    ASSERT(isnan(nan[1]);
-    ASSERT(isnan(nan[16]);
-    ASSERT(isnan(nan[17]);
+    ASSERT_TRUE(isnan(nan[0]));
+    ASSERT_TRUE(isnan(nan[1]));
+    ASSERT_TRUE(isnan(nan[16]));
+    ASSERT_TRUE(isnan(nan[17]));
 }
 
 CTEST(zscal, nan_i)
@@ -634,10 +635,10 @@ CTEST(zscal, nan_i)
     double i[] = {0,1, 0,1, 0,1, 0,1, 0,1, 0,1, 0,1, 0,1, 0,1 };
     double nan[] = {NAN,0, NAN,0, NAN,0, NAN,0, NAN,0, NAN,0, NAN,0, NAN,0, NAN,0, NAN,0};
     cblas_zscal(9, &nan, &i, 1);
-    ASSERT(isnan(i[0]);
-    ASSERT(isnan(i[1]);
-    ASSERT(isnan(i[16]);
-    ASSERT(isnan(i[17]);
+    ASSERT_TRUE(isnan(i[0]));
+    ASSERT_TRUE(isnan(i[1]));
+    ASSERT_TRUE(isnan(i[16]));
+    ASSERT_TRUE(isnan(i[17]));
 	    }    
 	    
 CTEST(zscal, i_inf)
@@ -645,10 +646,10 @@ CTEST(zscal, i_inf)
     double i[] = {0,1, 0,1, 0,1, 0,1, 0,1, 0,1, 0,1, 0,1, 0,1 };
     double inf[] = {INFINITY, 0, INFINITY,0, INFINITY,0, INFINITY,0, INFINITY,0, INFINITY,0, INFINITY,0, INFINITY,0, INFINITY,0};
     cblas_zscal(9, i, &inf, 1);
-    ASSERT(isnan(inf[0]);
-    ASSERT(isinf(inf[1]);
-    ASSERT(isnan(inf[16]);
-    ASSERT(isinf(inf[17]);
+    ASSERT_TRUE(isnan(inf[0]));
+    ASSERT_TRUE(isinf(inf[1]));
+    ASSERT_TRUE(isnan(inf[16]));
+    ASSERT_TRUE(isinf(inf[17]));
 }    
 
 CTEST(zscal, inf_i)
@@ -656,10 +657,10 @@ CTEST(zscal, inf_i)
     double i[] = {0,1, 0,1, 0,1, 0,1, 0,1, 0,1, 0,1, 0,1, 0,1 };
     double inf[] = {INFINITY, 0, INFINITY,0, INFINITY,0, INFINITY,0, INFINITY,0, INFINITY,0, INFINITY,0, INFINITY,0, INFINITY,0};
     cblas_zscal(9, &inf, &i, 1);
-    ASSERT(isnan(i[0]);
-    ASSERT(isinf(i[1]);
-    ASSERT(isnan(i[16]);
-    ASSERT(isinf(i[17]);
+    ASSERT_TRUE(isnan(i[0]));
+    ASSERT_TRUE(isinf(i[1]));
+    ASSERT_TRUE(isnan(i[16]));
+    ASSERT_TRUE(isinf(i[17]));
 }
 
 int main(int argc, const char ** argv){


### PR DESCRIPTION
Introduced recently when adding new test cases for ZSCAL

- include cblas is needed for cblas_zscal
- ASSERT macro does not exist
- missing closing )