### PR TITLE
fix typo

### DIFF
--- a/openblas.pc.in
+++ b/openblas.pc.in
@@ -2,6 +2,6 @@ Name: openblas
 Description: OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version
 Version: ${version}
 URL: https://github.com/xianyi/OpenBLAS
-Libs: -L${libdir} -l$(libprefix}openblas${libnamesuffix}
+Libs: -L${libdir} -l${libprefix}openblas${libnamesuffix}
 Libs.private: ${extralib}
 Cflags: -I${includedir}


### PR DESCRIPTION
Fix a typo discovered by @tylerjereddy when working on scipy/scipy#20362. I think this crept in from 9ef10ffa49. 