### PR TITLE
Fix AIX build

### DIFF
--- a/kernel/power/gemm_common.c
+++ b/kernel/power/gemm_common.c
@@ -49,7 +49,7 @@ FORCEINLINE void vec_load_pair(vec_f32 *dst, vec_f32 *src)
 #ifdef __clang__
   vy0p = __builtin_vsx_lxvp(0L, (const __vector_pair *)(src));
 #else
-  vy0p = *(__vector_pair *)(src);
+  vy0p = *(__vector_pair *)((void *)src);
 #endif
   __builtin_vsx_disassemble_pair((void *)(dst), &vy0p);
 #else
@@ -66,7 +66,7 @@ FORCEINLINE void vec_store_pair(vec_f32 *dst, vec_f32 *src)
 #ifdef __clang__
   __builtin_vsx_stxvp(vy0p, 0L, (__vector_pair *)(dst));
 #else
-  *(__vector_pair *)(dst) = vy0p;
+  *(__vector_pair *)((void *)dst) = vy0p;
 #endif
 #else
   dst[0] = src[0];

--- a/kernel/power/gemm_common.c
+++ b/kernel/power/gemm_common.c
@@ -28,7 +28,12 @@
 #define USE_VECTOR_PAIRS
 #endif
 
+#ifdef _AIX
+#include<stdbool.h>
+typedef __vector unsigned short vec_bf16;
+#else
 typedef __vector IFLOAT        vec_bf16;
+#endif
 typedef __vector FLOAT         vec_f32;
 typedef __vector unsigned char vec_uc8;
 


### PR DESCRIPTION
AIX build with OpenXL broke after PR #4944 with the below errors. 

In file included from ../kernel/power/sbgemv_t_vsx.c:31:
In file included from ../kernel/power/sbgemv_common.c:30:
../kernel/power/gemm_common.c:31:18: error: type specifier missing, defaults to 'int'; ISO C99 and later do not support implicit int [-Wimplicit-int]
   31 | typedef __vector IFLOAT        vec_bf16;
      | ~~~~~~~~~~~~~~~~ ^
      | int
../common.h:310:16: note: expanded from macro 'IFLOAT'
  310 | #define IFLOAT  bfloat16
      |                 ^
In file included from ../kernel/power/sbgemv_t_vsx.c:31:
In file included from ../kernel/power/sbgemv_common.c:30:
../kernel/power/gemm_common.c:31:18: error: typedef redefinition with different types ('__vector int' (vector of 4 'int' values) vs 'uint16_t' (aka 'unsigned short'))
../common.h:310:16: note: expanded from macro 'IFLOAT'
  310 | #define IFLOAT  bfloat16
      |                 ^
../common.h:265:18: note: previous definition is here
  265 | typedef uint16_t bfloat16;
      |                  ^
In file included from ../kernel/power/sbgemv_t_vsx.c:31:
In file included from ../kernel/power/sbgemv_common.c:30:
../kernel/power/gemm_common.c:31:24: error: expected ';' after top level declarator
   31 | typedef __vector IFLOAT        vec_bf16;
      |                        ^
      |                        ;
../kernel/power/gemm_common.c:72:13: error: unknown type name 'vec_bf16'
   72 | FORCEINLINE vec_bf16 vec_loadN(void *src, BLASLONG n)
      |             ^
      
Looks like vector types will not work with typedef 'ed defines in AIX with OpenXL compiler. 
Also bool type is used in the sbgemv_common_power10.c and needs the explicit include of stdbool.h in AIX.