### PR TITLE
Temporarily disable the CAXPY/ZAXPY kernels for C910V to workaround a CI hang

### DIFF
--- a/kernel/riscv64/KERNEL.C910V
+++ b/kernel/riscv64/KERNEL.C910V
@@ -42,8 +42,8 @@ ZSUMKERNEL  = ../arm/zsum.c
 
 SAXPYKERNEL  = axpy_vector.c
 DAXPYKERNEL  = axpy_vector.c
-CAXPYKERNEL  = zaxpy_vector.c
-ZAXPYKERNEL  = zaxpy_vector.c
+CAXPYKERNEL  = zaxpy.c
+ZAXPYKERNEL  = zaxpy.c
 
 SAXPBYKERNEL  = axpby_vector.c
 DAXPBYKERNEL  = axpby_vector.c


### PR DESCRIPTION
qemu-based run of xccblat2 (and xzcblat2) in gh workflow hangs in cblas_chpmv without this 