### PR TITLE
Address Windows thread server re-entrant queue bug #4582

### DIFF
--- a/driver/others/blas_server_win32.c
+++ b/driver/others/blas_server_win32.c
@@ -409,14 +409,14 @@ int exec_blas_async(BLASLONG pos, blas_queue_t *queue) {
   }
   else
   {
-	  blas_queue_t *next_item = work_queue;
+	  blas_queue_t *queue_item = work_queue;
 
     // find the end of the work queue
-    while (next_item)
-        next_item = next_item->next;
+    while (queue_item->next)
+        queue_item = queue_item->next;
 
     // add new work to the end
-    next_item = queue;
+    queue_item->next = queue;
   }
 
   LeaveCriticalSection(&queue_lock);


### PR DESCRIPTION
Code to fix lost work in case of re-entrant calls to `exec_blas_async()`. This is intended to fix scipy/scipy#20294