### PR TITLE
POWER: Fix issues in zscal to address lapack failures

### DIFF
--- a/kernel/power/zscal.c
+++ b/kernel/power/zscal.c
@@ -38,6 +38,10 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #pragma GCC optimize "O1"
 
+#if defined(__clang__)
+#pragma clang fp contract(off)
+#endif
+
 #if defined(__VEC__) || defined(__ALTIVEC__)
 #if defined(POWER8) || defined(POWER9)
 #if defined(DOUBLE)


### PR DESCRIPTION
This patch fixes following lapack failures with clang compiler on POWER.
zed.out: ZVX:   18 out of  5190 tests failed to pass the threshold
zgd.out: ZGV drivers:     25 out of   1092 tests failed to pass the threshold
zgd.out: ZGV drivers:      6 out of   1092 tests failed to pass the threshold