### PR TITLE
Fix SCAL on x86 and RISCV_GENERIC

### DIFF
--- a/kernel/riscv64/scal.c
+++ b/kernel/riscv64/scal.c
@@ -43,7 +43,7 @@ int CNAME(BLASLONG n, BLASLONG dummy0, BLASLONG dummy1, FLOAT da, FLOAT *x, BLAS
 	if ( (n <= 0) || (inc_x <= 0))
 		return(0);
 	
-	if (dummy2 == 0) {
+	if (dummy2 == 1) {
 		while(j < n)
 		{
 

--- a/kernel/x86/scal.S
+++ b/kernel/x86/scal.S
@@ -65,7 +65,7 @@
 #else
 	movl	32(%esp),%edi
 	movl	36(%esp),%esi
-	movl	54(%esp),%ecx
+	movl	52(%esp),%ecx
 #endif
 
 	ftst

--- a/utest/test_gemv.c
+++ b/utest/test_gemv.c
@@ -7,13 +7,14 @@
 #ifndef INFINITY
 #define INFINITY 1.0/0.0
 #endif
+#define N 17
+#define Ny 33
 
 #ifdef BUILD_SINGLE
 
 CTEST(sgemv, 0_nan_inf)
 {
     int i;
-    blasint N = 17;
     blasint incX = 1;
     blasint incY = 1;
     float alpha = 0.0;
@@ -39,8 +40,6 @@ CTEST(sgemv, 0_nan_inf)
 CTEST(sgemv, 0_nan_inf_incy_2)
 {
     int i;
-    blasint N  = 17;
-    blasint Ny = 33;
     blasint incX = 1;
     blasint incY = 2;
     float alpha = 0.0;
@@ -73,7 +72,6 @@ CTEST(sgemv, 0_nan_inf_incy_2)
 CTEST(dgemv, 0_nan_inf)
 {
     int i;
-    blasint N = 17;
     blasint incX = 1;
     blasint incY = 1;
     double alpha = 0.0;
@@ -99,8 +97,6 @@ CTEST(dgemv, 0_nan_inf)
 CTEST(dgemv, 0_nan_inf_incy_2)
 {
     int i;
-    blasint N  = 17;
-    blasint Ny = 33;
     blasint incX = 1;
     blasint incY = 2;
     double alpha = 0.0;

--- a/utest/test_gemv.c
+++ b/utest/test_gemv.c
@@ -12,6 +12,7 @@
 
 CTEST(sgemv, 0_nan_inf)
 {
+    int i;
     blasint N = 17;
     blasint incX = 1;
     blasint incY = 1;
@@ -24,19 +25,20 @@ CTEST(sgemv, 0_nan_inf)
 
     memset(A, 0, sizeof(A));
     memset(X, 0, sizeof(X));
-    for (int i = 0; i < (N - 1); i += 2)
+    for (i = 0; i < (N - 1); i += 2)
     {
         Y[i]     = NAN;
         Y[i + 1] = INFINITY;
     }
     Y[N - 1] = NAN;
     BLASFUNC(sgemv)(&trans, &N, &N, &alpha, A, &N, X, &incX, &beta, Y, &incY);
-    for (int i = 0; i < N; i ++)
+    for (i = 0; i < N; i ++)
         ASSERT_TRUE(Y[i] == 0.0);
 }
 
 CTEST(sgemv, 0_nan_inf_incy_2)
 {
+    int i;
     blasint N  = 17;
     blasint Ny = 33;
     blasint incX = 1;
@@ -52,7 +54,7 @@ CTEST(sgemv, 0_nan_inf_incy_2)
     memset(A, 0, sizeof(A));
     memset(X, 0, sizeof(X));
     memset(Y, 0, sizeof(Y));
-    for (int i = 0; i < (N - 1); i += 2)
+    for (i = 0; i < (N - 1); i += 2)
     {
         ay[0]   = NAN;
         ay     += 2;
@@ -61,7 +63,7 @@ CTEST(sgemv, 0_nan_inf_incy_2)
     }
     Y[Ny - 1] = NAN;
     BLASFUNC(sgemv)(&trans, &N, &N, &alpha, A, &N, X, &incX, &beta, Y, &incY);
-    for (int i = 0; i < Ny; i ++)
+    for (i = 0; i < Ny; i ++)
         ASSERT_TRUE(Y[i] == 0.0);
 }
 
@@ -70,6 +72,7 @@ CTEST(sgemv, 0_nan_inf_incy_2)
 #ifdef BUILD_DOUBLE
 CTEST(dgemv, 0_nan_inf)
 {
+    int i;
     blasint N = 17;
     blasint incX = 1;
     blasint incY = 1;
@@ -82,19 +85,20 @@ CTEST(dgemv, 0_nan_inf)
 
     memset(A, 0, sizeof(A));
     memset(X, 0, sizeof(X));
-    for (int i = 0; i < (N - 1); i += 2)
+    for (i = 0; i < (N - 1); i += 2)
     {
         Y[i]     = NAN;
         Y[i + 1] = INFINITY;
     }
     Y[N - 1] = NAN;
     BLASFUNC(dgemv)(&trans, &N, &N, &alpha, A, &N, X, &incX, &beta, Y, &incY);
-    for (int i = 0; i < N; i ++)
+    for (i = 0; i < N; i ++)
         ASSERT_TRUE(Y[i] == 0.0);
 }
 
 CTEST(dgemv, 0_nan_inf_incy_2)
 {
+    int i;
     blasint N  = 17;
     blasint Ny = 33;
     blasint incX = 1;
@@ -110,7 +114,7 @@ CTEST(dgemv, 0_nan_inf_incy_2)
     memset(A, 0, sizeof(A));
     memset(X, 0, sizeof(X));
     memset(Y, 0, sizeof(Y));
-    for (int i = 0; i < (N - 1); i += 2)
+    for (i = 0; i < (N - 1); i += 2)
     {
         ay[0]   = NAN;
         ay     += 2;
@@ -119,7 +123,7 @@ CTEST(dgemv, 0_nan_inf_incy_2)
     }
     Y[Ny - 1] = NAN;
     BLASFUNC(dgemv)(&trans, &N, &N, &alpha, A, &N, X, &incX, &beta, Y, &incY);
-    for (int i = 0; i < Ny; i ++)
+    for (i = 0; i < Ny; i ++)
         ASSERT_TRUE(Y[i] == 0.0);
 }
 

--- a/utest/test_gemv.c
+++ b/utest/test_gemv.c
@@ -7,22 +7,21 @@
 #ifndef INFINITY
 #define INFINITY 1.0/0.0
 #endif
-#define N 17
-#define Ny 33
 
 #ifdef BUILD_SINGLE
 
 CTEST(sgemv, 0_nan_inf)
 {
     int i;
+    blasint N = 17;
     blasint incX = 1;
     blasint incY = 1;
     float alpha = 0.0;
     float beta = 0.0;
     char  trans = 'N';
-    float A[N * N];
-    float X[N];
-    float Y[N];
+    float A[17 * 17];
+    float X[17];
+    float Y[17];
 
     memset(A, 0, sizeof(A));
     memset(X, 0, sizeof(X));
@@ -40,14 +39,16 @@ CTEST(sgemv, 0_nan_inf)
 CTEST(sgemv, 0_nan_inf_incy_2)
 {
     int i;
+    blasint N = 17;
+    blasint Ny = 33;
     blasint incX = 1;
     blasint incY = 2;
     float alpha = 0.0;
     float beta = 0.0;
     char  trans = 'N';
-    float A[N * N];
-    float X[N];
-    float Y[Ny];
+    float A[17 * 17];
+    float X[17];
+    float Y[33];
     float *ay = Y;
 
     memset(A, 0, sizeof(A));
@@ -72,14 +73,15 @@ CTEST(sgemv, 0_nan_inf_incy_2)
 CTEST(dgemv, 0_nan_inf)
 {
     int i;
+    blasint N = 17;
     blasint incX = 1;
     blasint incY = 1;
     double alpha = 0.0;
     double beta = 0.0;
     char  trans = 'N';
-    double A[N * N];
-    double X[N];
-    double Y[N];
+    double A[17 * 17];
+    double X[17];
+    double Y[17];
 
     memset(A, 0, sizeof(A));
     memset(X, 0, sizeof(X));
@@ -97,14 +99,16 @@ CTEST(dgemv, 0_nan_inf)
 CTEST(dgemv, 0_nan_inf_incy_2)
 {
     int i;
+    blasint N = 17;
+    blasint Ny = 33;
     blasint incX = 1;
     blasint incY = 2;
     double alpha = 0.0;
     double beta = 0.0;
     char  trans = 'N';
-    double A[N * N];
-    double X[N];
-    double Y[Ny];
+    double A[17 * 17];
+    double X[17];
+    double Y[33];
     double *ay = Y;
 
     memset(A, 0, sizeof(A));


### PR DESCRIPTION
fixes two oversights from #4807