### PR TITLE
Disable forwarding from SBGEMM to SBGEMV for now

### DIFF
--- a/interface/gemm.c
+++ b/interface/gemm.c
@@ -498,7 +498,7 @@ void CNAME(enum CBLAS_ORDER order, enum CBLAS_TRANSPOSE TransA, enum CBLAS_TRANS
 	 args.m, args.n, args.k, args.lda, args.ldb, args.ldc);
 #endif
 
-#if defined(GEMM_GEMV_FORWARD) && !defined(GEMM3M) && !defined(COMPLEX)
+#if defined(GEMM_GEMV_FORWARD) && !defined(GEMM3M) && !defined(COMPLEX) && !defined(BFLOAT16)
   // Check if we can convert GEMM -> GEMV
   if (args.k != 0) {
     if (args.n == 1) {


### PR DESCRIPTION
this probably needs more benchmarking to check performance effects when the target has an optimized SBGEMM but no SBGEMV