### PR TITLE
Align Makefile build options for embedded (Cortex M)  systems with the CMAKE code

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -156,7 +156,7 @@ FreeBSD_task:
     image_family: freebsd-13-2
   install_script:
   - pkg update -f && pkg upgrade -y && pkg install -y gmake gcc 
-  - ln -s /usr/local/lib/gcc12/libgfortran.so.5.0.0 /usr/lib/libgfortran.so
+  - ln -s /usr/local/lib/gcc13/libgfortran.so.5.0.0 /usr/lib/libgfortran.so
   compile_script:
   - gmake CC=clang FC=gfortran USE_OPENMP=1 CPP_THREAD_SAFETY_TEST=1
 

--- a/Makefile.rule
+++ b/Makefile.rule
@@ -173,6 +173,10 @@ NO_AFFINITY = 1
 # If you are compiling for Linux and you have more than 16 numa nodes or more than 256 cpus
 # BIGNUMA = 1
 
+# If you are compiling for an embedded system ("bare metal") like Cortex M series
+# Note that you will have to provide implementations of malloc() and free() in this case
+# EMBEDDED = 1
+
 # Don't use AVX kernel on Sandy Bridge. It is compatible with old compilers
 # and OS. However, the performance is low.
 # NO_AVX = 1

--- a/Makefile.system
+++ b/Makefile.system
@@ -815,7 +815,7 @@ ifneq ($(EMBEDDED), 1)
 CCOMMON_OPT += -marm
 FCOMMON_OPT += -marm
 else
-CCOMMON_OPT += -DOS_EMBEDDED
+CCOMMON_OPT += -DOS_EMBEDDED -mthumb -mcpu=cortex-m4 -mfloat-abi=hard -mfpu=fpv4-sp-d16
 endif
 
 # If softfp abi is mentioned on the command line, force it.

--- a/Makefile.system
+++ b/Makefile.system
@@ -811,8 +811,10 @@ ifeq ($(ARCH), arm)
 NO_BINARY_MODE  = 1
 BINARY_DEFINED  = 1
 
+ifneq ($(OS_EMBEDDED), 1)
 CCOMMON_OPT += -marm
 FCOMMON_OPT += -marm
+endif
 
 # If softfp abi is mentioned on the command line, force it.
 ifeq ($(ARM_SOFTFP_ABI), 1)

--- a/Makefile.system
+++ b/Makefile.system
@@ -811,9 +811,11 @@ ifeq ($(ARCH), arm)
 NO_BINARY_MODE  = 1
 BINARY_DEFINED  = 1
 
-ifneq ($(OS_EMBEDDED), 1)
+ifneq ($(EMBEDDED), 1)
 CCOMMON_OPT += -marm
 FCOMMON_OPT += -marm
+else
+CCOMMON_OPT += -DOS_EMBEDDED
 endif
 
 # If softfp abi is mentioned on the command line, force it.


### PR DESCRIPTION
fixes #4570