### PR TITLE
Don't try to deploy docs when PR-building in a fork

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   build:
     name: Deploy docs
+    if: "github.repository == 'OpenMathLib/OpenBLAS'"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
cuts down on noise from failed write permissions