### PR TITLE
Fix global (static) constructor priority so that OpenBLAS gets initialized before other libraries.  Other unit test AIX fix.

### DIFF
--- a/exports/Makefile
+++ b/exports/Makefile
@@ -266,7 +266,7 @@ so : ../$(LIBSONAME) linktest.c
 
 ../$(LIBSONAME) : aix.exp
 	$(CC) $(CFLAGS) $(LDFLAGS)  -shared -o ../$(LIBSONAME) \
-	-Wl,-bE:aix.exp -Wl,-bbigtoc ../$(LIBNAME) $(EXTRALIB)
+	-Wl,-bcdtors:all:-2147481648:s,-bE:aix.exp -Wl,-bbigtoc ../$(LIBNAME) $(EXTRALIB)
 
 aix.exp :
 	/usr/bin/nm -X32_64 -PCpgl ../$(LIBNAME) | /usr/bin/awk '{ if ((($$ 2 == "T") \

--- a/utest/Makefile
+++ b/utest/Makefile
@@ -63,20 +63,18 @@ endif
 all : run_test
 
 ifeq ($(OSNAME), AIX)
-ifeq ($(USE_OPENMP), 1)
 $(UTESTBIN): $(OBJS)
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^ ../$(LIBNAME) $(EXTRALIB)
+
+$(UTESTEXTBIN): $(OBJS_EXT)
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^ ../$(LIBNAME) $(EXTRALIB)
 else
 $(UTESTBIN): $(OBJS)
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^ ../$(LIBNAME) $(EXTRALIB) $(FEXTRALIB)
-endif
-else
-$(UTESTBIN): $(OBJS)
-	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^ ../$(LIBNAME) $(EXTRALIB) $(FEXTRALIB)
-endif
 
 $(UTESTEXTBIN): $(OBJS_EXT)
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $^ ../$(LIBNAME) $(EXTRALIB) $(FEXTRALIB)
+endif
 
 run_test: $(UTESTBIN) $(UTESTEXTBIN)
 ifneq ($(CROSS), 1)


### PR DESCRIPTION
Fix global (static) constructor priority so that OpenBLAS gets initialized before other libraries.  Other unit test AIX fix.