### PR TITLE
Revert PRs 4515 and 4520 (restore second, dsecnd)

### DIFF
--- a/exports/Makefile
+++ b/exports/Makefile
@@ -315,11 +315,6 @@ test : linktest.c
 
 linktest.c : $(GENSYM) ../Makefile.system ../getarch.c
 	./$(GENSYM) linktest  $(ARCH) "$(BU)" $(EXPRECISION) $(NO_CBLAS) $(NO_LAPACK) $(NO_LAPACKE) $(NEED2UNDERSCORES) $(ONLY_CBLAS) "$(SYMBOLPREFIX)" "$(SYMBOLSUFFIX)" $(BUILD_LAPACK_DEPRECATED) $(BUILD_BFLOAT16) $(BUILD_SINGLE) $(BUILD_DOUBLE) $(BUILD_COMPLEX) $(BUILD_COMPLEX16) > linktest.c
-ifeq ($(F_COMPILER), IBM)
-	mv linktest.c linktest.c.FIRST
-	egrep -v 'second_|dsecnd_' linktest.c.FIRST > linktest.c
-	rm linktest.c.FIRST
-endif
 
 clean ::
 	@rm -f *.def *.dylib __.SYMDEF* *.renamed

--- a/lapack-netlib/SRC/Makefile
+++ b/lapack-netlib/SRC/Makefile
@@ -101,10 +101,8 @@ SCLAUX = la_constants.o \
    slaset.o slasq1.o slasq2.o slasq3.o slasq4.o slasq5.o slasq6.o \
    slasr.o  slasrt.o slassq.o slasv2.o spttrf.o sstebz.o sstedc.o \
    ssteqr.o ssterf.o slaisnan.o sisnan.o \
-   slartgp.o slartgs.o scombssq.o ../INSTALL/sroundup_lwork.o
-ifneq ($(F_COMPILER), IBM)
-SCLAUX += ../INSTALL/second_$(TIMER).o
-endif
+   slartgp.o slartgs.o scombssq.o ../INSTALL/sroundup_lwork.o \
+   ../INSTALL/second_$(TIMER).o
 endif
 
 ifneq "$(or $(BUILD_DOUBLE),$(BUILD_COMPLEX16))" ""
@@ -126,10 +124,7 @@ DZLAUX = la_constants.o\
    dlasr.o  dlasrt.o dlassq.o dlasv2.o dpttrf.o dstebz.o dstedc.o \
    dsteqr.o dsterf.o dlaisnan.o disnan.o \
    dlartgp.o dlartgs.o ../INSTALL/droundup_lwork.o \
-   ../INSTALL/dlamch.o
-ifneq ($(F_COMPILER), IBM)
-DZLAUX +=  ../INSTALL/dsecnd_$(TIMER).o
-endif
+   ../INSTALL/dlamch.o ../INSTALL/dsecnd_$(TIMER).o
 endif
 
 #ifeq ($(BUILD_SINGLE),1)


### PR DESCRIPTION
It turns out that PRs 4515 and 4520 break xlf builds of tests under  
lapack-netlib/TESTING which require SECOND and DSECND. IBM
has decided this is a bigger problem than the conflict
between lapack second_ and the xlf run time.