### PR TITLE
Add another object signature for classic flang

### DIFF
--- a/f_check
+++ b/f_check
@@ -86,7 +86,7 @@ else
 		vendor=CRAY
 		openmp='-fopenmp'
 		;;
-   	    *Arm\ F90*)
+   	    *Arm\ F90*|*F90\ Flang*)
 		vendor=FLANG
 		openmp='-fopenmp'
 		;;	


### PR DESCRIPTION
in response to worries that vendor compilers might rebase on LLVM17 or higher without switching to flang-new.
ref #4178