### PR TITLE
Add support for negative increments to the ?NRM2 kernels for RISC-V RVV targets

### DIFF
--- a/kernel/riscv64/nrm2_rvv.c
+++ b/kernel/riscv64/nrm2_rvv.c
@@ -101,7 +101,7 @@ FLOAT CNAME(BLASLONG n, FLOAT *x, BLASLONG inc_x)
 {
 	BLASLONG i=0;
 
-	if (n <= 0 || inc_x <= 0) return(0.0);
+	if (n <= 0 || inc_x == 0) return(0.0);
         if(n == 1) return (ABS(x[0]));
 
         unsigned int gvl = 0;
@@ -190,7 +190,7 @@ FLOAT CNAME(BLASLONG n, FLOAT *x, BLASLONG inc_x)
         //finish any tail using scalar ops
         i*=gvl*inc_x;
         n*=inc_x;
-        while(i < n){
+        while(abs(i) < abs(n)){
                 if ( x[i] != 0.0 ){
                         FLOAT absxi = ABS( x[i] );
                         if ( scale < absxi ){

--- a/kernel/riscv64/nrm2_rvv.c
+++ b/kernel/riscv64/nrm2_rvv.c
@@ -119,7 +119,7 @@ FLOAT CNAME(BLASLONG n, FLOAT *x, BLASLONG inc_x)
         unsigned int stride_x = inc_x * sizeof(FLOAT);
         int idx = 0;
 
-        if( n >= gvl ) // don't pay overheads if we're not doing useful work
+        if( n >= gvl && inc_x > 0 ) // don't pay overheads if we're not doing useful work
         {
                 for(i=0; i<n/gvl; i++){
                         v0 = VLSEV_FLOAT( &x[idx], stride_x, gvl );

--- a/kernel/riscv64/nrm2_vector.c
+++ b/kernel/riscv64/nrm2_vector.c
@@ -122,7 +122,7 @@ FLOAT CNAME(BLASLONG n, FLOAT *x, BLASLONG inc_x)
         unsigned int stride_x = inc_x * sizeof(FLOAT);
         int idx = 0;
 
-        if( n >= gvl ) // don't pay overheads if we're not doing useful work
+        if( n >= gvl && inc_x > 0) // don't pay overheads if we're not doing useful work
         {
                 for(i=0; i<n/gvl; i++){
                         v0 = VLSEV_FLOAT( &x[idx], stride_x, gvl );
@@ -193,7 +193,7 @@ FLOAT CNAME(BLASLONG n, FLOAT *x, BLASLONG inc_x)
         //finish any tail using scalar ops
         i*=gvl*inc_x;
         n*=inc_x;
-        while(i< n){
+        while(abs(i)< abs(n)){
                 if ( x[i] != 0.0 ){
                         FLOAT absxi = ABS( x[i] );
                         if ( scale < absxi ){

--- a/kernel/riscv64/nrm2_vector.c
+++ b/kernel/riscv64/nrm2_vector.c
@@ -104,7 +104,7 @@ FLOAT CNAME(BLASLONG n, FLOAT *x, BLASLONG inc_x)
 {
 	BLASLONG i=0;
 
-	if (n <= 0 || inc_x <= 0) return(0.0);
+	if (n <= 0 || inc_x == 0) return(0.0);
         if(n == 1) return (ABS(x[0]));
 
         unsigned int gvl = 0;
@@ -193,7 +193,7 @@ FLOAT CNAME(BLASLONG n, FLOAT *x, BLASLONG inc_x)
         //finish any tail using scalar ops
         i*=gvl*inc_x;
         n*=inc_x;
-        while(i < n){
+        while(abs(i) < abs(n)){
                 if ( x[i] != 0.0 ){
                         FLOAT absxi = ABS( x[i] );
                         if ( scale < absxi ){

--- a/kernel/riscv64/nrm2_vector.c
+++ b/kernel/riscv64/nrm2_vector.c
@@ -193,7 +193,7 @@ FLOAT CNAME(BLASLONG n, FLOAT *x, BLASLONG inc_x)
         //finish any tail using scalar ops
         i*=gvl*inc_x;
         n*=inc_x;
-        while(abs(i) < abs(n)){
+        while(i< n){
                 if ( x[i] != 0.0 ){
                         FLOAT absxi = ABS( x[i] );
                         if ( scale < absxi ){

--- a/kernel/riscv64/znrm2_rvv.c
+++ b/kernel/riscv64/znrm2_rvv.c
@@ -69,7 +69,7 @@ FLOAT CNAME(BLASLONG n, FLOAT *x, BLASLONG inc_x)
 {
 	BLASLONG i=0, j=0;
 
-	if (n <= 0 || inc_x <= 0) return(0.0);
+	if (n <= 0 || inc_x == 0) return(0.0);
 
     FLOAT_V_T vr, v0, v_zero;
     unsigned int gvl = 0;

--- a/kernel/riscv64/znrm2_vector.c
+++ b/kernel/riscv64/znrm2_vector.c
@@ -96,7 +96,7 @@ FLOAT CNAME(BLASLONG n, FLOAT *x, BLASLONG inc_x)
 {
         BLASLONG i=0;
 
-	if (n <= 0 || inc_x <= 0) return(0.0);
+	if (n <= 0 || inc_x == 0) return(0.0);
 
         FLOAT_V_T v_ssq, v_scale, v0, v1, v_zero;
         unsigned int gvl = 0;
@@ -176,7 +176,7 @@ FLOAT CNAME(BLASLONG n, FLOAT *x, BLASLONG inc_x)
                         }
 
                         i += inc_x*2;
-                }while(i<n);
+                }while(abs(i)<abs(n));
         }
 
         return(scale * sqrt(ssq));


### PR DESCRIPTION
hopefully concludes the series of fixes for #4551