### PR TITLE
Fix uninitialized variables in LAPACK tests for ?QP3RK (Reference-LAPACK PR 961)

### DIFF
--- a/lapack-netlib/TESTING/LIN/cchkqp3rk.f
+++ b/lapack-netlib/TESTING/LIN/cchkqp3rk.f
@@ -608,6 +608,9 @@
                   CALL CLACPY( 'All', M, NRHS, COPYB, LDA,
      $                         B,  LDA )
                   CALL ICOPY( N, IWORK( 1 ), 1, IWORK( N+1 ), 1 )
+                  DO I = 1, NTESTS
+                    RESULT( I ) = ZERO
+                  END DO
 *
                   ABSTOL = -1.0
                   RELTOl = -1.0
@@ -652,16 +655,6 @@
                      RESULT( 1 ) = CQRT12( M, N, A, LDA, S, WORK,
      $                                     LWORK , RWORK )
 *
-                     DO T = 1, 1
-                        IF( RESULT( T ).GE.THRESH ) THEN
-                           IF( NFAIL.EQ.0 .AND. NERRS.EQ.0 )
-     $                        CALL ALAHD( NOUT, PATH )
-                           WRITE( NOUT, FMT = 9999 ) 'CGEQP3RK', M, N,
-     $                        NRHS, KMAX, ABSTOL, RELTOL, NB, NX,
-     $                        IMAT, T, RESULT( T )
-                           NFAIL = NFAIL + 1
-                        END IF
-                     END DO
                      NRUN = NRUN + 1
 *
 *                   End test 1
@@ -675,7 +668,7 @@
 *                 1-norm( A*P - Q*R ) / ( max(M,N) * 1-norm(A) * EPS )
 *
                   RESULT( 2 ) = CQPT01( M, N, KFACT, COPYA, A, LDA, TAU,
-     $                          IWORK( N+1 ), WORK, LWORK )
+     $                                  IWORK( N+1 ), WORK, LWORK )
 *
 *                 Compute test 3:
 *
@@ -684,21 +677,8 @@
 *                 1-norm( Q**T * Q - I ) / ( M * EPS )
 *
                   RESULT( 3 ) = CQRT11( M, KFACT, A, LDA, TAU, WORK,
-     $                          LWORK )
+     $                                  LWORK )
 *
-*                 Print information about the tests that did not pass
-*                 the threshold.
-*
-                  DO T = 2, 3
-                     IF( RESULT( T ).GE.THRESH ) THEN
-                        IF( NFAIL.EQ.0 .AND. NERRS.EQ.0 )
-     $                     CALL ALAHD( NOUT, PATH )
-                        WRITE( NOUT, FMT = 9999 ) 'CGEQP3RK', M, N,
-     $                      NRHS, KMAX, ABSTOL, RELTOL,
-     $                      NB, NX, IMAT, T, RESULT( T )
-                        NFAIL = NFAIL + 1
-                     END IF
-                  END DO
                   NRUN = NRUN + 2
 *
 *                 Compute test 4:
@@ -717,8 +697,8 @@
 *
                      DO J = 1, KFACT-1, 1
 *
