### PR TITLE
Handle INF and NAN in inputs in riscv64/scal_rvv.c

### DIFF
--- a/kernel/riscv64/scal_rvv.c
+++ b/kernel/riscv64/scal_rvv.c
@@ -56,7 +56,7 @@ int CNAME(BLASLONG n, BLASLONG dummy0, BLASLONG dummy1, FLOAT da, FLOAT *x, BLAS
     FLOAT_V_T v0;
  
     if(inc_x == 1) {
-        if(da == 0.0) {
+        if (0) { //if(da == 0.0){
             int gvl = VSETVL_MAX;
             v0 = VFMVVF_FLOAT(0.0, gvl);
             for (size_t vl; n > 0; n -= vl, x += vl) {
@@ -75,7 +75,7 @@ int CNAME(BLASLONG n, BLASLONG dummy0, BLASLONG dummy1, FLOAT da, FLOAT *x, BLAS
     } else {
         BLASLONG stride_x = inc_x * sizeof(FLOAT);
 
-        if(da == 0.0) {
+        if (0) { //if(da == 0.0){
             int gvl = VSETVL_MAX;
             v0 = VFMVVF_FLOAT(0.0, gvl);
             for (size_t vl; n > 0; n -= vl, x += vl*inc_x) {


### PR DESCRIPTION
The following openblas_utest tests fail when the RISCV64_ZVL128B core is enabled.

TEST 39/106 sscal:0_nan [FAIL]
  ERR: test_zscal.c:19  should be true
TEST 40/106 sscal:0_nan_inc_2 [FAIL]
  ERR: test_zscal.c:31  should be true
TEST 41/106 sscal:nan_0 [OK]
TEST 42/106 sscal:nan_0_inc_2 [OK]
TEST 43/106 sscal:0_inf [FAIL]
  ERR: test_zscal.c:65  should be true
TEST 44/106 sscal:0_inf_inc_2 [FAIL]
  ERR: test_zscal.c:77  should be true

This commit fixes the issue by porting the fixes made to riscv64/scal_vector.c in PR #4729.