### PR TITLE
Expose whether locking is enabled in get_config

### DIFF
--- a/driver/others/openblas_get_config.c
+++ b/driver/others/openblas_get_config.c
@@ -13,9 +13,9 @@ met:
       notice, this list of conditions and the following disclaimer in
       the documentation and/or other materials provided with the
       distribution.
-   3. Neither the name of the OpenBLAS project nor the names of 
-      its contributors may be used to endorse or promote products 
-      derived from this software without specific prior written 
+   3. Neither the name of the OpenBLAS project nor the names of
+      its contributors may be used to endorse or promote products
+      derived from this software without specific prior written
       permission.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
@@ -63,6 +63,9 @@ static char* openblas_config_str=""
 #ifdef USE_TLS
   "USE_TLS "
 #endif
+#ifdef USE_LOCKING
+  "USE_LOCKING "
+#endif
 #ifndef DYNAMIC_ARCH
   CHAR_CORENAME
 #endif
@@ -83,7 +86,7 @@ char tmpstr[20];
 #endif
   if (openblas_get_parallel() == 0)
     sprintf(tmpstr, " SINGLE_THREADED");
-  else 
+  else
     snprintf(tmpstr,19," MAX_THREADS=%d",MAX_CPU_NUMBER);
   strcat(tmp_config_str, tmpstr);
   return tmp_config_str;
@@ -91,7 +94,7 @@ char tmpstr[20];
 
 
 char* openblas_get_corename(void) {
-#ifndef DYNAMIC_ARCH 
+#ifndef DYNAMIC_ARCH
   return CHAR_CORENAME;
 #else
   return gotoblas_corename();


### PR DESCRIPTION
Hello! I ran into an issue w/ single-threaded openblas and OpenMP which turned out to be the result of not having locking enabled. I then noticed that there's really no way to find out at runtime if it is enabled or not ([mgcv's blast.thread.test quite literally brute forces it as an alternative](https://github.com/cran/mgcv/blob/master/R/misc.r#L29C1-L48C22)). I figured it would make sense for this to be exposed by openblas_get_config instead.