### PR TITLE
[Doc]Update user_manual.md for static linker

### DIFF
--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -159,7 +159,7 @@ int main(int argc, char* argv[])
 ```
 
 ```
-gcc -o time_dgemm time_dgemm.c /your/path/libopenblas.a
+gcc -o time_dgemm time_dgemm.c /your/path/libopenblas.a -lpthread
 ./time_dgemm <m> <n> <k>
 ```
 


### PR DESCRIPTION
when I use static link method to compile , result is undefined with pthread_create, so we should add -lpthread