### PR TITLE
Fix recursive variable expansion in Makefiles for LOONGSON3A

### DIFF
--- a/ctest/Makefile
+++ b/ctest/Makefile
@@ -26,7 +26,7 @@ endif
 override CFLAGS += -DADD$(BU) -DCBLAS
 ifeq ($(F_COMPILER),GFORTRAN)
 ifneq (, $(filter $(CORE),LOONGSON3R3 LOONGSON3R4))
-	override FFLAGS = $(filter_out(-O2 -O3,$(FFLAGS))) -O0
+	override FFLAGS := $(filter_out(-O2 -O3,$(FFLAGS))) -O0
 endif
 	override FFLAGS += -fno-tree-vectorize
 endif

--- a/test/Makefile
+++ b/test/Makefile
@@ -2,7 +2,7 @@ TOPDIR	= ..
 include ../Makefile.system
 ifeq ($(F_COMPILER),GFORTRAN)
 ifneq (, $(filter $(CORE),LOONGSON3R3 LOONGSON3R4))
-	override FFLAGS = $(filter_out(-O2 -O3,$(FFLAGS))) -O0
+	override FFLAGS := $(filter_out(-O2 -O3,$(FFLAGS))) -O0
 endif
         override FFLAGS += -fno-tree-vectorize
 endif


### PR DESCRIPTION
replace `=` with `:=` to avoid `*** Recursive variable 'FFLAGS' references itself (eventually).`