-                        DTEMP = (( ABS( A( (J-1)*M+J ) ) -
-     $                          ABS( A( (J)*M+J+1 ) ) ) /
+                        DTEMP = (( ABS( A( (J-1)*LDA+J ) ) -
+     $                          ABS( A( (J)*LDA+J+1 ) ) ) /
      $                          ABS( A(1) ) )
 *
                         IF( DTEMP.LT.ZERO ) THEN
@@ -727,20 +707,6 @@
 *
                      END DO
 *
-*                    Print information about the tests that did not
-*                    pass the threshold.
-*
-                     DO T = 4, 4
-                        IF( RESULT( T ).GE.THRESH ) THEN
-                           IF( NFAIL.EQ.0 .AND. NERRS.EQ.0 )
-     $                        CALL ALAHD( NOUT, PATH )
-                           WRITE( NOUT, FMT = 9999 ) 'CGEQP3RK',
-     $                        M, N, NRHS, KMAX, ABSTOL, RELTOL,
-     $                        NB, NX, IMAT, T,
-     $                        RESULT( T )
-                           NFAIL = NFAIL + 1
-                        END IF
-                     END DO
                      NRUN = NRUN + 1
 *
 *                    End test 4.
@@ -762,41 +728,40 @@
 *
                      LWORK_MQR = MAX(1, NRHS)
                      CALL CUNMQR( 'Left', 'Conjugate transpose',
-     $                         M, NRHS, KFACT, A, LDA, TAU, B, LDA,
-     $                         WORK, LWORK_MQR, INFO )
+     $                            M, NRHS, KFACT, A, LDA, TAU, B, LDA,
+     $                            WORK, LWORK_MQR, INFO )
 *
                      DO I = 1, NRHS
 *
 *                       Compare N+J-th column of A and J-column of B.
 *
                         CALL CAXPY( M, -CONE, A( ( N+I-1 )*LDA+1 ), 1,
-     $                                    B( ( I-1 )*LDA+1 ), 1 )
+     $                              B( ( I-1 )*LDA+1 ), 1 )
                      END DO
 *
-                     RESULT( 5 ) =
-     $               ABS(
-     $               CLANGE( 'One-norm', M, NRHS, B, LDA, RDUMMY ) /
-     $               ( REAL( M )*SLAMCH( 'Epsilon' ) )
-     $               )
+                     RESULT( 5 ) = ABS(
+     $                  CLANGE( 'One-norm', M, NRHS, B, LDA, RDUMMY ) /
+     $                  ( REAL( M )*SLAMCH( 'Epsilon' ) ) )
 *
-*                    Print information about the tests that did not pass
-*                    the threshold.
-*
-                     DO T = 5, 5
-                        IF( RESULT( T ).GE.THRESH ) THEN
-                           IF( NFAIL.EQ.0 .AND. NERRS.EQ.0 )
-     $                        CALL ALAHD( NOUT, PATH )
-                           WRITE( NOUT, FMT = 9999 ) 'CGEQP3RK', M, N,
-     $                        NRHS, KMAX, ABSTOL, RELTOL,
-     $                        NB, NX, IMAT, T, RESULT( T )
-                           NFAIL = NFAIL + 1
-                        END IF
-                     END DO
                      NRUN = NRUN + 1
 *
 *                    End compute test 5.
 *
                   END IF
+*
+*                 Print information about the tests that did not pass
+*                 the threshold.
+*
+                  DO T = 1, NTESTS
+                     IF( RESULT( T ).GE.THRESH ) THEN
+                        IF( NFAIL.EQ.0 .AND. NERRS.EQ.0 )
+     $                     CALL ALAHD( NOUT, PATH )
+                        WRITE( NOUT, FMT = 9999 ) 'CGEQP3RK', M, N,
+     $                      NRHS, KMAX, ABSTOL, RELTOL,
+     $                      NB, NX, IMAT, T, RESULT( T )
+                        NFAIL = NFAIL + 1
+                     END IF
+                  END DO
 *
 *                 END DO KMAX = 1, MIN(M,N)+1
 *

--- a/lapack-netlib/TESTING/LIN/dchkqp3rk.f
+++ b/lapack-netlib/TESTING/LIN/dchkqp3rk.f
@@ -605,6 +605,9 @@
                   CALL DLACPY( 'All', M, NRHS, COPYB, LDA,
      $                         B,  LDA )
                   CALL ICOPY( N, IWORK( 1 ), 1, IWORK( N+1 ), 1 )
+                   DO I = 1, NTESTS
+                     RESULT( I ) = ZERO
+                   END DO
 *
                   ABSTOL = -1.0
                   RELTOL = -1.0
@@ -648,16 +651,6 @@
                      RESULT( 1 ) = DQRT12( M, N, A, LDA, S, WORK,
      $                                     LWORK )
 *
