### PR TITLE
Improve error message output from the fork() utest

### DIFF
--- a/utest/test_fork.c
+++ b/utest/test_fork.c
@@ -33,6 +33,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <sys/types.h>
 #include <sys/wait.h>
+#include <errno.h>
 #include <cblas.h>
 #include "openblas_utest.h"
 
@@ -103,6 +104,7 @@ exit(0);
 
     fork_pid = fork();
     if (fork_pid == -1) {
+        perror(fork");
         CTEST_ERR("Failed to fork process.");
     } else if (fork_pid == 0) {
         // Compute a DGEMM product in the child process to check that the
@@ -113,7 +115,8 @@ exit(0);
         // recursively
         fork_pid_nested = fork();
         if (fork_pid_nested == -1) {
-            CTEST_ERR("Failed to fork process.");
+            perror("fork");
+            CTEST_ERR("Failed to fork nested process.");
             exit(1);
         } else if (fork_pid_nested == 0) {
             check_dgemm(a, b, d, c, n);

--- a/utest/test_fork.c
+++ b/utest/test_fork.c
@@ -42,7 +42,7 @@ static void* xmalloc(size_t n)
     void* tmp;
     tmp = malloc(n);
     if (tmp == NULL) {
-        fprintf(stderr, "You are about to die\n");
+        fprintf(stderr, "Failed to allocate memory for the testcase.\n");
         exit(1);
     } else {
         return tmp;
@@ -104,7 +104,7 @@ exit(0);
 
     fork_pid = fork();
     if (fork_pid == -1) {
-        perror(fork");
+        perror("fork");
         CTEST_ERR("Failed to fork process.");
     } else if (fork_pid == 0) {
         // Compute a DGEMM product in the child process to check that the

--- a/utest/test_post_fork.c
+++ b/utest/test_post_fork.c
@@ -33,6 +33,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <sys/types.h>
 #include <sys/wait.h>
+#include <errno.h>
 #include <cblas.h>
 #ifdef USE_OPENMP
 #include <omp.h>
@@ -114,7 +115,11 @@ exit(0);
 
         fork_pid = fork();
         if (fork_pid == -1) {
-            CTEST_ERR("Failed to fork process.");
+            perror("fork");
+            CTEST_ERR("Failed to fork subprocesses in a loop.");
+#ifdef USE_OPENMP
+            CTEST_ERR("Number of OpenMP threads was %d in this attempt.",i);
+#endif
         } else if (fork_pid == 0) {
             // Just pretend to do something, e.g. call `uname`, then exit
             exit(0);

--- a/utest/test_post_fork.c
+++ b/utest/test_post_fork.c
@@ -45,7 +45,7 @@ static void* xmalloc(size_t n)
     void* tmp;
     tmp = malloc(n);
     if (tmp == NULL) {
-        fprintf(stderr, "You are about to die\n");
+        fprintf(stderr, "Failed to allocate memory for the test payload.\n");
         exit(1);
     } else {
         return tmp;


### PR DESCRIPTION
fixes ambiguities seen in #4745 - this test can require huge amounts of memory if certain build parameters are set to  large values