### PR TITLE
Revert "CI: add openblas_utest_ext for c910v, mips64 and loongarch64"

### DIFF
--- a/.github/workflows/c910v.yml
+++ b/.github/workflows/c910v.yml
@@ -84,7 +84,6 @@ jobs:
         run: |
           export PATH=$GITHUB_WORKSPACE/qemu-install/bin/:$PATH
           qemu-riscv64 ./utest/openblas_utest
-          qemu-riscv64 ./utest/openblas_utest_ext
           OPENBLAS_NUM_THREADS=2 qemu-riscv64 ./ctest/xscblat1
           OPENBLAS_NUM_THREADS=2 qemu-riscv64 ./ctest/xdcblat1
           OPENBLAS_NUM_THREADS=2 qemu-riscv64 ./ctest/xccblat1

--- a/.github/workflows/loongarch64.yml
+++ b/.github/workflows/loongarch64.yml
@@ -77,7 +77,6 @@ jobs:
       - name: Test
         run: |
           qemu-loongarch64-static ./utest/openblas_utest
-          qemu-loongarch64-static ./utest/openblas_utest_ext
           OPENBLAS_NUM_THREADS=2 qemu-loongarch64-static ./ctest/xscblat1
           OPENBLAS_NUM_THREADS=2 qemu-loongarch64-static ./ctest/xdcblat1
           OPENBLAS_NUM_THREADS=2 qemu-loongarch64-static ./ctest/xccblat1

--- a/.github/workflows/mips64.yml
+++ b/.github/workflows/mips64.yml
@@ -80,7 +80,6 @@ jobs:
         run: |
           export PATH=$GITHUB_WORKSPACE/qemu-install/bin/:$PATH
           qemu-mips64el ./utest/openblas_utest
-          qemu-mips64el ./utest/openblas_utest_ext
           OPENBLAS_NUM_THREADS=2 qemu-mips64el ./ctest/xscblat1
           OPENBLAS_NUM_THREADS=2 qemu-mips64el ./ctest/xdcblat1
           OPENBLAS_NUM_THREADS=2 qemu-mips64el ./ctest/xccblat1


### PR DESCRIPTION
Reverts OpenMathLib/OpenBLAS#4628 misread the failures exposed by this PR, backing out to unbreak the build