### PR TITLE
Drop the -static Fortran flag from generic RISCV builds as it breaks OpenMP

### DIFF
--- a/Makefile.riscv64
+++ b/Makefile.riscv64
@@ -8,13 +8,13 @@ FCOMMON_OPT += -march=rv64imafdcv_zba_zbb_zfh -mabi=lp64d -static
 endif
 ifeq ($(CORE), RISCV64_ZVL256B)
 CCOMMON_OPT += -march=rv64imafdcv_zvl256b -mabi=lp64d
-FCOMMON_OPT += -march=rv64imafdcv -mabi=lp64d -static
+FCOMMON_OPT += -march=rv64imafdcv -mabi=lp64d
 endif
 ifeq ($(CORE), RISCV64_ZVL128B)
 CCOMMON_OPT += -march=rv64imafdcv -mabi=lp64d 
-FCOMMON_OPT += -march=rv64imafdcv -mabi=lp64d -static
+FCOMMON_OPT += -march=rv64imafdcv -mabi=lp64d
 endif
 ifeq ($(CORE), RISCV64_GENERIC)
 CCOMMON_OPT += -march=rv64imafdc -mabi=lp64d
-FCOMMON_OPT += -march=rv64imafdc -mabi=lp64d -static
+FCOMMON_OPT += -march=rv64imafdc -mabi=lp64d
 endif


### PR DESCRIPTION
fixes #4719