### PR TITLE
Restore outer loop of blas_buffer_inuse setup for parallel OpenMP

### DIFF
--- a/driver/others/blas_server_omp.c
+++ b/driver/others/blas_server_omp.c
@@ -407,6 +407,7 @@ int exec_blas(BLASLONG num, blas_queue_t *queue){
   }
 #endif
 
+while (true) {
     for(i=0; i < MAX_PARALLEL_NUMBER; i++) {
 #ifdef HAVE_C11
       _Bool inuse = false;
@@ -419,7 +420,9 @@ int exec_blas(BLASLONG num, blas_queue_t *queue){
         break;
       }
     }
-
+    if (i != MAX_PARALLEL_NUMBER)
+	    break;
+}
 if (openblas_omp_adaptive_env() != 0) {
 #pragma omp parallel for num_threads(num) schedule(OMP_SCHED)
   for (i = 0; i < num; i ++) {


### PR DESCRIPTION
this was inadvertently dropped in #4503, leading to some threads starting with an uninitialized and potentially invalid buffer index