### PR TITLE
fix conlict between PR 4515 and AIX shared obj support

### DIFF
--- a/exports/Makefile
+++ b/exports/Makefile
@@ -315,6 +315,11 @@ test : linktest.c
 
 linktest.c : $(GENSYM) ../Makefile.system ../getarch.c
 	./$(GENSYM) linktest  $(ARCH) "$(BU)" $(EXPRECISION) $(NO_CBLAS) $(NO_LAPACK) $(NO_LAPACKE) $(NEED2UNDERSCORES) $(ONLY_CBLAS) "$(SYMBOLPREFIX)" "$(SYMBOLSUFFIX)" $(BUILD_LAPACK_DEPRECATED) $(BUILD_BFLOAT16) $(BUILD_SINGLE) $(BUILD_DOUBLE) $(BUILD_COMPLEX) $(BUILD_COMPLEX16) > linktest.c
+ifeq ($(F_COMPILER), IBM)
+	mv linktest.c linktest.c.FIRST
+	egrep -v 'second_|dsecnd_' linktest.c.FIRST > linktest.c
+	rm linktest.c.FIRST
+endif
 
 clean ::
 	@rm -f *.def *.dylib __.SYMDEF* *.renamed


### PR DESCRIPTION
PR 4515 (removing second_ and dsecnd_ from IBM xlf builds) and the changes to enable AIX shared object support were delivered on the same day and were not tested together.  second_ and dsecnd_ must also be conditionally removed from linktest.c, used to verify the shared object build, and that is the purpose of this change.  The change was made in exports/Makefile because the F_COMPILER make variable is available there.