### PR TITLE
Fix openblas_utest_ext build in AIX

### DIFF
--- a/utest/test_extensions/utest_main2.c
+++ b/utest/test_extensions/utest_main2.c
@@ -40,7 +40,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define CTEST_ADD_TESTS_MANUALLY
 
 #include "cblas.h"
-#include "openblas_utest.h"
+#include "utest/openblas_utest.h"
 #if 1
 CTEST(amax, samax){
   blasint N=3, inc=1;


### PR DESCRIPTION
Building `openblas_utest_ext` fails with the below error.

`/opt/IBM/openxlC/17.1.2/bin/ibm-clang_r -O2 -DSMALL_MATRIX_OPT -DUTEST_CHECK -DSANITY_CHECK -DREFNAME=utest_main2f_ -DMAX_STACK_ALLOC=2048 -fopenmp -DHAVE_P10_SUPPORT -Wall -DF_INTERFACE_IBM -fPIC -DDYNAMIC_ARCH -DSMP_SERVER -DUSE_OPENMP -DNO_WARMUP -DMAX_CPU_NUMBER=16 -DMAX_PARALLEL_NUMBER=1 -DBUILD_BFLOAT16 -DBUILD_SINGLE=1 -DBUILD_DOUBLE=1 -DBUILD_COMPLEX=1 -DBUILD_COMPLEX16=1 -DVERSION=\"0.3.27.dev\" -DUSE_OPENMP -fopenmp -fno-integrated-as -m64 -UASMNAME -UASMFNAME -UNAME -UCNAME -UCHAR_NAME -UCHAR_CNAME -DASMNAME=utest_main2 -DASMFNAME=utest_main2_ -DNAME=utest_main2_ -DCNAME=utest_main2 -DCHAR_NAME=\"utest_main2_\" -DCHAR_CNAME=\"utest_main2\" -DNO_AFFINITY -I..   -c -o test_extensions/utest_main2.o test_extensions/utest_main2.c
test_extensions/utest_main2.c:43:10: fatal error: 'openblas_utest.h' file not found
   43 | #include "openblas_utest.h"
      |          ^~~~~~~~~~~~~~~~~~
1 error generated.
make[1]: *** [<builtin>: test_extensions/utest_main2.o] Error 1
make[1]: Leaving directory '/home/buildusr/OpenBLAS/utest'
make: *** [Makefile:168: tests] Error 2`