### PR TITLE
Stop using sched_yield on non-Windows x86_64

### DIFF
--- a/common.h
+++ b/common.h
@@ -358,12 +358,6 @@ typedef int blasint;
 #define YIELDING        __asm__ __volatile__ ("nop;nop;nop;nop;nop;nop;nop;nop; \n");
 #endif
 
-#ifdef BULLDOZER
-#ifndef YIELDING
-#define YIELDING        __asm__ __volatile__ ("nop;nop;nop;nop;nop;nop;nop;nop;\n");
-#endif
-#endif
-
 
 #if defined(POWER8) || defined(POWER9) || defined(POWER10)
 #ifndef YIELDING
@@ -371,21 +365,13 @@ typedef int blasint;
 #endif
 #endif
 
-/*
-#ifdef PILEDRIVER
-#ifndef YIELDING
-#define YIELDING        __asm__ __volatile__ ("nop;nop;nop;nop;nop;nop;nop;nop;\n");
-#endif
-#endif
-*/
 
-/*
-#ifdef STEAMROLLER
+#if defined(ARCH_X86_64)
 #ifndef YIELDING
 #define YIELDING        __asm__ __volatile__ ("nop;nop;nop;nop;nop;nop;nop;nop;\n");
 #endif
 #endif
-*/
+
 
 #ifdef __EMSCRIPTEN__
 #define YIELDING


### PR DESCRIPTION
fixes #4496