### PR TITLE
Continue requesting ubuntu18 instead of latest on OSUOSL powerCI

### DIFF
--- a/Jenkinsfile.pwr
+++ b/Jenkinsfile.pwr
@@ -1,7 +1,7 @@
 pipeline {
     agent { 
         docker {
-            image 'osuosl/ubuntu-ppc64le:22.04'
+            image 'osuosl/ubuntu-ppc64le:18.04'
         }
     }
     stages {

--- a/Jenkinsfile.pwr
+++ b/Jenkinsfile.pwr
@@ -1,7 +1,7 @@
 pipeline {
     agent { 
         docker {
-            image 'osuosl/ubuntu-ppc64le'
+            image 'osuosl/ubuntu-ppc64le:22.04'
         }
     }
     stages {


### PR DESCRIPTION
there appears to be a problem with the later images (updated 19 days ago) that prevents the docker job from running