### PR TITLE
fix dtrtrs_ and ztrtrs_ to accept case-insensitive uplo and diag parameters

### DIFF
--- a/interface/lapack/trtrs.c
+++ b/interface/lapack/trtrs.c
@@ -95,10 +95,12 @@ int NAME(char *UPLO, char* TRANS, char* DIAG, blasint *N, blasint *NRHS, FLOAT *
   if (trans_arg == 'R') trans = 0;
   if (trans_arg == 'C') trans = 1;
 
+  TOUPPER(uplo_arg);
   uplo = -1;
   if (uplo_arg == 'U') uplo = 0;
   if (uplo_arg == 'L') uplo = 1;
 
+  TOUPPER(diag_arg);
   diag = -1;
   if (diag_arg == 'U') diag = 0;
   if (diag_arg == 'N') diag = 1;

--- a/interface/lapack/ztrtrs.c
+++ b/interface/lapack/ztrtrs.c
@@ -95,10 +95,12 @@ int NAME(char *UPLO, char* TRANS, char* DIAG, blasint *N, blasint *NRHS, FLOAT *
   if (trans_arg == 'R') trans = 2;
   if (trans_arg == 'C') trans = 3;
 
+  TOUPPER(uplo_arg);
   uplo = -1;
   if (uplo_arg == 'U') uplo = 0;
   if (uplo_arg == 'L') uplo = 1;
 
+  TOUPPER(diag_arg);
   diag = -1;
   if (diag_arg == 'U') diag = 0;
   if (diag_arg == 'N') diag = 1;


### PR DESCRIPTION
`uplo` and `diag` parameters are case-sensitive for LAPACK `DTRTRS` and `ZTRTRS` routines. This contradicts to specs. The demo for `DTRTRS` routine and `diag` parameter is:

```c
#include "stdio.h"
#include "stdlib.h"

extern void dtrtrs_(char*, char*, char*, int*, int*, double*, int*, double*, int*, int*);

int main(int argc, char* argv[])
{
  int i;
  if(argc<3){
    printf("arguments expected: N and NRHS\n");
    return 1;
  }

  int n = atoi(argv[1]);
  int nrhs = atoi(argv[2]);
  int sizeofa = n * n;
  int sizeofb = n * nrhs;
  int info = -1;
  char uplo = 'L';
  char trans = 'N';
  char diag = 'n';

  double* A = (double*)malloc(sizeof(double) * sizeofa);
  double* B = (double*)malloc(sizeof(double) * sizeofb);

  srand((unsigned)time(NULL));

  for (i=0; i<sizeofa; i++)
    A[i] = i%3+1;

  for (i=0; i<sizeofb; i++)
    B[i] = i%3+1;

  printf("n=%d,nrhs=%d,sizeofa=%d,sizeofb=%d\n",n,nrhs,sizeofa,sizeofb);
  dtrtrs_(&uplo, &trans, &diag, &n, &nrhs, A, &n, B, &n, &info);

  free(A);
  free(B);
  return 0;
}
```
Demo's run:
```console
./openblas_test_dtrtrs 10 5
n=10,nrhs=5,sizeofa=100,sizeofb=50
 ** On entry to DTRTRS parameter number  3 had an illegal value
```

The reason is in files: [interface/lapack/trtrs.c](https://github.com/OpenMathLib/OpenBLAS/blob/develop/interface/lapack/trtrs.c) and [interface/lapack/ztrtrs.c](https://github.com/OpenMathLib/OpenBLAS/blob/develop/interface/lapack/ztrtrs.c) which lack a transformation to upper-case before comparisons begin for `uplo` and `diag` parameters. The `trans` parameter is processed properly, though.

Environment:

- CPU: Intel(R) Core(TM) i7-4790 CPU @ 3.60GHz (Haswell, 8 threads max.)
- OS: openSUSE Leap 15.5 x86_64
- compiler: gcc (SUSE Linux) 7.5.0
- OpenBLAS compiling flags (all default):
```config
VERSION = 0.3.26.dev
BUILD_LAPACK_DEPRECATED = 1
NO_WARMUP = 1
NO_AFFINITY = 1
COMMON_PROF = -pg
```