### PR TITLE
Fix spurious errors in the extended utest for INTERFACE64=1 on big-endian systems

### DIFF
--- a/utest/test_extensions/xerbla.c
+++ b/utest/test_extensions/xerbla.c
@@ -39,7 +39,7 @@ static char *rout;
 
 static void F77_xerbla(char *srname, void *vinfo)
 {
-   int info=*(int*)vinfo;
+   blasint info=*(blasint*)vinfo;
 
    if (link_xerbla)
    {


### PR DESCRIPTION
fixes #4633