### PR TITLE
Get the l2 cache size via environment variable on confidential VM

### DIFF
--- a/kernel/setparam-ref.c
+++ b/kernel/setparam-ref.c
@@ -1248,6 +1248,10 @@ static __inline__ int get_l2_size(void){
 
   int eax, ebx, ecx, edx, l2;
 
+  l2 = readenv_atoi("OPENBLAS_L2_SIZE");
+  if (l2 != 0)
+    return l2;
+
   cpuid(0x80000006, &eax, &ebx, &ecx, &edx);
 
   l2 = BITMASK(ecx, 16, 0xffff);


### PR DESCRIPTION
The CPUID(leaf:2 or leaf:0x80000006) is not supported on some confidential VMs. As a result the get_l2_size() returns the default 512M which brings performance issues.

Introduce the environment variable OPENBLAS_L2_SIZE provided by the user to get the l2 cache size.

Suggested-by: "Keshavamurthy, Anil S" <anil.s.keshavamurthy@intel.com>
Signed-off-by: Chen Yu <yu.c.chen@intel.com>