### PR TITLE
Move cirun runner to GCP

### DIFF
--- a/.cirun.yml
+++ b/.cirun.yml
@@ -1,16 +1,13 @@
 # Self-Hosted Github Action Runners on AWS via Cirun.io
 # Reference: https://docs.cirun.io/reference/yaml
 runners:
-  - name: "aws-runner-graviton"
-    # Cloud Provider: AWS
-    cloud: "aws"
-    region: "us-east-1"
-    # Cheapest VM on AWS
-    instance_type: "c7g.large"
-    # Ubuntu-22.04, ami image
-    machine_image: "ami-0a0c8eebcdd6dcbd0"
+  - name: "cirun-runner"
+    # Cloud Provider: GCP
+    cloud: "gcp"
+    instance_type: "t2a-standard-2"
+    machine_image: "ubuntu-2204-jammy-arm64-v20240208"
     preemptible: false
     # Add this label in the "runs-on" param in .github/workflows/<workflow-name>.yml
     # So that this runner is created for running the workflow
     labels:
-      - "cirun-aws-runner-graviton"
+      - "cirun-gcp-runner"

--- a/.github/workflows/arm64_gcp.yml
+++ b/.github/workflows/arm64_gcp.yml
@@ -1,4 +1,4 @@
-name: arm64 graviton cirun
+name: arm64 gcp cirun
 
 on:
   push:
@@ -19,8 +19,7 @@ permissions:
 
 jobs:
   build:
-    if: "github.repository == 'OpenMathLib/OpenBLAS'"
-    runs-on: "cirun-aws-runner-graviton--${{ github.run_id }}"
+    runs-on: "cirun-gcp-runner--${{ github.run_id }}"
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
Quansight is moving it's remaining infra scattered across clouds to GCP, that's why moving this one to GCP as well.

cc @steppi @martin-frbg 