### PR TITLE
Change multi-threading logic for SBGEMV to be the same as SGEMV.

### DIFF
--- a/interface/sbgemv.c
+++ b/interface/sbgemv.c
@@ -178,21 +178,10 @@ void CNAME(enum CBLAS_ORDER order, enum CBLAS_TRANSPOSE TransA, blasint m, blasi
     if (incy < 0) {y -= (leny - 1) * incy;}
 
 #ifdef SMP
-    int thread_thres_row = 20480;
-    if (trans) {
-        if (n <= thread_thres_row) {
-            nthreads = 1;
-        } else {
-            nthreads = num_cpu_avail(1);
-        }
-    } else {
-        if (m <= thread_thres_row) {
-            nthreads = 1;
-        } else {
-            nthreads = num_cpu_avail(1);
-        }
-    }
-
+    if ( 1L * m * n < 115200L * GEMM_MULTITHREAD_THRESHOLD )
+      nthreads = 1;
+    else
+      nthreads = num_cpu_avail(2);
 
     if (nthreads == 1) {
 #endif


### PR DESCRIPTION
The logic for threading SBGEMV was only using the size of the vector when determining whether or not to thread it.

This makes the logic the same as SGEMV (F32).

With 32 threads, I'm seeing a 4.9X improvement for SBGEMV.