### PR TITLE
Override Intel icx's default fp-model to ensure correct handling on NaNs

### DIFF
--- a/Makefile.x86_64
+++ b/Makefile.x86_64
@@ -8,6 +8,11 @@ endif
 endif
 endif
 
+ifeq ($(C_COMPILER), CLANG)
+ifeq ($(findstring icx,$(CC)),icx)
+CCOMMON_OPT += -fp-model=consistent
+endif
+endif
 
 ifneq ($(DYNAMIC_ARCH),1)
 ADD_CPUFLAGS = 1

--- a/cmake/cc.cmake
+++ b/cmake/cc.cmake
@@ -4,6 +4,10 @@
 ##              Sets C related variables.
 include(CheckCCompilerFlag)
 
+if (${CMAKE_C_COMPILER_ID} MATCHES "IntelLLVM")
+  set(CCOMMON_OPT "${CCOMMON_OPT} -fp-model=consistent")
+endif ()
+
 if (${CMAKE_C_COMPILER_ID} STREQUAL "GNU" OR ${CMAKE_C_COMPILER_ID} STREQUAL "LSB" OR ${CMAKE_C_COMPILER_ID} MATCHES "Clang")
   set(CCOMMON_OPT "${CCOMMON_OPT} -Wall")
   set(COMMON_PROF "${COMMON_PROF} -fno-inline")


### PR DESCRIPTION
fixes #4713 and various TRSV failures in the BLAS extension utests