### PR TITLE
Skip the fork utest in builds with an uClibc that lacks fork

### DIFF
--- a/utest/test_fork.c
+++ b/utest/test_fork.c
@@ -64,6 +64,11 @@ static void check_dgemm(double *a, double *b, double *result, double *expected, 
 
 CTEST(fork, safety)
 {
+#ifdef __UCLIBC__
+#if !defined __UCLIBC_HAS_STUBS__ && !defined __ARCH_USE_MMU__
+exit(0);
+#endif
+#endif
 #ifndef BUILD_DOUBLE
 exit(0);
 #else


### PR DESCRIPTION
problem mentioned in #4543