### PR TITLE
Do not run the CBLAS_?GEMM3M tests when cross-compiling with gmake

### DIFF
--- a/ctest/Makefile
+++ b/ctest/Makefile
@@ -203,7 +203,6 @@ ifeq ($(BUILD_COMPLEX16),1)
 	OPENBLAS_NUM_THREADS=2 ./xzcblat3 < zin3
 endif
 endif
-endif
 
 ifeq ($(SUPPORT_GEMM3M),1)
 ifeq ($(USE_OPENMP), 1)
@@ -222,7 +221,7 @@ ifeq ($(BUILD_COMPLEX16),1)
 endif
 endif
 endif
-
+endif
 
 
 


### PR DESCRIPTION
fixes #4612 as suggested by eschnett there