### PR TITLE
Work around a gcc14.1 bug that breaks utest on Loongarch

### DIFF
--- a/utest/test_potrs.c
+++ b/utest/test_potrs.c
@@ -32,7 +32,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 **********************************************************************************/
 
 #include "openblas_utest.h"
-
+#pragma GCC optimize("no-gcse")
 /*
 void BLASFUNC(cpotrf)(char*, BLASINT*, complex float*, BLASINT*, BLASINT*);
 void BLASFUNC(zpotrs_(char*, BLASINT*, BLASINT*, complex double*,


### PR DESCRIPTION
fixes #4805 (I see no harm in applying this unconditionally, as the tests should not depend on specific optimizations anyway)