### PR TITLE
Add fallback compile options for A64FX target

### DIFF
--- a/Makefile.arm64
+++ b/Makefile.arm64
@@ -278,7 +278,7 @@ endif
 
 ifeq ($(CORE), A64FX)
 ifeq (1, $(filter 1,$(GCCVERSIONGTEQ10) $(ISCLANG)))
-ifeq (1, $(filter 1,$(GCCMINORVERSIONGTEQ3)))
+ifeq (1, $(filter 1,$(GCCMINORVERSIONGTEQ3) $(ISCLANG)))
 CCOMMON_OPT += -march=armv8.2-a+sve -mtune=a64fx
 ifneq ($(F_COMPILER), NAG)
 FCOMMON_OPT += -march=armv8.2-a+sve -mtune=a64fx

--- a/Makefile.arm64
+++ b/Makefile.arm64
@@ -276,11 +276,18 @@ endif
 endif
 endif
 
-ifeq (1, $(filter 1,$(GCCVERSIONGTEQ11) $(ISCLANG)))
 ifeq ($(CORE), A64FX)
+ifeq (1, $(filter 1,$(GCCVERSIONGTEQ10) $(ISCLANG)))
+ifeq (1, $(filter 1,$(GCCMINORVERSIONGTEQ3)))
 CCOMMON_OPT += -march=armv8.2-a+sve -mtune=a64fx
 ifneq ($(F_COMPILER), NAG)
 FCOMMON_OPT += -march=armv8.2-a+sve -mtune=a64fx
+endif
+else
+CCOMMON_OPT += -march=armv8.4-a+sve -mtune=neoverse-n1
+ifneq ($(F_COMPILER), NAG)
+FCOMMON_OPT += -march=armv8.4-a -mtune=neoverse-n1
+endif
 endif
 endif
 endif


### PR DESCRIPTION
According to https://gcc.gnu.org/gcc-10/changes.html, `mtune=a64fx` should be supported in 10.3.