### PR TITLE
Exclude the WhereAmI function on Arm64 when compiling with MSVC

### DIFF
--- a/common_arm64.h
+++ b/common_arm64.h
@@ -1,5 +1,5 @@
 /*****************************************************************************
-Copyright (c) 2011-2015, The OpenBLAS Project
+Copyright (c) 2011-2024, The OpenBLAS Project
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -54,7 +54,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #ifndef ASSEMBLER
 
-
+#ifndef C_MSVC
 static __inline int WhereAmI(void){
   uint64_t ret;
   __asm__ volatile (
@@ -67,6 +67,7 @@ static __inline int WhereAmI(void){
   if ((int)ret <0) ret = 0;
   return (int)ret;
 }
+#endif
 
 static __inline void blas_lock(volatile BLASULONG *address){
 


### PR DESCRIPTION
fixes compilation problem for WoA flagged in comment on my original PR #4648