### PR TITLE
resolve second_ conflict which breaks xlf timef

### DIFF
--- a/lapack-netlib/SRC/Makefile
+++ b/lapack-netlib/SRC/Makefile
@@ -101,8 +101,10 @@ SCLAUX = la_constants.o \
    slaset.o slasq1.o slasq2.o slasq3.o slasq4.o slasq5.o slasq6.o \
    slasr.o  slasrt.o slassq.o slasv2.o spttrf.o sstebz.o sstedc.o \
    ssteqr.o ssterf.o slaisnan.o sisnan.o \
-   slartgp.o slartgs.o scombssq.o ../INSTALL/sroundup_lwork.o \
-   ../INSTALL/second_$(TIMER).o
+   slartgp.o slartgs.o scombssq.o ../INSTALL/sroundup_lwork.o
+ifneq ($(F_COMPILER), IBM)
+SCLAUX += ../INSTALL/second_$(TIMER).o
+endif
 endif
 
 ifneq "$(or $(BUILD_DOUBLE),$(BUILD_COMPLEX16))" ""
@@ -124,7 +126,10 @@ DZLAUX = la_constants.o\
    dlasr.o  dlasrt.o dlassq.o dlasv2.o dpttrf.o dstebz.o dstedc.o \
    dsteqr.o dsterf.o dlaisnan.o disnan.o \
    dlartgp.o dlartgs.o ../INSTALL/droundup_lwork.o \
-   ../INSTALL/dlamch.o ../INSTALL/dsecnd_$(TIMER).o
+   ../INSTALL/dlamch.o
+ifneq ($(F_COMPILER), IBM)
+DZLAUX +=  ../INSTALL/dsecnd_$(TIMER).o
+endif
 endif
 
 #ifeq ($(BUILD_SINGLE),1)


### PR DESCRIPTION
I am building openblas on an IBM Power AIX system using openxlf/openxlc.
I tried testing my build with a program which calls xlf's timef utility and found timef was incorrectly returning zero instead of the time in milliseconds. This problem happens because xlf's timef routine internally calls a second_ routine, and it should be
calling the second_ in xlf's runtime library, but instead it is calling a second_ in OpenBLAS (which only returns zero). 
The fix is to remove second_ from openblas builds done with xlf. For consistency, dsecnd_ was also removed, since the
dsecnd_ created by OpenBLAS is also only returning zero.