### PR TITLE
Make the dummy GEMM3M kernel for GENERIC targets forward to regular GEMM for now

### DIFF
--- a/kernel/Makefile.L3
+++ b/kernel/Makefile.L3
@@ -17,15 +17,6 @@ ifeq ($(ARCH), ia64)
 USE_GEMM3M = 1
 endif
 
-ifneq ($(DYNAMIC_ARCH), 1)
-ifeq ($(TARGET), GENERIC)
-USE_GEMM3M = 0
-endif
-else
-ifeq ($(CORE), GENERIC)
-USE_GEMM3M = 0
-endif
-endif
 
 ifeq ($(ARCH), arm)
 USE_TRMM = 1

--- a/kernel/generic/zgemm3mkernel_dump.c
+++ b/kernel/generic/zgemm3mkernel_dump.c
@@ -25,10 +25,16 @@ CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 *****************************************************************************/
+#if 1
 
+#include "zgemmkernel_2x2.c"
+
+
+#else
 #include "common.h"
 
 int CNAME(BLASLONG bm, BLASLONG bn, BLASLONG bk, FLOAT alphar, FLOAT alphai, FLOAT * ba, FLOAT * bb, FLOAT * C, BLASLONG ldc)
 {
   return 0;
 }
+#endif


### PR DESCRIPTION
this should be a less nasty surprise than just returning from an empty function, while not as invasive and impractical as adding exceptions for the GENERIC target in each architecture (which leads to further complications in the linktest and in DYNAMIC_ARCH builds). effectively reverts #4738