### PR TITLE
revert the C/Z NRM2 kernels for NEOVERSEN1 and VORTEX to the base NEON kernel as well

### DIFF
--- a/kernel/arm64/KERNEL.NEOVERSEN1
+++ b/kernel/arm64/KERNEL.NEOVERSEN1
@@ -93,8 +93,8 @@ IZAMAXKERNEL   = izamax_thunderx2t99.c
 
 SNRM2KERNEL    = nrm2.S
 DNRM2KERNEL    = nrm2.S
-CNRM2KERNEL    = scnrm2_thunderx2t99.c
-ZNRM2KERNEL    = dznrm2_thunderx2t99.c
+CNRM2KERNEL    = znrm2.S
+ZNRM2KERNEL    = znrm2.S
 
 DDOTKERNEL     = dot.c
 SDOTKERNEL     = dot.c


### PR DESCRIPTION
(temporarily?) fixes #4626