### PR TITLE
Cap the number of parallel threads for GEMM;GETRF and POTRF to ensure sensible workloads on big systems

### DIFF
--- a/interface/gemm.c
+++ b/interface/gemm.c
@@ -533,8 +533,12 @@ void CNAME(enum CBLAS_ORDER order, enum CBLAS_TRANSPOSE TransA, enum CBLAS_TRANS
   MNK = (double) args.m * (double) args.n * (double) args.k;
   if ( MNK <= (SMP_THRESHOLD_MIN  * (double) GEMM_MULTITHREAD_THRESHOLD)  )
 	args.nthreads = 1;
-  else
+  else {
 	args.nthreads = num_cpu_avail(3);
+	if (MNK/args.nthreads < SMP_THRESHOLD_MIN*(double)GEMM_MULTITHREAD_THRESHOLD)
+		args.nthreads = MNK/(SMP_THRESHOLD_MIN*(double)GEMM_MULTITHREAD_THRESHOLD);
+  }
+
   args.common = NULL;
 
  if (args.nthreads == 1) {

--- a/interface/lapack/getrf.c
+++ b/interface/lapack/getrf.c
@@ -95,14 +95,19 @@ int NAME(blasint *M, blasint *N, FLOAT *a, blasint *ldA, blasint *ipiv, blasint 
 
 #ifdef SMP
   args.common = NULL;
+
 #ifndef DOUBLE
-  if (args.m*args.n < 40000)
-#else
-  if (args.m*args.n < 10000)
-#endif
-	args.nthreads=1;
-  else
-	args.nthreads = num_cpu_avail(4);
+  int nmax = 40000;
+#else 
+  int nmax = 10000;
+endif
+  if (args.m*args.n <nmax) {
+    args.nthreads = 1;
+  } else {
+    args.nthreads = num_cpu_avail(4);
+    if ((args.m*args.n)/args.nthreads <nmax)
+	    args.nthreads = (args.m*args.n)/nmax;
+  }
 
   if (args.nthreads == 1) {
 #endif

--- a/interface/lapack/getrf.c
+++ b/interface/lapack/getrf.c
@@ -100,7 +100,7 @@ int NAME(blasint *M, blasint *N, FLOAT *a, blasint *ldA, blasint *ipiv, blasint 
   int nmax = 40000;
 #else 
   int nmax = 10000;
-endif
+#endif
   if (args.m*args.n <nmax) {
     args.nthreads = 1;
   } else {

--- a/interface/lapack/potrf.c
+++ b/interface/lapack/potrf.c
@@ -113,13 +113,17 @@ int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
 #ifdef SMP
   args.common = NULL;
 #ifndef DOUBLE
-  if (args.n <128)
-#else
-  if (args.n <64)
-#endif
+  int nmax = 128;
+#else 
+  int nmax = 64;
+endif
+  if (args.n <nmax) {
     args.nthreads = 1;
-  else
-  args.nthreads = num_cpu_avail(4);
+  } else {
+    args.nthreads = num_cpu_avail(4);
+    if (args.n/args.nthreads <nmax)
+	    args.nthreads = args.n/nmax;
+  }
 
   if (args.nthreads == 1) {
 #endif

--- a/interface/lapack/potrf.c
+++ b/interface/lapack/potrf.c
@@ -116,7 +116,7 @@ int NAME(char *UPLO, blasint *N, FLOAT *a, blasint *ldA, blasint *Info){
   int nmax = 128;
 #else 
   int nmax = 64;
-endif
+#endif
   if (args.n <nmax) {
     args.nthreads = 1;
   } else {


### PR DESCRIPTION
probably fixes #1881 and also fixes #678 as well as it fixes #611 - the idea here is to obtain a maximum thread count that ensures each thread gets about the same workload as a single thread would (before the switchover to multithreading occurs), instead of always starting as many threads as possible. 