### PR TITLE
Fix builds for LOONGARCH64 in LSX mode

### DIFF
--- a/kernel/loongarch64/dot_lsx.S
+++ b/kernel/loongarch64/dot_lsx.S
@@ -165,7 +165,7 @@ PROLOGUE
     /* store dot in s1 $f8 */
 #ifdef DSDOT
     vfadd.d   $vr8,   $vr8,    $vr9
-    fsub.s    s2,     s2,      s2,  /* set s2 to 0.0 */
+    fsub.s    s2,     s2,      s2   /* set s2 to 0.0 */
     vpackod.d $vr0,   $vr8,    $vr8
     vfadd.d   $vr8,   $vr8,    $vr0
 #else


### PR DESCRIPTION
same stray comma as fixed for LASX in #4661 - second part of fix for #4660 as reminded by azuresky01