### PR TITLE
Set GEMM_PREFERED_SIZE parameter for Neoverse V1

### DIFF
--- a/param.h
+++ b/param.h
@@ -3547,8 +3547,10 @@ is a big desktop or server with abundant cache rather than a phone or embedded d
 
 #if defined(XDOUBLE) || defined(DOUBLE)
 #define SWITCH_RATIO            8
+#define GEMM_PREFERED_SIZE      4
 #else
 #define SWITCH_RATIO            16
+#define GEMM_PREFERED_SIZE      8
 #endif
 
 #define SGEMM_DEFAULT_UNROLL_M  16


### PR DESCRIPTION
Hello.
This pull request addresses the previously raised issue #4590.
The parameter GEMM_PREFERED_SIZE is adjusted to 4 for double precision and 8 for single precision for Neoverse V1.
Below is the performance graph of 8 threads that shows the improvement:

![image](https://github.com/OpenMathLib/OpenBLAS/assets/38725002/791c5ce2-70b0-4593-9391-feabada696dd)

Setting the parameter to 8 instead of 4 for double precision might seem more natural, if you refer to the similar kind of parameters SWITCH_RATIO, xGEMM_DEFAULT_UNROLL_M, and xGEMM_DEFAULT_UNROLL_N.  However, I measured performance under several conditions up to 64 threads on Graviton3E and found that using the value 8 sometimes degrade performance but the value 4 shows improvements.

This is analyzed as follows:
When a problem size of 840 is divided into 8 threads, for example, 
- if the value for double precision is changed from the default value 1 to 8, then the size assigned to the first thread increases from 105 to 112.  This can cause performance degradation due to load imbalance among threads.
- by setting the value to 4, the size assigned to the first thread becomes 108.  However, the execution time will not change because it just fills the remaining three elements of the SIMD calculation.

The dgemm_kernel_sve_v2x8.S contains loops for [v1x8](https://github.com/OpenMathLib/OpenBLAS/blob/3cf57a61d59a39cc668b21ceafaa006abcfdcf94/kernel/arm64/dgemm_kernel_sve_v2x8.S#L1013) and [v2x4](https://github.com/OpenMathLib/OpenBLAS/blob/3cf57a61d59a39cc668b21ceafaa006abcfdcf94/kernel/arm64/dgemm_kernel_sve_v2x8.S#L1128), of which efficiency are just as good as [v2x8](https://github.com/OpenMathLib/OpenBLAS/blob/3cf57a61d59a39cc668b21ceafaa006abcfdcf94/kernel/arm64/dgemm_kernel_sve_v2x8.S#L911).   So GEMM_PREFERED_SIZE should be small enough not to cause load imbalance and large enough to improve kernel efficiency.

As a result, this setting is good for making the sizes "preferred" by the kernel.