-                     DO T = 1, 1
-                        IF( RESULT( T ).GE.THRESH ) THEN
-                           IF( NFAIL.EQ.0 .AND. NERRS.EQ.0 )
-     $                        CALL ALAHD( NOUT, PATH )
-                           WRITE( NOUT, FMT = 9999 ) 'DGEQP3RK', M, N,
-     $                        NRHS, KMAX, ABSTOL, RELTOL, NB, NX,
-     $                        IMAT, T, RESULT( T )
-                           NFAIL = NFAIL + 1
-                        END IF
-                     END DO
                      NRUN = NRUN + 1
 *
 *                   End test 1
@@ -671,7 +664,7 @@
 *                 1-norm( A*P - Q*R ) / ( max(M,N) * 1-norm(A) * EPS )
 *
                   RESULT( 2 ) = DQPT01( M, N, KFACT, COPYA, A, LDA, TAU,
-     $                          IWORK( N+1 ), WORK, LWORK )
+     $                                  IWORK( N+1 ), WORK, LWORK )
 *
 *                 Compute test 3:
 *
@@ -680,21 +673,8 @@
 *                 1-norm( Q**T * Q - I ) / ( M * EPS )
 *
                   RESULT( 3 ) = DQRT11( M, KFACT, A, LDA, TAU, WORK,
-     $                          LWORK )
+     $                                  LWORK )
 *
-*                 Print information about the tests that did not pass
-*                 the threshold.
-*
-                  DO T = 2, 3
-                     IF( RESULT( T ).GE.THRESH ) THEN
-                        IF( NFAIL.EQ.0 .AND. NERRS.EQ.0 )
-     $                     CALL ALAHD( NOUT, PATH )
-                        WRITE( NOUT, FMT = 9999 ) 'DGEQP3RK', M, N,
-     $                      NRHS, KMAX, ABSTOL, RELTOL,
-     $                      NB, NX, IMAT, T, RESULT( T )
-                        NFAIL = NFAIL + 1
-                     END IF
-                  END DO
                   NRUN = NRUN + 2
 *
 *                 Compute test 4:
@@ -713,8 +693,8 @@
 *
                      DO J = 1, KFACT-1, 1
 
-                        DTEMP = (( ABS( A( (J-1)*M+J ) ) -
-     $                          ABS( A( (J)*M+J+1 ) ) ) /
+                        DTEMP = (( ABS( A( (J-1)*LDA+J ) ) -
+     $                          ABS( A( (J)*LDA+J+1 ) ) ) /
      $                          ABS( A(1) ) )
 *
                         IF( DTEMP.LT.ZERO ) THEN
@@ -723,20 +703,6 @@
 *
                      END DO
 *
-*                    Print information about the tests that did not
-*                    pass the threshold.
-*
-                     DO T = 4, 4
-                        IF( RESULT( T ).GE.THRESH ) THEN
-                           IF( NFAIL.EQ.0 .AND. NERRS.EQ.0 )
-     $                        CALL ALAHD( NOUT, PATH )
-                           WRITE( NOUT, FMT = 9999 ) 'DGEQP3RK',
-     $                        M, N, NRHS, KMAX, ABSTOL, RELTOL,
-     $                        NB, NX, IMAT, T,
-     $                        RESULT( T )
-                           NFAIL = NFAIL + 1
-                        END IF
-                     END DO
                      NRUN = NRUN + 1
 *
 *                    End test 4.
@@ -758,41 +724,40 @@
 *
                      LWORK_MQR = MAX(1, NRHS)
                      CALL DORMQR( 'Left', 'Transpose',
-     $                         M, NRHS, KFACT, A, LDA, TAU, B, LDA,
-     $                         WORK, LWORK_MQR, INFO )
+     $                            M, NRHS, KFACT, A, LDA, TAU, B, LDA,
+     $                            WORK, LWORK_MQR, INFO )
 *
                      DO I = 1, NRHS
 *
 *                       Compare N+J-th column of A and J-column of B.
 *
                         CALL DAXPY( M, -ONE, A( ( N+I-1 )*LDA+1 ), 1,
-     $                                 B( ( I-1 )*LDA+1 ), 1 )
+     $                              B( ( I-1 )*LDA+1 ), 1 )
                      END DO
 *
