### PR TITLE
POWER9: Use default param values from POWER8 on AIX

### DIFF
--- a/param.h
+++ b/param.h
@@ -2493,7 +2493,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #endif
 
-#if defined(POWER8)
+#if defined(POWER8) || (defined(POWER9) && defined(OS_AIX))
 
 #define SNUMOPT		16
 #define DNUMOPT		8
@@ -2547,7 +2547,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #endif
 
-#if defined(POWER9)
+#if defined(POWER9) && defined(OS_LINUX)
 
 #define SNUMOPT		16
 #define DNUMOPT		8


### PR DESCRIPTION
AIX uses KERNEL.POWER8 optimization on POWER9 and changing the default GEMM parameters in param.h to use POWER8 values on POWER9.