### PR TITLE
Fix compiler options for Cortex-X1,X2,A710 in gmake builds

### DIFF
--- a/Makefile.arm64
+++ b/Makefile.arm64
@@ -270,9 +270,17 @@ endif
 
 ifeq (1, $(filter 1,$(GCCVERSIONGTEQ11) $(ISCLANG)))
 ifeq ($(CORE), CORTEXX1)
-CCOMMON_OPT += -march=armv8.2-a -mtune=cortexa72
+CCOMMON_OPT += -march=armv8.2-a
+ifeq (1, $(filter 1,$(GCCMINORVERSIONGTEQ4) $(GCCVERSIONGTEQ12) $(ISCLANG)))
+CCOMMON_OPT += -mtune=cortex-x1
 ifneq ($(F_COMPILER), NAG)
-FCOMMON_OPT += -march=armv8.2-a -mtune=cortexa72
+FCOMMON_OPT += -march=armv8.2-a -mtune=cortex-x1
+endif
+else
+CCOMMON_OPT += -mtune=cortex-a72
+ifneq ($(F_COMPILER), NAG)
+FCOMMON_OPT += -march=armv8.2-a -mtune=cortex-a72
+endif
 endif
 endif
 endif
@@ -282,6 +290,12 @@ ifeq ($(CORE), CORTEXX2)
 CCOMMON_OPT += -march=armv8.4-a+sve
 ifneq ($(F_COMPILER), NAG)
 FCOMMON_OPT += -march=armv8.4-a+sve
+endif
+ifeq (1, $(filter 1,$(GCCVERSIONGTEQ12) $(ISCLANG)))
+CCOMMON_OPT += -mtune=cortex-x2
+ifneq ($(F_COMPILER), NAG)
+FCOMMON_OPT += -mtune=cortex-x2
+endif
 endif
 endif
 endif
@@ -301,6 +315,12 @@ ifeq ($(CORE), CORTEXA710)
 CCOMMON_OPT += -march=armv8.4-a+sve
 ifneq ($(F_COMPILER), NAG)
 FCOMMON_OPT += -march=armv8.4-a+sve
+endif
+ifeq (1, $(filter 1,$(GCCVERSIONGTEQ12) $(ISCLANG)))
+CCOMMON_OPT += -mtune=cortex-a710
+ifneq ($(F_COMPILER), NAG)
+FCOMMON_OPT += -mtune=cortex-a710
+endif
 endif
 endif
 endif

--- a/Makefile.system
+++ b/Makefile.system
@@ -365,8 +365,9 @@ GCCVERSIONGT5 := $(shell expr `$(CC) -dumpversion | cut -f1 -d.` \> 5)
 GCCVERSIONGTEQ7 := $(shell expr `$(CC) -dumpversion | cut -f1 -d.` \>= 7)
 GCCVERSIONGTEQ8 := $(shell expr `$(CC) -dumpversion | cut -f1 -d.` \>= 8)
 GCCVERSIONGTEQ9 := $(shell expr `$(CC) -dumpversion | cut -f1 -d.` \>= 9)
-GCCVERSIONGTEQ11 := $(shell expr `$(CC) -dumpversion | cut -f1 -d.` \>= 11)
 GCCVERSIONGTEQ10 := $(shell expr `$(CC) -dumpversion | cut -f1 -d.` \>= 10)
+GCCVERSIONGTEQ11 := $(shell expr `$(CC) -dumpversion | cut -f1 -d.` \>= 11)
+GCCVERSIONGTEQ12 := $(shell expr `$(CC) -dumpversion | cut -f1 -d.` \>= 12)
 # Note that the behavior of -dumpversion is compile-time-configurable for
 # gcc-7.x and newer. Use -dumpfullversion there
 ifeq ($(GCCVERSIONGTEQ7),1)


### PR DESCRIPTION
fixes #4547