-                   RESULT( 5 ) =
-     $               ABS(
-     $               DLANGE( 'One-norm', M, NRHS, B, LDA, RDUMMY ) /
-     $               ( DBLE( M )*DLAMCH( 'Epsilon' ) )
-     $               )
+                     RESULT( 5 ) = ABS(
+     $                  DLANGE( 'One-norm', M, NRHS, B, LDA, RDUMMY ) /
+     $                  ( DBLE( M )*DLAMCH( 'Epsilon' ) ) )
 *
-*                    Print information about the tests that did not pass
-*                    the threshold.
-*
-                     DO T = 5, 5
-                        IF( RESULT( T ).GE.THRESH ) THEN
-                           IF( NFAIL.EQ.0 .AND. NERRS.EQ.0 )
-     $                        CALL ALAHD( NOUT, PATH )
-                           WRITE( NOUT, FMT = 9999 ) 'DGEQP3RK', M, N,
-     $                        NRHS, KMAX, ABSTOL, RELTOL,
-     $                        NB, NX, IMAT, T, RESULT( T )
-                           NFAIL = NFAIL + 1
-                        END IF
-                     END DO
                      NRUN = NRUN + 1
 *
 *                    End compute test 5.
 *
                   END IF
+*
+*                 Print information about the tests that did not
+*                 pass the threshold.
+*
+                  DO T = 1, NTESTS
+                     IF( RESULT( T ).GE.THRESH ) THEN
+                        IF( NFAIL.EQ.0 .AND. NERRS.EQ.0 )
+     $                     CALL ALAHD( NOUT, PATH )
+                        WRITE( NOUT, FMT = 9999 ) 'DGEQP3RK', M, N,
+     $                     NRHS, KMAX, ABSTOL, RELTOL, NB, NX,
+     $                     IMAT, T, RESULT( T )
+                        NFAIL = NFAIL + 1
+                     END IF
+                  END DO
 *
 *                 END DO KMAX = 1, MIN(M,N)+1
 *

--- a/lapack-netlib/TESTING/LIN/schkqp3rk.f
+++ b/lapack-netlib/TESTING/LIN/schkqp3rk.f
@@ -604,6 +604,9 @@
                   CALL SLACPY( 'All', M, NRHS, COPYB, LDA,
      $                         B,  LDA )
                   CALL ICOPY( N, IWORK( 1 ), 1, IWORK( N+1 ), 1 )
+                  DO I = 1, NTESTS
+                    RESULT( I ) = ZERO
+                  END DO
 *
                   ABSTOL = -1.0
                   RELTOL = -1.0
@@ -647,16 +650,6 @@
                      RESULT( 1 ) = SQRT12( M, N, A, LDA, S, WORK,
      $                                     LWORK )
 *
-                     DO T = 1, 1
-                        IF( RESULT( T ).GE.THRESH ) THEN
-                           IF( NFAIL.EQ.0 .AND. NERRS.EQ.0 )
-     $                        CALL ALAHD( NOUT, PATH )
-                           WRITE( NOUT, FMT = 9999 ) 'SGEQP3RK', M, N,
-     $                        NRHS, KMAX, ABSTOL, RELTOL, NB, NX,
-     $                        IMAT, T, RESULT( T )
-                           NFAIL = NFAIL + 1
-                        END IF
-                     END DO
                      NRUN = NRUN + 1
 *
 *                   End test 1
@@ -670,7 +663,7 @@
 *                 1-norm( A*P - Q*R ) / ( max(M,N) * 1-norm(A) * EPS )
 *
                   RESULT( 2 ) = SQPT01( M, N, KFACT, COPYA, A, LDA, TAU,
-     $                          IWORK( N+1 ), WORK, LWORK )
+     $                                  IWORK( N+1 ), WORK, LWORK )
 *
 *                 Compute test 3:
 *
@@ -679,21 +672,8 @@
 *                 1-norm( Q**T * Q - I ) / ( M * EPS )
 *
                   RESULT( 3 ) = SQRT11( M, KFACT, A, LDA, TAU, WORK,
-     $                          LWORK )
+     $                                  LWORK )
 *
