### PR TITLE
Expanding the scope of 2D thread distribution to improve multi-threaded DGEMM performance

### DIFF
--- a/driver/level3/level3_thread.c
+++ b/driver/level3/level3_thread.c
@@ -826,6 +826,16 @@ int CNAME(blas_arg_t *args, BLASLONG *range_m, BLASLONG *range_n, IFLOAT *sa, IF
     if (nthreads_m * nthreads_n > args -> nthreads) {
       nthreads_n = blas_quickdivide(args -> nthreads, nthreads_m);
     }
+    /* The nthreads_m and nthreads_n are adjusted so that the submatrix       */
+    /* to be handled by each thread preferably becomes a square matrix        */
+    /* by minimizing an objective function 'n * nthreads_m + m * nthreads_n'. */
+    /* Objective function come from sum of partitions in m and n.             */
+    /* (n / nthreads_n) + (m / nthreads_m)                                    */
+    /* = (n * nthreads_m + m * nthreads_n) / (nthreads_n * nthreads_m)        */
+    while (nthreads_m % 2 == 0 && n * nthreads_m + m * nthreads_n > n * (nthreads_m / 2) + m * (nthreads_n * 2)) {
+      nthreads_m /= 2;
+      nthreads_n *= 2;
+    }
   }
 
   /* Execute serial or parallel computation */


### PR DESCRIPTION
This pull request proposes a fix to the issue #4644 .

The currently implemented 2D thread distribution in level3_thread.c works well for small matrices, however, it falls into a simple one-dimensional distribution in the M direction as the size of matirix becomes larger.​ This pull request improves thread parallell performance for large matrices by expanding the scope of 2D thread distribution.​

Performance improved by about 10% on Graviton3E (64 cores) and more than 20% on Xeon Platinum 8375C (32 cores x 2 sockets).​

Graviton3E
![1](https://github.com/OpenMathLib/OpenBLAS/assets/166666378/94c24c08-afd7-4eef-96f7-68edf53da81c)

Xeon Platinum 8375C
![2](https://github.com/OpenMathLib/OpenBLAS/assets/166666378/b1ac5e61-07bf-4dc0-a204-35466008b429)


The calculations are distributed so that each thread handles about the same size of the range in the M and N directions, even when the input matrices are rectangle.​ Although not confirmed on all platforms, this relatively simple fix is expected to be generally effective on modern manycore CPUs.​