### PR TITLE
Fix CMake warning

### DIFF
--- a/cmake/prebuild.cmake
+++ b/cmake/prebuild.cmake
@@ -1342,7 +1342,7 @@ else(NOT CMAKE_CROSSCOMPILING)
 
   if ("${CMAKE_C_COMPILER_ID}" STREQUAL "MSVC")
     #Use generic for MSVC now
-    message("MSVC")
+    message(STATUS "MSVC")
     set(GETARCH_FLAGS ${GETARCH_FLAGS} -DFORCE_GENERIC)
   else()
     list(APPEND GETARCH_SRC ${PROJECT_SOURCE_DIR}/cpuid.S)


### PR DESCRIPTION
```
CMake Warning (dev) at cmake/prebuild.cmake:1346 (if):
  Policy CMP0054 is not set: Only interpret if() arguments as variables or
  keywords when unquoted.  Run "cmake --help-policy CMP0054" for policy
  details.  Use the cmake_policy command to set the policy and suppress this
  warning.

  Quoted variables like "MSVC" will no longer be dereferenced when the policy
  is set to NEW.  Since the policy is not set the OLD behavior will be used.
Call Stack (most recent call first):
  cmake/system.cmake:166 (include)
  CMakeLists.txt:104 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.
```