-*                 Print information about the tests that did not pass
-*                 the threshold.
-*
-                  DO T = 2, 3
-                     IF( RESULT( T ).GE.THRESH ) THEN
-                        IF( NFAIL.EQ.0 .AND. NERRS.EQ.0 )
-     $                     CALL ALAHD( NOUT, PATH )
-                        WRITE( NOUT, FMT = 9999 ) 'SGEQP3RK', M, N,
-     $                      NRHS, KMAX, ABSTOL, RELTOL,
-     $                      NB, NX, IMAT, T, RESULT( T )
-                        NFAIL = NFAIL + 1
-                     END IF
-                  END DO
                   NRUN = NRUN + 2
 *
 *                 Compute test 4:
@@ -712,8 +692,8 @@
 *
                      DO J = 1, KFACT-1, 1
 
-                        DTEMP = (( ABS( A( (J-1)*M+J ) ) -
-     $                          ABS( A( (J)*M+J+1 ) ) ) /
+                        DTEMP = (( ABS( A( (J-1)*LDA+J ) ) -
+     $                          ABS( A( (J)*LDA+J+1 ) ) ) /
      $                          ABS( A(1) ) )
 *
                         IF( DTEMP.LT.ZERO ) THEN
@@ -722,20 +702,6 @@
 *
                      END DO
 *
-*                    Print information about the tests that did not
-*                    pass the threshold.
-*
-                     DO T = 4, 4
-                        IF( RESULT( T ).GE.THRESH ) THEN
-                           IF( NFAIL.EQ.0 .AND. NERRS.EQ.0 )
-     $                        CALL ALAHD( NOUT, PATH )
-                           WRITE( NOUT, FMT = 9999 ) 'SGEQP3RK',
-     $                        M, N, NRHS, KMAX, ABSTOL, RELTOL,
-     $                        NB, NX, IMAT, T,
-     $                        RESULT( T )
-                           NFAIL = NFAIL + 1
-                        END IF
-                     END DO
                      NRUN = NRUN + 1
 *
 *                    End test 4.
@@ -757,41 +723,40 @@
 *
                      LWORK_MQR = MAX(1, NRHS)
                      CALL SORMQR( 'Left', 'Transpose',
-     $                         M, NRHS, KFACT, A, LDA, TAU, B, LDA,
-     $                         WORK, LWORK_MQR, INFO )
+     $                            M, NRHS, KFACT, A, LDA, TAU, B, LDA,
+     $                            WORK, LWORK_MQR, INFO )
 *
                      DO I = 1, NRHS
 *
 *                       Compare N+J-th column of A and J-column of B.
 *
                         CALL SAXPY( M, -ONE, A( ( N+I-1 )*LDA+1 ), 1,
-     $                                 B( ( I-1 )*LDA+1 ), 1 )
+     $                              B( ( I-1 )*LDA+1 ), 1 )
                      END DO
 *
-                   RESULT( 5 ) =
-     $               ABS(
-     $               SLANGE( 'One-norm', M, NRHS, B, LDA, RDUMMY ) /
-     $               ( REAL( M )*SLAMCH( 'Epsilon' ) )
-     $               )
+                     RESULT( 5 ) = ABS(
+     $                  SLANGE( 'One-norm', M, NRHS, B, LDA, RDUMMY ) /
+     $                  ( REAL( M )*SLAMCH( 'Epsilon' ) ) )
 *
-*                    Print information about the tests that did not pass
-*                    the threshold.
-*
-                     DO T = 5, 5
-                        IF( RESULT( T ).GE.THRESH ) THEN
-                           IF( NFAIL.EQ.0 .AND. NERRS.EQ.0 )
-     $                        CALL ALAHD( NOUT, PATH )
-                           WRITE( NOUT, FMT = 9999 ) 'SGEQP3RK', M, N,
-     $                        NRHS, KMAX, ABSTOL, RELTOL,
-     $                        NB, NX, IMAT, T, RESULT( T )
-                           NFAIL = NFAIL + 1
-                        END IF
-                     END DO
                      NRUN = NRUN + 1
 *
 *                    End compute test 5.
 *
                   END IF
