### PR TITLE
Add support for RISCV64_GENERIC in cmake

### DIFF
--- a/cmake/prebuild.cmake
+++ b/cmake/prebuild.cmake
@@ -1309,6 +1309,15 @@ endif ()
       "#define DTB_DEFAULT_ENTRIES 128\n"
       "#define DTB_SIZE 4096\n"
       "#define L2_ASSOCIATIVE 8\n")
+  elseif ("${TCORE}" STREQUAL "RISCV64_GENERIC")
+    file(APPEND ${TARGET_CONF_TEMP}
+        "#define L1_DATA_SIZE 32768\n"
+      "#define L1_DATA_LINESIZE 32\n"
+      "#define L2_SIZE 1048576\n"
+      "#define L2_LINESIZE 32 \n"
+      "#define DTB_DEFAULT_ENTRIES 128\n"
+      "#define DTB_SIZE 4096\n"
+      "#define L2_ASSOCIATIVE 4\n")
   endif()
   set(SBGEMM_UNROLL_M 8)
   set(SBGEMM_UNROLL_N 4)

--- a/cmake/system.cmake
+++ b/cmake/system.cmake
@@ -615,7 +615,7 @@ if (${CMAKE_SYSTEM_NAME} STREQUAL "Windows")
 endif ()
 
 if (CMAKE_Fortran_COMPILER)
-if (${F_COMPILER} STREQUAL "NAG" OR ${F_COMPILER} STREQUAL "CRAY" OR CMAKE_Fortran_COMPILER_ID MATCHES "LLVMFlang.*")
+if ("${F_COMPILER}" STREQUAL "NAG" OR "${F_COMPILER}" STREQUAL "CRAY" OR CMAKE_Fortran_COMPILER_ID MATCHES "LLVMFlang.*")
   set(FILTER_FLAGS "-msse3;-mssse3;-msse4.1;-mavx;-mavx2,-mskylake-avx512")
   if (CMAKE_Fortran_COMPILER_ID MATCHES "LLVMFlang.*")
 message(STATUS "removing fortran flags")


### PR DESCRIPTION
Support for RISCV64_GENERIC was missing in cmake, so I added support for it.
I am not sure where these values come from, but I copied them from the config.h when using Make. 