### PR TITLE
Add proper returns in x86_64 s/dscal kernels

### DIFF
--- a/kernel/x86_64/dscal.c
+++ b/kernel/x86_64/dscal.c
@@ -242,4 +242,5 @@ int CNAME(BLASLONG n, BLASLONG dummy0, BLASLONG dummy1, FLOAT da, FLOAT *x, BLAS
             }
         }
     }
+    return(0);
 }

--- a/kernel/x86_64/sscal.c
+++ b/kernel/x86_64/sscal.c
@@ -200,4 +200,5 @@ int CNAME(BLASLONG n, BLASLONG dummy0, BLASLONG dummy1, FLOAT da, FLOAT *x, BLAS
             }
         }
     }
+    return(0);
 }


### PR DESCRIPTION
fixes a compiler warning caused by a small omission in #4794