+*
+*                 Print information about the tests that did not pass
+*                 the threshold.
+*
+                  DO T = 1, NTESTS
+                     IF( RESULT( T ).GE.THRESH ) THEN
+                        IF( NFAIL.EQ.0 .AND. NERRS.EQ.0 )
+     $                     CALL ALAHD( NOUT, PATH )
+                        WRITE( NOUT, FMT = 9999 ) 'SGEQP3RK', M, N,
+     $                      NRHS, KMAX, ABSTOL, RELTOL,
+     $                      NB, NX, IMAT, T, RESULT( T )
+                        NFAIL = NFAIL + 1
+                     END IF
+                  END DO
 *
 *                 END DO KMAX = 1, MIN(M,N)+1
 *

--- a/lapack-netlib/TESTING/LIN/zchkqp3rk.f
+++ b/lapack-netlib/TESTING/LIN/zchkqp3rk.f
@@ -608,6 +608,9 @@
                   CALL ZLACPY( 'All', M, NRHS, COPYB, LDA,
      $                         B,  LDA )
                   CALL ICOPY( N, IWORK( 1 ), 1, IWORK( N+1 ), 1 )
+                  DO I = 1, NTESTS
+                    RESULT( I ) = ZERO
+                  END DO
 *
                   ABSTOL = -1.0
                   RELTOl = -1.0
@@ -652,16 +655,6 @@
                      RESULT( 1 ) = ZQRT12( M, N, A, LDA, S, WORK,
      $                                     LWORK , RWORK )
 *
-                     DO T = 1, 1
-                        IF( RESULT( T ).GE.THRESH ) THEN
-                           IF( NFAIL.EQ.0 .AND. NERRS.EQ.0 )
-     $                        CALL ALAHD( NOUT, PATH )
-                           WRITE( NOUT, FMT = 9999 ) 'ZGEQP3RK', M, N,
-     $                        NRHS, KMAX, ABSTOL, RELTOL, NB, NX,
-     $                        IMAT, T, RESULT( T )
-                           NFAIL = NFAIL + 1
-                        END IF
-                     END DO
                      NRUN = NRUN + 1
 *
 *                   End test 1
@@ -675,7 +668,7 @@
 *                 1-norm( A*P - Q*R ) / ( max(M,N) * 1-norm(A) * EPS )
 *
                   RESULT( 2 ) = ZQPT01( M, N, KFACT, COPYA, A, LDA, TAU,
-     $                          IWORK( N+1 ), WORK, LWORK )
+     $                                  IWORK( N+1 ), WORK, LWORK )
 *
 *                 Compute test 3:
 *
@@ -684,21 +677,8 @@
 *                 1-norm( Q**T * Q - I ) / ( M * EPS )
 *
                   RESULT( 3 ) = ZQRT11( M, KFACT, A, LDA, TAU, WORK,
-     $                          LWORK )
+     $                                  LWORK )
 *
-*                 Print information about the tests that did not pass
-*                 the threshold.
-*
-                  DO T = 2, 3
-                     IF( RESULT( T ).GE.THRESH ) THEN
-                        IF( NFAIL.EQ.0 .AND. NERRS.EQ.0 )
-     $                     CALL ALAHD( NOUT, PATH )
-                        WRITE( NOUT, FMT = 9999 ) 'ZGEQP3RK', M, N,
-     $                      NRHS, KMAX, ABSTOL, RELTOL,
-     $                      NB, NX, IMAT, T, RESULT( T )
-                        NFAIL = NFAIL + 1
-                     END IF
-                  END DO
                   NRUN = NRUN + 2
 *
 *                 Compute test 4:
@@ -717,8 +697,8 @@
 *
                      DO J = 1, KFACT-1, 1
 *
