### PR TITLE
Fix core assignment in cpu detection for Intel family 15

### DIFF
--- a/cpuid_x86.c
+++ b/cpuid_x86.c
@@ -2392,10 +2392,10 @@ int get_coretype(void){
 	  else
 	  return CORE_NEHALEM;
 	}
-      case 15:
-	if (model <= 0x2) return CORE_NORTHWOOD;
-	else return CORE_PRESCOTT;
       }
+    case 15:
+      if (model <= 0x2) return CORE_NORTHWOOD;
+      else return CORE_PRESCOTT;
     }
   }
 


### PR DESCRIPTION
fixes autodetection failure reported by bowensmachinesense in discussion #4790 as suggested by the reporter. This was apparently broken by my PR #3442 some time ago.