### PR TITLE
Fix two issues with cpuid_riscv64.c

### DIFF
--- a/cpuid_riscv64.c
+++ b/cpuid_riscv64.c
@@ -86,23 +86,29 @@ int detect(void){
   char *pmodel = NULL, *pisa = NULL;
 
   infile = fopen("/proc/cpuinfo", "r");
+  if (!infile)
+    return CPU_GENERIC;
   while (fgets(buffer, sizeof(buffer), infile)){
     if(!strncmp(buffer, "model name", 10)){
       strcpy(model_buffer, buffer);
-      pmodel = strchr(isa_buffer, ':') + 1;
+      pmodel = strchr(model_buffer, ':');
+      if (pmodel)
+        pmodel++;
     }
 
     if(!strncmp(buffer, "isa", 3)){
       strcpy(isa_buffer, buffer);
-      pisa = strchr(isa_buffer, '4') + 1;
+      pisa = strchr(isa_buffer, '4');
+      if (pisa)
+        pisa++;
     }
   }
 
   fclose(infile);
 
-  if (!pmodel)
+  if (!pmodel || !pisa)
    return(CPU_GENERIC);
-   
+
   if (strstr(pmodel, check_c910_str) && strchr(pisa, 'v'))
     return CPU_C910V;
 

--- a/cpuid_riscv64.c
+++ b/cpuid_riscv64.c
@@ -78,6 +78,11 @@ static char *cpuname[] = {
   "C910V"
 };
 
+static char *cpuname_lower[] = {
+  "riscv64_generic",
+  "c910v"
+};
+
 int detect(void){
 #ifdef __linux
   FILE *infile;
@@ -146,5 +151,5 @@ void get_cpuconfig(void){
 }
 
 void get_libname(void){
-  printf("riscv64\n");
+  printf("%s", cpuname_lower[detect()]);
 }


### PR DESCRIPTION
The code that extracts the model name is incorrect.  It searches in the wrong buffer for the ':' and doesn't check to see whether the character is found before incrementing the pointer to skip the colon, potentially resulting in a pointer value of 1.  There's also a mismatch between the LIBNAME used when the target is forced at build time and when it is dynamically detected.  Presumably, these two values should match.  They do on other architectures.