### PR TITLE
Fix a build issue for PRESCOTT on x86_64

### DIFF
--- a/common_x86.h
+++ b/common_x86.h
@@ -229,7 +229,7 @@ static __inline int blas_quickdivide(unsigned int x, unsigned int y){
 #define EMMS
 #endif
 
-#if defined(CORE2) || defined(PENTIUM4)
+#if defined(CORE2) || defined(PENTIUM4) || defined(PRESCOTT)
 #define movapd	movaps
 #endif
 

--- a/kernel/x86_64/dgemm_ncopy_4.S
+++ b/kernel/x86_64/dgemm_ncopy_4.S
@@ -39,7 +39,7 @@
 #define ASSEMBLER
 #include "common.h"
 
-#if defined(PENTIUM4) || defined(GENERIC)
+#if defined(PENTIUM4) || defined(PRESCOTT) || defined(GENERIC)
 #define PREFETCHSIZE	16
 #define PREFETCH      prefetcht0
 #define PREFETCHW     prefetcht0

--- a/kernel/x86_64/dgemm_tcopy_2.S
+++ b/kernel/x86_64/dgemm_tcopy_2.S
@@ -39,7 +39,7 @@
 #define ASSEMBLER
 #include "common.h"
 
-#if defined(PENTIUM4) || defined(GENERIC)
+#if defined(PENTIUM4) || defined(PRESCOTT) || defined(GENERIC)
 #define PREFETCHSIZE	16
 #define PREFETCH      prefetcht0
 #define PREFETCHW     prefetcht0

--- a/kernel/x86_64/dgemm_tcopy_4.S
+++ b/kernel/x86_64/dgemm_tcopy_4.S
@@ -39,7 +39,7 @@
 #define ASSEMBLER
 #include "common.h"
 
-#if defined(PENTIUM4) || defined(GENERIC)
+#if defined(PENTIUM4) || defined(PRESCOTT) || defined(GENERIC)
 #define PREFETCHSIZE	16
 #define PREFETCH      prefetcht0
 #define PREFETCHW     prefetcht0

--- a/kernel/x86_64/gemm_kernel_8x4_sse.S
+++ b/kernel/x86_64/gemm_kernel_8x4_sse.S
@@ -1713,7 +1713,7 @@
 	ALIGN_4
 
 .L52:
-#if defined(PENTIUM4) || defined(GENERIC)
+#if defined(PENTIUM4) || defined(PRESCOTT) || defined(GENERIC)
 	movss	 0 * SIZE(B), %xmm0
 	movss	 1 * SIZE(B), %xmm1
 	movss	 2 * SIZE(B), %xmm2
@@ -1801,7 +1801,7 @@
 	ALIGN_4
 
 .L54:
-#if defined(PENTIUM4) || defined(GENERIC)
+#if defined(PENTIUM4) || defined(PRESCOTT) || defined(GENERIC)
 	movss	 0 * SIZE(B), %xmm0
 	movss	 1 * SIZE(B), %xmm1
 
@@ -2689,7 +2689,7 @@
 
 
 .L102:
-#if defined(PENTIUM4) || defined(GENERIC)
+#if defined(PENTIUM4) || defined(PRESCOTT) || defined(GENERIC)
 	movss	 0 * SIZE(B), %xmm0
 	movss	 1 * SIZE(B), %xmm1
 	movss	 2 * SIZE(B), %xmm2
@@ -2777,7 +2777,7 @@
 	ALIGN_4
 
 .L104:
-#if defined(PENTIUM4) || defined(GENERIC)
+#if defined(PENTIUM4) || defined(PRESCOTT) || defined(GENERIC)
 	movss	 0 * SIZE(B), %xmm0
 	shufps	 $0, %xmm0, %xmm0
 	movaps	%xmm0,  0 * SIZE(BO)

--- a/kernel/x86_64/gemm_ncopy_4.S
+++ b/kernel/x86_64/gemm_ncopy_4.S
@@ -39,7 +39,7 @@
 #define ASSEMBLER
 #include "common.h"
 
-#if defined(PENTIUM4) || defined(GENERIC)
+#if defined(PENTIUM4) || defined(PRESCOTT) || defined(GENERIC)
 #define RPREFETCHSIZE	16
 #define WPREFETCHSIZE (RPREFETCHSIZE * 4)
 #define PREFETCH      prefetcht0

--- a/kernel/x86_64/gemm_tcopy_4.S
+++ b/kernel/x86_64/gemm_tcopy_4.S
@@ -39,7 +39,7 @@
 #define ASSEMBLER
 #include "common.h"
 
-#if defined(PENTIUM4) || defined(GENERIC)
+#if defined(PENTIUM4) || defined(PRESCOTT) || defined(GENERIC)
 #define RPREFETCHSIZE	16
 #define WPREFETCHSIZE (RPREFETCHSIZE * 4)
 #define PREFETCH      prefetcht0
@@ -204,7 +204,7 @@
 	movlps	0 * SIZE(AO4), %xmm3
 	movhps	2 * SIZE(AO4), %xmm3
 
-#if defined(PENTIUM4) || defined(GENERIC)
+#if defined(PENTIUM4) || defined(PRESCOTT) || defined(GENERIC)
 	PREFETCH	RPREFETCHSIZE * SIZE(AO1)
 	PREFETCH	RPREFETCHSIZE * SIZE(AO2)
 	PREFETCH	RPREFETCHSIZE * SIZE(AO3)
@@ -362,7 +362,7 @@
 	movlps	0 * SIZE(AO2), %xmm1
 	movhps	2 * SIZE(AO2), %xmm1
 
-#if defined(PENTIUM4) || defined(GENERIC)
+#if defined(PENTIUM4) || defined(PRESCOTT) || defined(GENERIC)
 	PREFETCH	RPREFETCHSIZE * SIZE(AO1)
 	PREFETCH	RPREFETCHSIZE * SIZE(AO2)
 	PREFETCHW	WPREFETCHSIZE * SIZE(BO)
@@ -381,7 +381,7 @@
 	movsd	2 * SIZE(AO2), %xmm3
 	movhpd	3 * SIZE(AO2), %xmm3
 
-#if defined(PENTIUM4) || defined(GENERIC)
+#if defined(PENTIUM4) || defined(PRESCOTT) || defined(GENERIC)
 	PREFETCH	RPREFETCHSIZE * SIZE(AO1)
 	PREFETCH	RPREFETCHSIZE * SIZE(AO2)
 	PREFETCHW	WPREFETCHSIZE * SIZE(BO)

--- a/kernel/x86_64/izamax_sse2.S
+++ b/kernel/x86_64/izamax_sse2.S
@@ -473,7 +473,7 @@
 	prefetch	PREFETCHSIZE * SIZE(X)
 #endif
 
-#ifdef PENTIUM4
+#if defined(PENTIUM4) || defined(PRESCOTT)
 	prefetchnta	PREFETCHSIZE * SIZE(X)
 #endif
 

--- a/kernel/x86_64/symv_L_sse.S
+++ b/kernel/x86_64/symv_L_sse.S
@@ -63,7 +63,7 @@
 #define PREFETCHSIZE	(16 * 12)
 #endif
 
-#ifdef PENTIUM4
+#if defined(PENTIUM4) || defined(PRESCOTT)
 #define PREFETCH	prefetcht0
 #define PREFETCHW	prefetcht0
 #define PREFETCHSIZE	(16 * 20)

--- a/kernel/x86_64/symv_L_sse2.S
+++ b/kernel/x86_64/symv_L_sse2.S
@@ -63,7 +63,7 @@
 #define PREFETCHSIZE	(16 * 12)
 #endif
 
-#ifdef PENTIUM4
+#if defined(PENTIUM4) || defined(PRESCOTT)
 #define PREFETCH	prefetcht0
 #define PREFETCHW	prefetcht0
 #define PREFETCHSIZE	(16 * 20)

--- a/kernel/x86_64/symv_U_sse.S
+++ b/kernel/x86_64/symv_U_sse.S
@@ -63,7 +63,7 @@
 #define PREFETCHSIZE	(16 * 12)
 #endif
 
-#ifdef PENTIUM4
+#if defined(PENTIUM4) || defined(PRESCOTT)
 #define PREFETCH	prefetcht0
 #define PREFETCHW	prefetcht0
 #define PREFETCHSIZE	(16 * 20)

--- a/kernel/x86_64/symv_U_sse2.S
+++ b/kernel/x86_64/symv_U_sse2.S
@@ -63,7 +63,7 @@
 #define PREFETCHSIZE	(16 * 24)
 #endif
 
-#ifdef PENTIUM4
+#if defined(PENTIUM4) || defined(PRESCOTT)
 #define PREFETCH	prefetcht0
 #define PREFETCHW	prefetcht0
 #define PREFETCHSIZE	(16 * 20)

--- a/kernel/x86_64/trsm_kernel_LN_8x4_sse.S
+++ b/kernel/x86_64/trsm_kernel_LN_8x4_sse.S
@@ -81,7 +81,7 @@
 #define BORIG	 48(%rsp)
 #define BUFFER	128(%rsp)
 
-#ifdef PENTIUM4
+#if defined(PENTIUM4) || defined(PRESCOTT)
 #define PREFETCH     prefetcht0
 #define PREFETCHW    prefetcht0
 #endif

--- a/kernel/x86_64/trsm_kernel_LT_8x4_sse.S
+++ b/kernel/x86_64/trsm_kernel_LT_8x4_sse.S
@@ -81,7 +81,7 @@
 #define BORIG	 48(%rsp)
 #define BUFFER	128(%rsp)
 
-#ifdef PENTIUM4
+#if defined(PENTIUM4) || defined(PRESCOTT)
 #define PREFETCH     prefetcht0
 #define PREFETCHW    prefetcht0
 #endif

--- a/kernel/x86_64/trsm_kernel_RT_8x4_sse.S
+++ b/kernel/x86_64/trsm_kernel_RT_8x4_sse.S
@@ -81,7 +81,7 @@
 #define BORIG	 48(%rsp)
 #define BUFFER	128(%rsp)
 
-#ifdef PENTIUM4
+#if defined(PENTIUM4) || defined(PRESCOTT)
 #define PREFETCH     prefetcht0
 #define PREFETCHW    prefetcht0
 #endif

--- a/kernel/x86_64/zasum_sse2.S
+++ b/kernel/x86_64/zasum_sse2.S
@@ -249,7 +249,7 @@
 	prefetcht0	PREFETCHSIZE * SIZE(X)
 #endif
 
-#ifdef PENTIUM4
+#if defined(PENTIUM4) || defined(PRESCOTT)
 	prefetchnta	PREFETCHSIZE * SIZE(X)
 #endif
 

--- a/kernel/x86_64/zgemm3m_kernel_8x4_sse.S
+++ b/kernel/x86_64/zgemm3m_kernel_8x4_sse.S
@@ -1792,7 +1792,7 @@
 	ALIGN_4
 
 .L52:
-#if defined(PENTIUM4) || defined(GENERIC)
+#if defined(PENTIUM4) || defined(PRESCOTT) || defined(GENERIC)
 	movss	 0 * SIZE(B), %xmm0
 	movss	 1 * SIZE(B), %xmm1
 	movss	 2 * SIZE(B), %xmm2
@@ -1880,7 +1880,7 @@
 	ALIGN_4
 
 .L54:
-#if defined(PENTIUM4) || defined(GENERIC)
+#if defined(PENTIUM4) || defined(PRESCOTT) || defined(GENERIC)
 	movss	 0 * SIZE(B), %xmm0
 	movss	 1 * SIZE(B), %xmm1
 
@@ -2763,7 +2763,7 @@
 
 
 .L102:
-#if defined(PENTIUM4) || defined(GENERIC)
+#if defined(PENTIUM4) || defined(PRESCOTT) || defined(GENERIC)
 	movss	 0 * SIZE(B), %xmm0
 	movss	 1 * SIZE(B), %xmm1
 	movss	 2 * SIZE(B), %xmm2
@@ -2851,7 +2851,7 @@
 	ALIGN_4
 
 .L104:
-#if defined(PENTIUM4) || defined(GENERIC)
+#if defined(PENTIUM4) || defined(PRESCOTT) || defined(GENERIC)
 	movss	 0 * SIZE(B), %xmm0
 	shufps	 $0, %xmm0, %xmm0
 	movaps	%xmm0,  0 * SIZE(BO)

--- a/kernel/x86_64/zgemm_kernel_4x2_sse.S
+++ b/kernel/x86_64/zgemm_kernel_4x2_sse.S
@@ -93,7 +93,7 @@
 #define PREFETCHSIZE (16 * 5 + 8)
 #endif
 
-#if defined(PENTIUM4) || defined(GENERIC)
+#if defined(PENTIUM4) || defined(PRESCOTT) || defined(GENERIC)
 #define PREFETCH     prefetcht0
 #define PREFETCHW    prefetcht0
 #define PREFETCHSIZE  160
@@ -1573,7 +1573,7 @@
 	movaps	%xmm14, 24 * SIZE(BO)
 	movaps	%xmm15, 28 * SIZE(BO)
 
-#if defined(PENTIUM4) || defined(GENERIC)
+#if defined(PENTIUM4) || defined(PRESCOTT) || defined(GENERIC)
         PREFETCHW	128 * SIZE(BO)
 	PREFETCH	112 * SIZE(B)
 #endif

--- a/kernel/x86_64/zgemm_ncopy_2.S
+++ b/kernel/x86_64/zgemm_ncopy_2.S
@@ -74,7 +74,7 @@
 #define WPREFETCHSIZE 48
 #endif
 
-#if defined(PENTIUM4) || defined(GENERIC) || defined(NANO)
+#if defined(PENTIUM4) || defined(PRESCOTT) || defined(GENERIC) || defined(NANO)
 #define RPREFETCHSIZE 32
 #define WPREFETCHSIZE 80
 #endif
@@ -150,7 +150,7 @@
 	movlps	6 * SIZE(AO1), %xmm3
 	movhps	6 * SIZE(AO2), %xmm3
 
-#if defined(PENTIUM4) || defined(GENERIC) || defined(NANO)
+#if defined(PENTIUM4) || defined(PRESCOTT) || defined(GENERIC) || defined(NANO)
 	prefetcht0	RPREFETCHSIZE * SIZE(AO1)
 	prefetcht0	RPREFETCHSIZE * SIZE(AO2)
 
@@ -191,7 +191,7 @@
 	movsd	6 * SIZE(AO2), %xmm7
 	movhpd	7 * SIZE(AO2), %xmm7
 
-#if defined(PENTIUM4) || defined(GENERIC) || defined(NANO)
+#if defined(PENTIUM4) || defined(PRESCOTT) || defined(GENERIC) || defined(NANO)
 	prefetcht0	RPREFETCHSIZE * SIZE(AO1)
 	prefetcht0	RPREFETCHSIZE * SIZE(AO2)
 
@@ -295,7 +295,7 @@
 	movapd	%xmm3,   6 * SIZE(B)
 #endif
 
-#if defined(PENTIUM4) || defined(GENERIC) || defined(NANO)
+#if defined(PENTIUM4) || defined(PRESCOTT) || defined(GENERIC) || defined(NANO)
 	prefetcht0	RPREFETCHSIZE * SIZE(AO1)
 	prefetcht0	RPREFETCHSIZE * SIZE(AO2)
 

--- a/kernel/x86_64/zgemm_tcopy_2.S
+++ b/kernel/x86_64/zgemm_tcopy_2.S
@@ -153,7 +153,7 @@
 	movlps	4 * SIZE(AO2), %xmm3
 	movhps	6 * SIZE(AO2), %xmm3
 
-#if defined(PENTIUM4) || defined(GENERIC) || defined(NANO)
+#if defined(PENTIUM4) || defined(PRESCOTT) || defined(GENERIC) || defined(NANO)
 	prefetcht0	RPREFETCHSIZE * SIZE(AO1)
 	prefetcht0	RPREFETCHSIZE * SIZE(AO2)
 	prefetcht0	WPREFETCHSIZE * SIZE(BO)
@@ -197,7 +197,7 @@
 	movsd	6 * SIZE(AO2), %xmm7
 	movhpd	7 * SIZE(AO2), %xmm7
 
-#if defined(PENTIUM4) || defined(GENERIC) || defined(NANO)
+#if defined(PENTIUM4) || defined(PRESCOTT) || defined(GENERIC) || defined(NANO)
 	prefetcht0	RPREFETCHSIZE * SIZE(AO1)
 	prefetcht0	RPREFETCHSIZE * SIZE(AO2)
 	prefetcht0	WPREFETCHSIZE * SIZE(BO)
@@ -316,7 +316,7 @@
 	movlps	4 * SIZE(AO1), %xmm1
 	movhps	6 * SIZE(AO1), %xmm1
 
-#if defined(PENTIUM4) || defined(GENERIC) || defined(NANO)
+#if defined(PENTIUM4) || defined(PRESCOTT) || defined(GENERIC) || defined(NANO)
 	prefetcht0	RPREFETCHSIZE * SIZE(AO1)
 	prefetcht0	WPREFETCHSIZE * SIZE(BO)
 #endif
@@ -339,7 +339,7 @@
 	movsd	6 * SIZE(AO1), %xmm3
 	movhpd	7 * SIZE(AO1), %xmm3
 
-#if defined(PENTIUM4) || defined(GENERIC) || defined(NANO)
+#if defined(PENTIUM4) || defined(PRESCOTT) || defined(GENERIC) || defined(NANO)
 	prefetcht0	RPREFETCHSIZE * SIZE(AO1)
 	prefetcht0	WPREFETCHSIZE * SIZE(BO)
 #endif

--- a/kernel/x86_64/zsum_sse2.S
+++ b/kernel/x86_64/zsum_sse2.S
@@ -219,7 +219,7 @@
 	prefetcht0	PREFETCHSIZE * SIZE(X)
 #endif
 
-#ifdef PENTIUM4
+#if defined(PENTIUM4) || defined(PRESCOTT)
 	prefetchnta	PREFETCHSIZE * SIZE(X)
 #endif
 

--- a/kernel/x86_64/zsymv_L_sse.S
+++ b/kernel/x86_64/zsymv_L_sse.S
@@ -63,7 +63,7 @@
 #define PREFETCHSIZE	(16 * 24)
 #endif
 
-#ifdef PENTIUM4
+#if defined(PENTIUM4) || defined(PRESCOTT)
 #define PREFETCH	prefetcht0
 #define PREFETCHW	prefetcht0
 #define PREFETCHSIZE	(16 * 28)

--- a/kernel/x86_64/zsymv_L_sse2.S
+++ b/kernel/x86_64/zsymv_L_sse2.S
@@ -63,7 +63,7 @@
 #define PREFETCHSIZE	(16 * 24)
 #endif
 
-#ifdef PENTIUM4
+#if defined(PENTIUM4) || defined(PRESCOTT)
 #define PREFETCH	prefetcht0
 #define PREFETCHW	prefetcht0
 #define PREFETCHSIZE	(16 * 28)

--- a/kernel/x86_64/zsymv_U_sse.S
+++ b/kernel/x86_64/zsymv_U_sse.S
@@ -63,7 +63,7 @@
 #define PREFETCHSIZE	(16 * 24)
 #endif
 
-#ifdef PENTIUM4
+#if defined(PENTIUM4) || defined(PRESCOTT)
 #define PREFETCH	prefetcht0
 #define PREFETCHW	prefetcht0
 #define PREFETCHSIZE	(16 * 28)

--- a/kernel/x86_64/zsymv_U_sse2.S
+++ b/kernel/x86_64/zsymv_U_sse2.S
@@ -63,7 +63,7 @@
 #define PREFETCHSIZE	(16 * 24)
 #endif
 
-#ifdef PENTIUM4
+#if defined(PENTIUM4) || defined(PRESCOTT)
 #define PREFETCH	prefetcht0
 #define PREFETCHW	prefetcht0
 #define PREFETCHSIZE	(16 * 28)

--- a/kernel/x86_64/ztrsm_kernel_LN_4x2_sse.S
+++ b/kernel/x86_64/ztrsm_kernel_LN_4x2_sse.S
@@ -88,7 +88,7 @@
 #define movsd movlps
 #endif
 
-#if defined(PENTIUM4) || defined(CORE2) || defined(PENRYN) || defined(DUNNINGTON) || defined(ATOM) || defined(NANO)
+#if defined(PENTIUM4) || defined(PRESCOTT) || defined(CORE2) || defined(PENRYN) || defined(DUNNINGTON) || defined(ATOM) || defined(NANO)
 #define PREFETCH     prefetcht0
 #define PREFETCHW    prefetcht0
 #define PREFETCHNTA  prefetchnta

--- a/kernel/x86_64/ztrsm_kernel_LT_4x2_sse.S
+++ b/kernel/x86_64/ztrsm_kernel_LT_4x2_sse.S
@@ -88,7 +88,7 @@
 #define movsd movlps
 #endif
 
-#if defined(PENTIUM4) || defined(CORE2) || defined(PENRYN) || defined(DUNNINGTON) || defined(ATOM) || defined(NANO)
+#if defined(PENTIUM4) || defined(PRESCOTT) || defined(CORE2) || defined(PENRYN) || defined(DUNNINGTON) || defined(ATOM) || defined(NANO)
 #define PREFETCH     prefetcht0
 #define PREFETCHW    prefetcht0
 #define PREFETCHNTA  prefetchnta

--- a/kernel/x86_64/ztrsm_kernel_RT_4x2_sse.S
+++ b/kernel/x86_64/ztrsm_kernel_RT_4x2_sse.S
@@ -88,7 +88,7 @@
 #define movsd movlps
 #endif
 
-#if defined(PENTIUM4) || defined(CORE2) || defined(PENRYN) || defined(DUNNINGTON) || defined(ATOM) || defined(NANO)
+#if defined(PENTIUM4) || defined(PRESCOTT) || defined(CORE2) || defined(PENRYN) || defined(DUNNINGTON) || defined(ATOM) || defined(NANO)
 #define PREFETCH     prefetcht0
 #define PREFETCHW    prefetcht0
 #define PREFETCHNTA  prefetchnta

--- a/l1param.h
+++ b/l1param.h
@@ -31,7 +31,7 @@
 #define movsd	movlps
 #endif
 
-#ifdef PENTIUM4
+#if defined(PENTIUM4) || defined(PRESCOTT)
 #define PREFETCH	prefetcht0
 #define PREFETCHSIZE (128 *  10)
 #define FETCH128

--- a/l2param.h
+++ b/l2param.h
@@ -19,7 +19,7 @@
 #define PREFETCHSIZE	64 * 3
 #endif
 
-#ifdef PENTIUM4
+#if defined(PENTIUM4) || defined(PRESCOTT)
 #define ALIGNED_ACCESS
 #define MOVUPS_A	movaps
 #define MOVUPS_XL	movaps


### PR DESCRIPTION
Define everything the same way for PRESCOTT as for PENTIUM4.

This is an RFC pull request. I have not actually tested running on a Prescott machine, only that 0.3.27 builds for x86_64.