-                        DTEMP = (( ABS( A( (J-1)*M+J ) ) -
-     $                          ABS( A( (J)*M+J+1 ) ) ) /
+                        DTEMP = (( ABS( A( (J-1)*LDA+J ) ) -
+     $                          ABS( A( (J)*LDA+J+1 ) ) ) /
      $                          ABS( A(1) ) )
 *
                         IF( DTEMP.LT.ZERO ) THEN
@@ -727,20 +707,6 @@
 *
                      END DO
 *
-*                    Print information about the tests that did not
-*                    pass the threshold.
-*
-                     DO T = 4, 4
-                        IF( RESULT( T ).GE.THRESH ) THEN
-                           IF( NFAIL.EQ.0 .AND. NERRS.EQ.0 )
-     $                        CALL ALAHD( NOUT, PATH )
-                           WRITE( NOUT, FMT = 9999 ) 'ZGEQP3RK',
-     $                        M, N, NRHS, KMAX, ABSTOL, RELTOL,
-     $                        NB, NX, IMAT, T,
-     $                        RESULT( T )
-                           NFAIL = NFAIL + 1
-                        END IF
-                     END DO
                      NRUN = NRUN + 1
 *
 *                    End test 4.
@@ -762,41 +728,40 @@
 *
                      LWORK_MQR = MAX(1, NRHS)
                      CALL ZUNMQR( 'Left', 'Conjugate transpose',
-     $                         M, NRHS, KFACT, A, LDA, TAU, B, LDA,
-     $                         WORK, LWORK_MQR, INFO )
+     $                            M, NRHS, KFACT, A, LDA, TAU, B, LDA,
+     $                            WORK, LWORK_MQR, INFO )
 *
                      DO I = 1, NRHS
 *
 *                       Compare N+J-th column of A and J-column of B.
 *
                         CALL ZAXPY( M, -CONE, A( ( N+I-1 )*LDA+1 ), 1,
-     $                                    B( ( I-1 )*LDA+1 ), 1 )
+     $                              B( ( I-1 )*LDA+1 ), 1 )
                      END DO
 *
-                     RESULT( 5 ) =
-     $               ABS(
-     $               ZLANGE( 'One-norm', M, NRHS, B, LDA, RDUMMY ) /
-     $               ( DBLE( M )*DLAMCH( 'Epsilon' ) )
-     $               )
+                     RESULT( 5 ) = ABS(
+     $                  ZLANGE( 'One-norm', M, NRHS, B, LDA, RDUMMY ) /
+     $                  ( DBLE( M )*DLAMCH( 'Epsilon' ) ) )
 *
-*                    Print information about the tests that did not pass
-*                    the threshold.
-*
-                     DO T = 5, 5
-                        IF( RESULT( T ).GE.THRESH ) THEN
-                           IF( NFAIL.EQ.0 .AND. NERRS.EQ.0 )
-     $                        CALL ALAHD( NOUT, PATH )
-                           WRITE( NOUT, FMT = 9999 ) 'ZGEQP3RK', M, N,
-     $                        NRHS, KMAX, ABSTOL, RELTOL,
-     $                        NB, NX, IMAT, T, RESULT( T )
-                           NFAIL = NFAIL + 1
-                        END IF
-                     END DO
                      NRUN = NRUN + 1
 *
 *                    End compute test 5.
 *
                   END IF
+*
+*                 Print information about the tests that did not pass
+*                 the threshold.
+*
+                  DO T = 1, NTESTS
+                     IF( RESULT( T ).GE.THRESH ) THEN
+                        IF( NFAIL.EQ.0 .AND. NERRS.EQ.0 )
+     $                     CALL ALAHD( NOUT, PATH )
+                        WRITE( NOUT, FMT = 9999 ) 'ZGEQP3RK', M, N,
+     $                      NRHS, KMAX, ABSTOL, RELTOL,
+     $                      NB, NX, IMAT, T, RESULT( T )
+                        NFAIL = NFAIL + 1
+                     END IF
+                  END DO
 *
 *                 END DO KMAX = 1, MIN(M,N)+1
 *


### PR DESCRIPTION
fixes #4625