### PR TITLE
Remove -openmp flag from XLF (since it doesn't support it).

### DIFF
--- a/Makefile.system
+++ b/Makefile.system
@@ -1195,9 +1195,6 @@ endif
 else
 FCOMMON_OPT += -q32
 endif
-ifeq ($(USE_OPENMP), 1)
-FCOMMON_OPT += -openmp
-endif
 endif
 
 ifeq ($(F_COMPILER), PGI)


### PR DESCRIPTION
Remove -openmp flag from XLF (since it doesn't support it).