### PR TITLE
Fixed the undefined reference to blas_set_parameter

### DIFF
--- a/driver/others/blas_server_omp.c
+++ b/driver/others/blas_server_omp.c
@@ -114,8 +114,10 @@ void goto_set_num_threads(int num_threads) {
 
   adjust_thread_buffers();
 #if defined(ARCH_MIPS64) || defined(ARCH_LOONGARCH64)
+#ifndef DYNAMIC_ARCH
   //set parameters for different number of threads.
   blas_set_parameter();
+#endif
 #endif
 
 }


### PR DESCRIPTION
Fixed the undefined reference to blas_set_parameter when enabling USE_OPENMP and DYNAMIC_ARCH.