### PR TITLE
Fix build on FreeBSD/powerpc64*

### DIFF
--- a/param.h
+++ b/param.h
@@ -2553,7 +2553,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #endif
 
-#if defined(POWER9) && defined(OS_LINUX)
+#if defined(POWER9) && (defined(OS_LINUX) || defined(OS_FREEBSD))
 
 #define SNUMOPT		16
 #define DNUMOPT		8


### PR DESCRIPTION
This is not related to https://github.com/OpenMathLib/OpenBLAS/issues/4793, it fixes a GCC build. Clang also fails with issue similar to GCC's.