### PR TITLE
Temporarily revert to the coarse-grained locking in the Windows thread server

### DIFF
--- a/common_thread.h
+++ b/common_thread.h
@@ -111,8 +111,8 @@ typedef struct blas_queue {
   struct blas_queue *next;
 
 #if defined( __WIN32__) || defined(__CYGWIN32__) || defined(_WIN32) || defined(__CYGWIN__)
-  // CRITICAL_SECTION lock;
-  // HANDLE finish;
+   CRITICAL_SECTION lock;
+   HANDLE finish;
   volatile int finished;
 #else
   pthread_mutex_t	 lock;

--- a/driver/others/blas_server_win32.c
+++ b/driver/others/blas_server_win32.c
@@ -1,4 +1,3 @@
-
 /*********************************************************************/
 /* Copyright 2009, 2010 The University of Texas at Austin.           */
 /* All rights reserved.                                              */
@@ -49,44 +48,34 @@
 #endif
 #endif
 
-#ifdef SMP_DEBUG
-#   define MT_TRACE(...) fprintf(stderr, __VA_ARGS__)
-#else
-#   define MT_TRACE(...)
-#endif
-
 /* This is a thread implementation for Win32 lazy implementation */
 
 /* Thread server common information */
+typedef struct{
+  CRITICAL_SECTION lock;
+  HANDLE filled;
+  HANDLE killed;
 
-static blas_queue_t *work_queue = NULL;
-static HANDLE kickoff_event = NULL;
-static CRITICAL_SECTION queue_lock;
+  blas_queue_t	*queue;    /* Parameter Pointer */
+  int		shutdown;  /* server shutdown flag */
+
+} blas_pool_t;
 
 /* We need this global for checking if initialization is finished.   */
 int blas_server_avail = 0;
-
 int blas_omp_threads_local = 1;
-
-static void * blas_thread_buffer[MAX_CPU_NUMBER];
-
 /* Local Variables */
 static BLASULONG server_lock       = 0;
 
+static blas_pool_t   pool;
 static HANDLE	    blas_threads   [MAX_CPU_NUMBER];
 static DWORD	    blas_threads_id[MAX_CPU_NUMBER];
-static volatile int thread_target;	// target num of live threads, volatile for cross-thread reads
 
-//Prototypes
-static void exec_threads(int , blas_queue_t *, int);
-static void adjust_thread_buffers();
 
-//
-// Legacy code path
-//
-static void legacy_exec(void *func, int mode, blas_arg_t *args, void *sb) {
 
-      if (!(mode & BLAS_COMPLEX)) {
+static void legacy_exec(void *func, int mode, blas_arg_t *args, void *sb){
+
+      if (!(mode & BLAS_COMPLEX)){
 #ifdef EXPRECISION
 	if ((mode & BLAS_PREC) == BLAS_XDOUBLE){
 	  /* REAL / Extended Double */
@@ -101,7 +90,7 @@ static void legacy_exec(void *func, int mode, blas_arg_t *args, void *sb) {
 		args -> c, args -> ldc, sb);
 	} else
 #endif
-	  if ((mode & BLAS_PREC) == BLAS_DOUBLE) {
+	  if ((mode & BLAS_PREC) == BLAS_DOUBLE){
 	    /* REAL / Double */
 	    void (*afunc)(BLASLONG, BLASLONG, BLASLONG, double,
 			  double *, BLASLONG, double *, BLASLONG,
@@ -112,7 +101,7 @@ static void legacy_exec(void *func, int mode, blas_arg_t *args, void *sb) {
 		  args -> a, args -> lda,
 		  args -> b, args -> ldb,
 		  args -> c, args -> ldc, sb);
-	  } else if ((mode & BLAS_PREC) == BLAS_SINGLE) {
+	  } else if ((mode & BLAS_PREC) == BLAS_SINGLE){
 	    /* REAL / Single */
 	    void (*afunc)(BLASLONG, BLASLONG, BLASLONG, float,
 			  float *, BLASLONG, float *, BLASLONG,
@@ -124,7 +113,7 @@ static void legacy_exec(void *func, int mode, blas_arg_t *args, void *sb) {
 		  args -> b, args -> ldb,
 		  args -> c, args -> ldc, sb);
 #ifdef BUILD_BFLOAT16
-          } else if ((mode & BLAS_PREC) == BLAS_BFLOAT16) {
+          } else if ((mode & BLAS_PREC) == BLAS_BFLOAT16){
             /* REAL / BFLOAT16 */
             void (*afunc)(BLASLONG, BLASLONG, BLASLONG, bfloat16,
                           bfloat16 *, BLASLONG, bfloat16 *, BLASLONG,
@@ -135,7 +124,7 @@ static void legacy_exec(void *func, int mode, blas_arg_t *args, void *sb) {
                   args -> a, args -> lda,
                   args -> b, args -> ldb,
                   args -> c, args -> ldc, sb);
-          } else if ((mode & BLAS_PREC) == BLAS_STOBF16) {
+          } else if ((mode & BLAS_PREC) == BLAS_STOBF16){
             /* REAL / BLAS_STOBF16 */
             void (*afunc)(BLASLONG, BLASLONG, BLASLONG, float,
                           float *, BLASLONG, bfloat16 *, BLASLONG,
@@ -146,7 +135,7 @@ static void legacy_exec(void *func, int mode, blas_arg_t *args, void *sb) {
                   args -> a, args -> lda,
                   args -> b, args -> ldb,
                   args -> c, args -> ldc, sb);
-          } else if ((mode & BLAS_PREC) == BLAS_DTOBF16) {
+          } else if ((mode & BLAS_PREC) == BLAS_DTOBF16){
             /* REAL / BLAS_DTOBF16 */
             void (*afunc)(BLASLONG, BLASLONG, BLASLONG, double,
                           double *, BLASLONG, bfloat16 *, BLASLONG,
@@ -163,7 +152,7 @@ static void legacy_exec(void *func, int mode, blas_arg_t *args, void *sb) {
 	  }
       } else {
 #ifdef EXPRECISION
-	if ((mode & BLAS_PREC) == BLAS_XDOUBLE) {
+	if ((mode & BLAS_PREC) == BLAS_XDOUBLE){
 	  /* COMPLEX / Extended Double */
 	  void (*afunc)(BLASLONG, BLASLONG, BLASLONG, xdouble, xdouble,
 			xdouble *, BLASLONG, xdouble *, BLASLONG,
@@ -177,7 +166,7 @@ static void legacy_exec(void *func, int mode, blas_arg_t *args, void *sb) {
 		args -> c, args -> ldc, sb);
 	} else
 #endif
-	  if ((mode & BLAS_PREC) == BLAS_DOUBLE) {
+	  if ((mode & BLAS_PREC) == BLAS_DOUBLE){
 	    /* COMPLEX / Double */
 	  void (*afunc)(BLASLONG, BLASLONG, BLASLONG, double, double,
 			double *, BLASLONG, double *, BLASLONG,
@@ -207,87 +196,185 @@ static void legacy_exec(void *func, int mode, blas_arg_t *args, void *sb) {
       }
 }
 
-//
-// This is a main routine of threads. Each thread waits until job is queued.
-//
-static DWORD WINAPI blas_thread_server(void *arg) {
+/* This is a main routine of threads. Each thread waits until job is */
+/* queued.                                                           */
+
+static DWORD WINAPI blas_thread_server(void *arg){
 
   /* Thread identifier */
+#ifdef SMP_DEBUG
   BLASLONG  cpu = (BLASLONG)arg;
-  
+#endif
+
+  void *buffer, *sa, *sb;
   blas_queue_t	*queue;
+  DWORD action;
+  HANDLE handles[] = {pool.filled, pool.killed};
 
-  MT_TRACE("Server[%2ld] Thread is started!\n", cpu);
+  /* Each server needs each buffer */
+  buffer   = blas_memory_alloc(2);
 
-  while (1) {
+#ifdef SMP_DEBUG
+  fprintf(STDERR, "Server[%2ld] Thread is started!\n", cpu);
+#endif
+
+  while (1){
 
     /* Waiting for Queue */
 
-    MT_TRACE("Server[%2ld] Waiting for Queue.\n", cpu);
+#ifdef SMP_DEBUG
+    fprintf(STDERR, "Server[%2ld] Waiting for Queue.\n", cpu);
+#endif
 
-    // event raised when work is added to the queue
-    WaitForSingleObject(kickoff_event, INFINITE);
+    do {
+      action = WaitForMultipleObjects(2, handles, FALSE, INFINITE);
+    } while ((action != WAIT_OBJECT_0) && (action != WAIT_OBJECT_0 + 1));
 
-    if (cpu > thread_target - 2) {
-      //MT_TRACE("thread [%d] exiting.\n", cpu);
-      break;	// excess thread, so worker thread exits
-    }
+    if (action == WAIT_OBJECT_0 + 1) break;
 
-    MT_TRACE("Server[%2ld] Got it.\n", cpu);
+#ifdef SMP_DEBUG
+    fprintf(STDERR, "Server[%2ld] Got it.\n", cpu);
+#endif
 
-    EnterCriticalSection(&queue_lock);
+    EnterCriticalSection(&pool.lock);
 
-    queue = work_queue;
-    if (queue)
-        work_queue = work_queue->next;
+    queue = pool.queue;
+    if (queue) pool.queue = queue->next;
 
-    LeaveCriticalSection(&queue_lock);
+    LeaveCriticalSection(&pool.lock);
 
-    if(queue) {
+    if (queue)  {
+      int (*routine)(blas_arg_t *, void *, void *, void *, void *, BLASLONG) = queue -> routine;
 
-    exec_threads(cpu, queue, 0);
-    } else {
+      if (pool.queue) SetEvent(pool.filled);
 
-        continue; //if queue == NULL
-    }
-    
-    MT_TRACE("Server[%2ld] Finished!\n", cpu);
-	
-	  queue->finished = 1;
+      sa = queue -> sa;
+      sb = queue -> sb;
+
+#ifdef CONSISTENT_FPCSR
+      __asm__ __volatile__ ("ldmxcsr %0" : : "m" (queue -> sse_mode));
+      __asm__ __volatile__ ("fldcw %0"   : : "m" (queue -> x87_mode));
+#endif
+
+#ifdef SMP_DEBUG
+      fprintf(STDERR, "Server[%2ld] Started.  Mode = 0x%03x M = %3ld N=%3ld K=%3ld\n",
+	      cpu, queue->mode, queue-> args ->m, queue->args->n, queue->args->k);
+#endif
+
+      // fprintf(stderr, "queue start[%ld]!!!\n", cpu);
+
+#ifdef MONITOR
+      main_status[cpu] = MAIN_RUNNING1;
+#endif
+
+      if (sa == NULL) sa = (void *)((BLASLONG)buffer + GEMM_OFFSET_A);
+
+      if (sb == NULL) {
+	if (!(queue -> mode & BLAS_COMPLEX)){
+#ifdef EXPRECISION
+	  if ((queue -> mode & BLAS_PREC) == BLAS_XDOUBLE){
+	    sb = (void *)(((BLASLONG)sa + ((XGEMM_P * XGEMM_Q * sizeof(xdouble)
+					+ GEMM_ALIGN) & ~GEMM_ALIGN)) + GEMM_OFFSET_B);
+	  } else
+#endif
+	    if ((queue -> mode & BLAS_PREC) == BLAS_DOUBLE){
+#ifdef BUILD_DOUBLE
+	      sb = (void *)(((BLASLONG)sa + ((DGEMM_P * DGEMM_Q * sizeof(double)
+					  + GEMM_ALIGN) & ~GEMM_ALIGN)) + GEMM_OFFSET_B);
+#endif
+	    } else if ((queue -> mode & BLAS_PREC) == BLAS_SINGLE) {
+#ifdef BUILD_SINGLE
+	      sb = (void *)(((BLASLONG)sa + ((SGEMM_P * SGEMM_Q * sizeof(float)
+					  + GEMM_ALIGN) & ~GEMM_ALIGN)) + GEMM_OFFSET_B);
+#endif
+	    } else {
+            /* Other types in future */
+	    }
+	} else {
+#ifdef EXPRECISION
+	  if ((queue -> mode & BLAS_PREC) == BLAS_XDOUBLE){
+	    sb = (void *)(((BLASLONG)sa + ((XGEMM_P * XGEMM_Q * 2 * sizeof(xdouble)
+					+ GEMM_ALIGN) & ~GEMM_ALIGN)) + GEMM_OFFSET_B);
+	  } else
+#endif
+	    if ((queue -> mode & BLAS_PREC) == BLAS_DOUBLE){
+#ifdef BUILD_COMPLEX16
+	      sb = (void *)(((BLASLONG)sa + ((ZGEMM_P * ZGEMM_Q * 2 * sizeof(double)
+					  + GEMM_ALIGN) & ~GEMM_ALIGN)) + GEMM_OFFSET_B);
+#endif
+	    } else if ((queue -> mode & BLAS_PREC) == BLAS_SINGLE) {
+#ifdef BUILD_COMPLEX
+	      sb = (void *)(((BLASLONG)sa + ((CGEMM_P * CGEMM_Q * 2 * sizeof(float)
+					  + GEMM_ALIGN) & ~GEMM_ALIGN)) + GEMM_OFFSET_B);
+#endif
+	    } else {
+            /* Other types in future */
+	    }
+	}
+	queue->sb=sb;
+      }
+
+#ifdef MONITOR
+      main_status[cpu] = MAIN_RUNNING2;
+#endif
+
+      if (!(queue -> mode & BLAS_LEGACY)) {
+
+	(routine)(queue -> args, queue -> range_m, queue -> range_n, sa, sb, queue -> position);
+      } else {
+	legacy_exec(routine, queue -> mode, queue -> args, sb);
+      }
+    }else{
+		continue; //if queue == NULL
+	}
+
+#ifdef SMP_DEBUG
+    fprintf(STDERR, "Server[%2ld] Finished!\n", cpu);
+#endif
+
+    EnterCriticalSection(&queue->lock);
+
+    queue -> status = BLAS_STATUS_FINISHED;
+
+    LeaveCriticalSection(&queue->lock);
+
+    SetEvent(queue->finish);
   }
 
   /* Shutdown procedure */
 
-  MT_TRACE("Server[%2ld] Shutdown!\n",  cpu);
+#ifdef SMP_DEBUG
+  fprintf(STDERR, "Server[%2ld] Shutdown!\n",  cpu);
+#endif
+
+  blas_memory_free(buffer);
 
   return 0;
-}
+  }
 
-//
-// Initializing routine
-//
-int blas_thread_init(void) {
+/* Initializing routine */
+int blas_thread_init(void){
   BLASLONG i;
 
   if (blas_server_avail || (blas_cpu_number <= 1)) return 0;
 
   LOCK_COMMAND(&server_lock);
 
-  adjust_thread_buffers();
+#ifdef SMP_DEBUG
+  fprintf(STDERR, "Initializing Thread(Num. threads = %d)\n",
+	  blas_cpu_number);
+#endif
 
-  MT_TRACE("Initializing Thread(Num. threads = %d)\n", blas_cpu_number);
+  if (!blas_server_avail){
 
-  if (!blas_server_avail) {
-    // create the kickoff Event
-    kickoff_event = CreateEvent(NULL, TRUE, FALSE, NULL);
+    InitializeCriticalSection(&pool.lock);
+    pool.filled = CreateEvent(NULL, FALSE, FALSE, NULL);
+    pool.killed = CreateEvent(NULL, TRUE,  FALSE, NULL);
 
-    thread_target = blas_cpu_number;
+    pool.shutdown = 0;
+    pool.queue    = NULL;
 
-    InitializeCriticalSection(&queue_lock);
-
-    for(i = 0; i < blas_cpu_number - 1; i++) {
-	    //MT_TRACE("thread_init: creating thread [%d]\n", i);
-
+    for(i = 0; i < blas_cpu_number - 1; i++){
       blas_threads[i] = CreateThread(NULL, 0,
 				     blas_thread_server, (void *)i,
 				     0, &blas_threads_id[i]);
@@ -301,12 +388,15 @@ int blas_thread_init(void) {
   return 0;
 }
 
-//
-//   User can call one of two routines.
-//     exec_blas_async ... immediately returns after jobs are queued.
-//     exec_blas       ... returns after jobs are finished.
-//
-int exec_blas_async(BLASLONG pos, blas_queue_t *queue) {
+/*
+   User can call one of two routines.
+
+     exec_blas_async ... immediately returns after jobs are queued.
+
+     exec_blas       ... returns after jobs are finished.
+*/
+
+int exec_blas_async(BLASLONG pos, blas_queue_t *queue){
 
 #if defined(SMP_SERVER)
   // Handle lazy re-init of the thread-pool after a POSIX fork
@@ -319,6 +409,8 @@ int exec_blas_async(BLASLONG pos, blas_queue_t *queue) {
   current = queue;
 
   while (current) {
+    InitializeCriticalSection(&current -> lock);
+    current -> finish = CreateEvent(NULL, FALSE, FALSE, NULL);
     current -> position = pos;
 
 #ifdef CONSISTENT_FPCSR
@@ -326,71 +418,56 @@ int exec_blas_async(BLASLONG pos, blas_queue_t *queue) {
     __asm__ __volatile__ ("stmxcsr %0" : "=m" (current -> sse_mode));
 #endif
 
-  	current->finished = 0;
     current = current -> next;
     pos ++;
   }
 
-  EnterCriticalSection(&queue_lock);
+  EnterCriticalSection(&pool.lock);
 
-  if (!work_queue)
-  {
-    work_queue = queue;
-  }
-  else
-  {
-	  blas_queue_t *queue_item = work_queue;
-
-    // find the end of the work queue
-    while (queue_item->next)
-        queue_item = queue_item->next;
-
-    // add new work to the end
-    queue_item->next = queue;
+  if (pool.queue) {
+    current = pool.queue;
+    while (current -> next) current = current -> next;
+    current -> next = queue;
+  } else {
+    pool.queue = queue;
   }
 
-  LeaveCriticalSection(&queue_lock);
+  LeaveCriticalSection(&pool.lock);
 
-  SetEvent(kickoff_event);
+  SetEvent(pool.filled);
 
   return 0;
 }
 
-//
-// Join. Wait for all queued tasks to complete
-//
-int exec_blas_async_wait(BLASLONG num, blas_queue_t *queue) {
+int exec_blas_async_wait(BLASLONG num, blas_queue_t *queue){
 
-  MT_TRACE("Synchronization Waiting.\n");
+#ifdef SMP_DEBUG
+    fprintf(STDERR, "Synchronization Waiting.\n");
+#endif
 
-  while (num) {
-    MT_TRACE("Waiting Queue ..\n");
+    while (num){
+#ifdef SMP_DEBUG
+    fprintf(STDERR, "Waiting Queue ..\n");
+#endif
 
-    while (!queue->finished)
-      YIELDING;
+      WaitForSingleObject(queue->finish, INFINITE);
 
-    queue = queue->next;
-    num--;
-  }
+      CloseHandle(queue->finish);
+      DeleteCriticalSection(&queue -> lock);
 
-  MT_TRACE("Completely Done.\n\n");
+      queue = queue -> next;
+      num --;
+    }
 
-	// if work was added to the queue after this batch we can't sleep the worker threads
-	// by resetting the event
-	EnterCriticalSection(&queue_lock);
+#ifdef SMP_DEBUG
+    fprintf(STDERR, "Completely Done.\n\n");
+#endif
 
-	if (work_queue == NULL)
-		ResetEvent(kickoff_event);
-
-	LeaveCriticalSection(&queue_lock);
-
-	return 0;
+  return 0;
 }
 
-//
-// Execute Threads
-//
-int exec_blas(BLASLONG num, blas_queue_t *queue) {
+/* Execute Threads */
+int exec_blas(BLASLONG num, blas_queue_t *queue){
 
 #if defined(SMP_SERVER) && defined(OS_CYGWIN_NT)
   // Handle lazy re-init of the thread-pool after a POSIX fork
@@ -403,44 +480,29 @@ int exec_blas(BLASLONG num, blas_queue_t *queue) {
 
   if ((num <= 0) || (queue == NULL)) return 0;
 
-  //Redirect to caller's callback routine
-  if (openblas_threads_callback_) {
-  int buf_index = 0, i = 0;
-#ifndef USE_SIMPLE_THREADED_LEVEL3
-    for (i = 0; i < num; i ++)
-      queue[i].position = i;
-#endif
-    openblas_threads_callback_(1, (openblas_dojob_callback) exec_threads, num, sizeof(blas_queue_t), (void*) queue, buf_index);
-    return 0;
-  }
-
-  if ((num > 1) && queue -> next) 
-    exec_blas_async(1, queue -> next);
+  if ((num > 1) && queue -> next) exec_blas_async(1, queue -> next);
 
   routine = queue -> routine;
 
   if (queue -> mode & BLAS_LEGACY) {
     legacy_exec(routine, queue -> mode, queue -> args, queue -> sb);
-  } else {
+  } else
     if (queue -> mode & BLAS_PTHREAD) {
       void (*pthreadcompat)(void *) = queue -> routine;
       (pthreadcompat)(queue -> args);
     } else
       (routine)(queue -> args, queue -> range_m, queue -> range_n,
-    		queue -> sa, queue -> sb, 0);
-  }
+		queue -> sa, queue -> sb, 0);
 
-  if ((num > 1) && queue -> next) 
-    exec_blas_async_wait(num - 1, queue -> next);
+  if ((num > 1) && queue -> next) exec_blas_async_wait(num - 1, queue -> next);
 
   return 0;
 }
 
-//
-// Shutdown procedure, but user don't have to call this routine. The
-// kernel automatically kill threads.
-//
-int BLASFUNC(blas_thread_shutdown)(void) {
+/* Shutdown procedure, but user don't have to call this routine. The */
+/* kernel automatically kill threads.                                */
+
+int BLASFUNC(blas_thread_shutdown)(void){
 
   int i;
 
@@ -448,17 +510,11 @@ int BLASFUNC(blas_thread_shutdown)(void) {
 
   LOCK_COMMAND(&server_lock);
 
-  //Free buffers allocated for threads
-  for(i=0; i<MAX_CPU_NUMBER; i++){
-    if(blas_thread_buffer[i]!=NULL){
-      blas_memory_free(blas_thread_buffer[i]);
-      blas_thread_buffer[i]=NULL;
-    }
-  }
+  if (blas_server_avail){
 
-  if (blas_server_avail) {
+    SetEvent(pool.killed);
 
-    for (i = 0; i < blas_num_threads - 1; i++) {
+    for(i = 0; i < blas_num_threads - 1; i++){
       // Could also just use WaitForMultipleObjects
       DWORD wait_thread_value = WaitForSingleObject(blas_threads[i], 50);
 
@@ -472,6 +528,9 @@ int BLASFUNC(blas_thread_shutdown)(void) {
       CloseHandle(blas_threads[i]);
     }
 
+    CloseHandle(pool.filled);
+    CloseHandle(pool.killed);
+
     blas_server_avail = 0;
   }
 
@@ -480,9 +539,6 @@ int BLASFUNC(blas_thread_shutdown)(void) {
   return 0;
 }
 
-//
-// Legacy function to set numbef of threads
-//
 void goto_set_num_threads(int num_threads)
 {
 	long i;
@@ -496,48 +552,23 @@ void goto_set_num_threads(int num_threads)
 
 	if (num_threads > MAX_CPU_NUMBER) num_threads = MAX_CPU_NUMBER;
 
-	if (blas_server_avail && num_threads < blas_num_threads) {
-		LOCK_COMMAND(&server_lock);
-
-		thread_target = num_threads;
-		
-		SetEvent(kickoff_event);
-
-		for (i = num_threads - 1; i < blas_num_threads - 1; i++) {
-			//MT_TRACE("set_num_threads: waiting on thread [%d] to quit.\n", i);
-
-			WaitForSingleObject(blas_threads[i], INFINITE);
-
-			//MT_TRACE("set_num_threads: thread [%d] has quit.\n", i);
-
-			CloseHandle(blas_threads[i]);
-		}
-
-		blas_num_threads = num_threads;
-		
-		ResetEvent(kickoff_event);
-
-		UNLOCK_COMMAND(&server_lock);
-	}
-
 	if (num_threads > blas_num_threads) {
 
 		LOCK_COMMAND(&server_lock);
 
-		thread_target = num_threads;
+		//increased_threads = 1;
+	    if (!blas_server_avail){
 
-		  //increased_threads = 1;
-	    if (!blas_server_avail) {
-			// create the kickoff Event
-			kickoff_event = CreateEvent(NULL, TRUE, FALSE, NULL);
+			InitializeCriticalSection(&pool.lock);
+			pool.filled = CreateEvent(NULL, FALSE, FALSE, NULL);
+			pool.killed = CreateEvent(NULL, TRUE,  FALSE, NULL);
 
-			InitializeCriticalSection(&queue_lock);
-
+			pool.shutdown = 0;
+			pool.queue    = NULL;
 			blas_server_avail = 1;
 		}
 
-		for (i = (blas_num_threads > 0) ? blas_num_threads - 1 : 0; i < num_threads - 1; i++) {
-			//MT_TRACE("set_num_threads: creating thread [%d]\n", i);
+		for(i = (blas_num_threads > 0) ? blas_num_threads - 1 : 0; i < num_threads - 1; i++){
 
 			blas_threads[i] = CreateThread(NULL, 0,
 				     blas_thread_server, (void *)i,
@@ -552,113 +583,7 @@ void goto_set_num_threads(int num_threads)
 	blas_cpu_number  = num_threads;
 }
 
-//
-// Openblas function to set thread count
-//
 void openblas_set_num_threads(int num)
 {
 	goto_set_num_threads(num);
-}
-
-static void adjust_thread_buffers() {
-
-  int i=0;
-
-  //adjust buffer for each thread
-  for(i=0; i < blas_cpu_number; i++){
-    if(blas_thread_buffer[i] == NULL){
-      blas_thread_buffer[i] = blas_memory_alloc(2);
-    }
-  }
-  for(; i < MAX_CPU_NUMBER; i++){
-    if(blas_thread_buffer[i] != NULL){
-      blas_memory_free(blas_thread_buffer[i]);
-      blas_thread_buffer[i] = NULL;
-    }
-  }
-}
-
-//Indivitual threads work executor, Helps in setting by synchronization environment and calling inner_threads routine
-static void exec_threads(int cpu, blas_queue_t *queue, int buf_index) {
-  
-  void *buffer, *sa, *sb;
-  
-  buffer = blas_thread_buffer[cpu];
-  sa = queue -> sa;
-  sb = queue -> sb;
-
-  int (*routine)(blas_arg_t *, void *, void *, void *, void *, BLASLONG) = queue -> routine;
-
-  #ifdef CONSISTENT_FPCSR
-    __asm__ __volatile__ ("ldmxcsr %0" : : "m" (queue -> sse_mode));
-    __asm__ __volatile__ ("fldcw %0"   : : "m" (queue -> x87_mode));
-  #endif
-
-  MT_TRACE("Server[%2ld] Started.  Mode = 0x%03x M = %3ld N=%3ld K=%3ld\n",
-    cpu, queue->mode, queue-> args ->m, queue->args->n, queue->args->k);
-
-  // fprintf(stderr, "queue start[%ld]!!!\n", cpu);
-
-  #ifdef MONITOR
-    main_status[cpu] = MAIN_RUNNING1;
-  #endif
-
-  if (sa == NULL) 
-    sa = (void *)((BLASLONG)buffer + GEMM_OFFSET_A);
-
-  if (sb == NULL) {
-    if (!(queue -> mode & BLAS_COMPLEX)) {
-#ifdef EXPRECISION
-if ((queue -> mode & BLAS_PREC) == BLAS_XDOUBLE) {
-  sb = (void *)(((BLASLONG)sa + ((XGEMM_P * XGEMM_Q * sizeof(xdouble)
-      + GEMM_ALIGN) & ~GEMM_ALIGN)) + GEMM_OFFSET_B);
-} else
-#endif
-  if ((queue -> mode & BLAS_PREC) == BLAS_DOUBLE) {
-#ifdef BUILD_DOUBLE
-    sb = (void *)(((BLASLONG)sa + ((DGEMM_P * DGEMM_Q * sizeof(double)
-        + GEMM_ALIGN) & ~GEMM_ALIGN)) + GEMM_OFFSET_B);
-#endif
-  } else if ((queue -> mode & BLAS_PREC) == BLAS_SINGLE) {
-#ifdef BUILD_SINGLE
-    sb = (void *)(((BLASLONG)sa + ((SGEMM_P * SGEMM_Q * sizeof(float)
-        + GEMM_ALIGN) & ~GEMM_ALIGN)) + GEMM_OFFSET_B);
-#endif
-  } else {
-        /* Other types in future */
-  }
-} else {
-#ifdef EXPRECISION
-if ((queue -> mode & BLAS_PREC) == BLAS_XDOUBLE){
-  sb = (void *)(((BLASLONG)sa + ((XGEMM_P * XGEMM_Q * 2 * sizeof(xdouble)
-      + GEMM_ALIGN) & ~GEMM_ALIGN)) + GEMM_OFFSET_B);
-} else
-#endif
-  if ((queue -> mode & BLAS_PREC) == BLAS_DOUBLE){
-#ifdef BUILD_COMPLEX16
-    sb = (void *)(((BLASLONG)sa + ((ZGEMM_P * ZGEMM_Q * 2 * sizeof(double)
-        + GEMM_ALIGN) & ~GEMM_ALIGN)) + GEMM_OFFSET_B);
-#endif
-  } else if ((queue -> mode & BLAS_PREC) == BLAS_SINGLE) {
-#ifdef BUILD_COMPLEX
-    sb = (void *)(((BLASLONG)sa + ((CGEMM_P * CGEMM_Q * 2 * sizeof(float)
-        + GEMM_ALIGN) & ~GEMM_ALIGN)) + GEMM_OFFSET_B);
-#endif
-  } else {
-        /* Other types in future */
-  }
-}
-    queue->sb=sb;
-  }
-
-  #ifdef MONITOR
-    main_status[cpu] = MAIN_RUNNING2;
-  #endif
-
-  if (!(queue -> mode & BLAS_LEGACY)) {
-    (routine)(queue -> args, queue -> range_m, queue -> range_n, sa, sb, queue -> position);
-  } else {
-    legacy_exec(routine, queue -> mode, queue -> args, sb);
-  }
-
 }


### PR DESCRIPTION
this effectively undoes #4359 due to thread safety regressions found in numpy (scipy/sunpy) contexts - whether caused directly or only exposed by more efficient multithreading with that PR
https://github.com/numpy/numpy/issues/27036
https://github.com/conda-forge/openblas-feedstock/issues/160