### PR TITLE
do not add LIBNAMESUFFIX to dylib

### DIFF
--- a/exports/Makefile
+++ b/exports/Makefile
@@ -137,7 +137,7 @@ libgoto_hpl.def : $(GENSYM)
 
 ifeq ($(OSNAME), Darwin)
 ifeq ($(FIXED_LIBNAME),1)
-INTERNALNAME = $(LIBPREFIX)$(LIBNAMESUFFIX).dylib
+INTERNALNAME = $(LIBPREFIX).dylib
 else
 INTERNALNAME = $(LIBPREFIX).$(MAJOR_VERSION).dylib
 endif


### PR DESCRIPTION
Follow on for #4627, this time for macos. Before this the `otool -D` name was `openblas64_64_dylib`, after it is `openblas64_.dylib`