### PR TITLE
Disable GEMM3M for generic targets (not implemented)

### DIFF
--- a/kernel/Makefile.L3
+++ b/kernel/Makefile.L3
@@ -17,6 +17,16 @@ ifeq ($(ARCH), ia64)
 USE_GEMM3M = 1
 endif
 
+ifneq ($(DYNAMIC_ARCH), 1)
+ifeq ($(TARGET), GENERIC)
+USE_GEMM3M = 0
+endif
+else
+ifeq ($(CORE), GENERIC)
+USE_GEMM3M = 0
+endif
+endif
+
 ifeq ($(ARCH), arm)
 USE_TRMM = 1
 endif


### PR DESCRIPTION
fixes #4737 - the CMAKE code does it correctly already, only the Makefile build ends up in nonfunctional, exploratory code from years ago 