### PR TITLE
A64FX: Add support for SVE to SGEMV/DGEMV kernels.

### DIFF
--- a/kernel/arm64/KERNEL.A64FX
+++ b/kernel/arm64/KERNEL.A64FX
@@ -1,1 +1,6 @@
 include $(KERNELDIR)/KERNEL.ARMV8SVE
+
+SGEMVNKERNEL = gemv_n_sve.c
+DGEMVNKERNEL = gemv_n_sve.c
+SGEMVTKERNEL = gemv_t_sve.c
+DGEMVTKERNEL = gemv_t_sve.c

--- a/kernel/arm64/gemv_n_sve.c
+++ b/kernel/arm64/gemv_n_sve.c
@@ -1,0 +1,92 @@
+/***************************************************************************
+Copyright (c) 2024, The OpenBLAS Project
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   1. Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+   3. Neither the name of the OpenBLAS project nor the names of 
+      its contributors may be used to endorse or promote products 
+      derived from this software without specific prior written 
+      permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+#include <arm_sve.h>
+#include "common.h"
+
+#ifdef DOUBLE
+#define SV_COUNT svcntd
+#define SV_TYPE svfloat64_t
+#define SV_TRUE svptrue_b64
+#define SV_WHILE svwhilelt_b64
+#define SV_DUP svdup_f64
+#else
+#define SV_COUNT svcntw
+#define SV_TYPE svfloat32_t
+#define SV_TRUE svptrue_b32
+#define SV_WHILE svwhilelt_b32
+#define SV_DUP svdup_f32
+#endif
+
+int CNAME(BLASLONG m, BLASLONG n, BLASLONG dummy1, FLOAT alpha, FLOAT *a, BLASLONG lda, FLOAT *x, BLASLONG inc_x, FLOAT *y, BLASLONG inc_y, FLOAT *buffer)
+{
+  BLASLONG i;
+  BLASLONG ix,iy;
+  BLASLONG j;
+  FLOAT *a_ptr;
+  FLOAT temp;
+
+  ix = 0;
+  a_ptr = a;
+
+  if (inc_y == 1) {
+    uint64_t sve_size = SV_COUNT();
+    for (j = 0; j < n; j++) {
+      SV_TYPE temp_vec = SV_DUP(alpha * x[ix]);
+      i = 0;
+      svbool_t pg = SV_WHILE(i, m);
+      while (svptest_any(SV_TRUE(), pg)) {
+        SV_TYPE a_vec = svld1(pg, a_ptr + i);
+        SV_TYPE y_vec = svld1(pg, y + i);
+        y_vec = svmla_x(pg, y_vec, temp_vec, a_vec);
+        svst1(pg, y + i, y_vec);
+        i += sve_size;
+        pg = SV_WHILE(i, m);
+      }
+      a_ptr += lda;
+      ix += inc_x;
+    }
+    return(0);
+  }
+
+  for (j = 0; j < n; j++) {
+    temp = alpha * x[ix];
+    iy = 0;
+    for (i = 0; i < m; i++) {
+      y[iy] += temp * a_ptr[i];
+      iy += inc_y;
+    }
+    a_ptr += lda;
+    ix += inc_x;
+  }
+  return (0);
+}

--- a/kernel/arm64/gemv_t_sve.c
+++ b/kernel/arm64/gemv_t_sve.c
@@ -1,0 +1,94 @@
+/***************************************************************************
+Copyright (c) 2024, The OpenBLAS Project
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   1. Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+   3. Neither the name of the OpenBLAS project nor the names of
+      its contributors may be used to endorse or promote products
+      derived from this software without specific prior written
+      permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+#include <arm_sve.h>
+#include "common.h"
+
+#ifdef DOUBLE
+#define SV_COUNT svcntd
+#define SV_TYPE svfloat64_t
+#define SV_TRUE svptrue_b64
+#define SV_WHILE svwhilelt_b64
+#define SV_DUP svdup_f64
+#else
+#define SV_COUNT svcntw
+#define SV_TYPE svfloat32_t
+#define SV_TRUE svptrue_b32
+#define SV_WHILE svwhilelt_b32
+#define SV_DUP svdup_f32
+#endif
+
+int CNAME(BLASLONG m, BLASLONG n, BLASLONG dummy1, FLOAT alpha, FLOAT *a, BLASLONG lda, FLOAT *x, BLASLONG inc_x, FLOAT *y, BLASLONG inc_y, FLOAT *buffer)
+{
+  BLASLONG i;
+  BLASLONG ix,iy;
+  BLASLONG j;
+  FLOAT *a_ptr;
+  FLOAT temp;
+
+  iy = 0;
+  a_ptr = a;
+
+  if (inc_x == 1) {
+    uint64_t sve_size = SV_COUNT();
+    for (j = 0; j < n; j++) {
+      SV_TYPE temp_vec = SV_DUP(0.0);
+      i = 0;
+      svbool_t pg = SV_WHILE(i, m);
+      while (svptest_any(SV_TRUE(), pg)) {
+        SV_TYPE a_vec = svld1(pg, a_ptr + i);
+        SV_TYPE x_vec = svld1(pg, x + i);
+        temp_vec = svmla_m(pg, temp_vec, a_vec, x_vec);
+        i += sve_size;
+        pg = SV_WHILE(i, m);
+      }
+      temp = svaddv(SV_TRUE(), temp_vec);
+      y[iy] += alpha * temp;
+      iy += inc_y;
+      a_ptr += lda;
+    }
+    return(0);
+  }
+
+  for (j = 0; j < n; j++) {
+    temp = 0.0;
+    ix = 0;
+    for (i = 0; i < m; i++) {
+      temp += a_ptr[i] * x[ix];
+      ix += inc_x;
+    }
+    y[iy] += alpha * temp;
+    iy += inc_y;
+    a_ptr += lda;
+  }
+  return (0);
+}


### PR DESCRIPTION
This pull request proposes a fix to the issue #4786.
I added the SGEMV/DGEMV kernels that use SVE for A64FX and confirmed performance improvements.

DGEMV(TRANS=N) with 1 thread
![DGEMV_N_1-thread](https://github.com/user-attachments/assets/2c4e3af5-d246-42b5-af90-7954e84765cc)

DGEMV(TRANS=T) with 1 thread
![DGEMV_T_1-thread](https://github.com/user-attachments/assets/a52d4d96-37fc-4496-9fd4-c212db3cfd0f)

The kernels can work with the SVE of a length other than 512 bits of the A64FX,but Neoverse V1 and Neoverse V2, which can execute four 128-bit NEON instructions per cycle do not necessarily need to adopt this SVE version.