### PR TITLE
fix: return types of *trtrs routines

### DIFF
--- a/lapack-netlib/LAPACKE/include/lapack.h
+++ b/lapack-netlib/LAPACKE/include/lapack.h
@@ -22379,7 +22379,7 @@ lapack_int LAPACK_ztrtri_base(
 #endif
 
 #define LAPACK_ctrtrs_base LAPACK_GLOBAL(ctrtrs,CTRTRS)
-lapack_int LAPACK_ctrtrs_base(
+void LAPACK_ctrtrs_base(
     char const* uplo, char const* trans, char const* diag,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_float const* A, lapack_int const* lda,
@@ -22396,7 +22396,7 @@ lapack_int LAPACK_ctrtrs_base(
 #endif
 
 #define LAPACK_dtrtrs_base LAPACK_GLOBAL(dtrtrs,DTRTRS)
-lapack_int LAPACK_dtrtrs_base(
+void LAPACK_dtrtrs_base(
     char const* uplo, char const* trans, char const* diag,
     lapack_int const* n, lapack_int const* nrhs,
     double const* A, lapack_int const* lda,
@@ -22413,7 +22413,7 @@ lapack_int LAPACK_dtrtrs_base(
 #endif
 
 #define LAPACK_strtrs_base LAPACK_GLOBAL(strtrs,STRTRS)
-lapack_int LAPACK_strtrs_base(
+void LAPACK_strtrs_base(
     char const* uplo, char const* trans, char const* diag,
     lapack_int const* n, lapack_int const* nrhs,
     float const* A, lapack_int const* lda,
@@ -22430,7 +22430,7 @@ lapack_int LAPACK_strtrs_base(
 #endif
 
 #define LAPACK_ztrtrs_base LAPACK_GLOBAL(ztrtrs,ZTRTRS)
-lapack_int LAPACK_ztrtrs_base(
+void LAPACK_ztrtrs_base(
     char const* uplo, char const* trans, char const* diag,
     lapack_int const* n, lapack_int const* nrhs,
     lapack_complex_double const* A, lapack_int const* lda,

--- a/lapack-netlib/SRC/cgels.c
+++ b/lapack-netlib/SRC/cgels.c
@@ -739,7 +739,7 @@ static integer c__0 = 0;
 	    complex *, complex *, integer *, complex *, integer *, integer *);
     real smlnum;
     logical lquery;
-    extern /* Subroutine */ int ctrtrs_(char *, char *, char *, integer *, 
+    extern /* Subroutine */ void ctrtrs_(char *, char *, char *, integer *, 
 	    integer *, complex *, integer *, complex *, integer *, integer *);
 
 

--- a/lapack-netlib/SRC/cgelst.c
+++ b/lapack-netlib/SRC/cgelst.c
@@ -748,7 +748,7 @@ f"> */
     integer mnnrhs;
     real smlnum;
     logical lquery;
-    extern /* Subroutine */ int ctrtrs_(char *, char *, char *, integer *, 
+    extern /* Subroutine */ void ctrtrs_(char *, char *, char *, integer *, 
 	    integer *, complex *, integer *, complex *, integer *, integer *);
     extern void cgemlqt_(char *, char *, integer *, 
 	    integer *, integer *, integer *, complex *, integer *, complex *, 

--- a/lapack-netlib/SRC/cgetsls.c
+++ b/lapack-netlib/SRC/cgetsls.c
@@ -713,7 +713,7 @@ static integer c__0 = 0;
     real bignum, smlnum;
     integer wsizem, wsizeo;
     logical lquery;
-    extern /* Subroutine */ int ctrtrs_(char *, char *, char *, integer *, 
+    extern /* Subroutine */ void ctrtrs_(char *, char *, char *, integer *, 
 	    integer *, complex *, integer *, complex *, integer *, integer *);
     integer lw1, lw2, mnk;
     real dum[1];

--- a/lapack-netlib/SRC/cggglm.c
+++ b/lapack-netlib/SRC/cggglm.c
@@ -728,7 +728,7 @@ f"> */
 	    complex *, complex *, integer *, complex *, integer *, integer *);
     integer lwkopt;
     logical lquery;
-    extern /* Subroutine */ int ctrtrs_(char *, char *, char *, integer *, 
+    extern /* Subroutine */ void ctrtrs_(char *, char *, char *, integer *, 
 	    integer *, complex *, integer *, complex *, integer *, integer *);
 
 

--- a/lapack-netlib/SRC/cgglse.c
+++ b/lapack-netlib/SRC/cgglse.c
@@ -725,7 +725,7 @@ f"> */
 	    complex *, complex *, integer *, complex *, integer *, integer *);
     integer lwkopt;
     logical lquery;
-    extern /* Subroutine */ int ctrtrs_(char *, char *, char *, integer *, 
+    extern /* Subroutine */ void ctrtrs_(char *, char *, char *, integer *, 
 	    integer *, complex *, integer *, complex *, integer *, integer *);
 
 

--- a/lapack-netlib/SRC/dgels.c
+++ b/lapack-netlib/SRC/dgels.c
@@ -739,7 +739,7 @@ static integer c__0 = 0;
 	    doublereal *, integer *, integer *);
     doublereal smlnum;
     logical lquery;
-    extern /* Subroutine */ int dtrtrs_(char *, char *, char *, integer *, 
+    extern /* Subroutine */ void dtrtrs_(char *, char *, char *, integer *, 
 	    integer *, doublereal *, integer *, doublereal *, integer *, 
 	    integer *);
 

--- a/lapack-netlib/SRC/dgelst.c
+++ b/lapack-netlib/SRC/dgelst.c
@@ -747,7 +747,7 @@ f"> */
     integer mnnrhs;
     doublereal smlnum;
     logical lquery;
-    extern /* Subroutine */ int dtrtrs_(char *, char *, char *, integer *, 
+    extern /* Subroutine */ void dtrtrs_(char *, char *, char *, integer *, 
 	    integer *, doublereal *, integer *, doublereal *, integer *, 
 	    integer *);
     extern void dgemlqt_(char *, char *, 

--- a/lapack-netlib/SRC/dgetsls.c
+++ b/lapack-netlib/SRC/dgetsls.c
@@ -713,7 +713,7 @@ static integer c__0 = 0;
     doublereal bignum, smlnum;
     integer wsizem, wsizeo;
     logical lquery;
-    extern /* Subroutine */ int dtrtrs_(char *, char *, char *, integer *, 
+    extern /* Subroutine */ void dtrtrs_(char *, char *, char *, integer *, 
 	    integer *, doublereal *, integer *, doublereal *, integer *, 
 	    integer *);
     integer lw1, lw2, mnk, lwm, lwo;

--- a/lapack-netlib/SRC/dggglm.c
+++ b/lapack-netlib/SRC/dggglm.c
@@ -730,7 +730,7 @@ f"> */
 	    doublereal *, integer *, integer *);
     integer lwkopt;
     logical lquery;
-    extern /* Subroutine */ int dtrtrs_(char *, char *, char *, integer *, 
+    extern /* Subroutine */ void dtrtrs_(char *, char *, char *, integer *, 
 	    integer *, doublereal *, integer *, doublereal *, integer *, 
 	    integer *);
 

--- a/lapack-netlib/SRC/sgels.c
+++ b/lapack-netlib/SRC/sgels.c
@@ -485,7 +485,7 @@ static integer c__0 = 0;
     extern /* Subroutine */ void sormqr_(char *, char *, integer *, integer *, 
 	    integer *, real *, integer *, real *, real *, integer *, real *, 
 	    integer *, integer *);
-    extern int strtrs_(char *, char *, 
+    extern void strtrs_(char *, char *, 
 	    char *, integer *, integer *, real *, integer *, real *, integer *
 	    , integer *);
 

--- a/lapack-netlib/SRC/sgelst.c
+++ b/lapack-netlib/SRC/sgelst.c
@@ -744,7 +744,7 @@ f"> */
 	    *, integer *, real *, integer *, real *, integer *);
     real smlnum;
     logical lquery;
-    extern /* Subroutine */ int strtrs_(char *, char *, char *, integer *, 
+    extern /* Subroutine */ void strtrs_(char *, char *, char *, integer *, 
 	    integer *, real *, integer *, real *, integer *, integer *);
     extern void sgemlqt_(char *, char *, integer *, 
 	    integer *, integer *, integer *, real *, integer *, real *, 

--- a/lapack-netlib/SRC/sgetsls.c
+++ b/lapack-netlib/SRC/sgetsls.c
@@ -711,7 +711,7 @@ static integer c__0 = 0;
     integer wsizem, wsizeo;
     logical lquery;
     integer lw1, lw2;
-    extern /* Subroutine */ int strtrs_(char *, char *, char *, integer *, 
+    extern /* Subroutine */ void strtrs_(char *, char *, char *, integer *, 
 	    integer *, real *, integer *, real *, integer *, integer *);
     integer mnk, lwm, lwo;
 

--- a/lapack-netlib/SRC/sggglm.c
+++ b/lapack-netlib/SRC/sggglm.c
@@ -473,7 +473,7 @@ f"> */
 	    integer *, integer *), sormrq_(char *, char *, 
 	    integer *, integer *, integer *, real *, integer *, real *, real *
 	    , integer *, real *, integer *, integer *);
-    extern int strtrs_(char *, char *, char *, integer *, integer *, real *, 
+    extern void strtrs_(char *, char *, char *, integer *, integer *, real *, 
 	    integer *, real *, integer *, integer *);
 
 

--- a/lapack-netlib/SRC/sgglse.c
+++ b/lapack-netlib/SRC/sgglse.c
@@ -471,7 +471,7 @@ f"> */
 	    integer *, integer *), sormrq_(char *, char *, 
 	    integer *, integer *, integer *, real *, integer *, real *, real *
 	    , integer *, real *, integer *, integer *); 
-    extern int strtrs_(char *, char *, char *, integer *, integer *, real *, 
+    extern void strtrs_(char *, char *, char *, integer *, integer *, real *, 
 	    integer *, real *, integer *, integer *);
 
 

--- a/lapack-netlib/SRC/zgels.c
+++ b/lapack-netlib/SRC/zgels.c
@@ -738,7 +738,7 @@ static integer c__0 = 0;
 	    doublecomplex *, integer *, doublecomplex *, integer *, integer *), zunmqr_(char *, char *, integer *, integer *, 
 	    integer *, doublecomplex *, integer *, doublecomplex *, 
 	    doublecomplex *, integer *, doublecomplex *, integer *, integer *);
-    extern int ztrtrs_(char *, char *, char *, integer *, 
+    extern void ztrtrs_(char *, char *, char *, integer *, 
 	    integer *, doublecomplex *, integer *, doublecomplex *, integer *,
 	     integer *);
 

--- a/lapack-netlib/SRC/zgelst.c
+++ b/lapack-netlib/SRC/zgelst.c
@@ -752,7 +752,7 @@ f"> */
 	    doublecomplex *, integer *, doublecomplex *, integer *, 
 	    doublecomplex *, integer *);
     logical lquery;
-    extern /* Subroutine */ int ztrtrs_(char *, char *, char *, integer *, 
+    extern /* Subroutine */ void ztrtrs_(char *, char *, char *, integer *, 
 	    integer *, doublecomplex *, integer *, doublecomplex *, integer *,
 	     integer *);
     extern void zgemlqt_(char *, char *, 

--- a/lapack-netlib/SRC/zgetsls.c
+++ b/lapack-netlib/SRC/zgetsls.c
@@ -716,7 +716,7 @@ static integer c__0 = 0;
     integer wsizem, wsizeo;
     logical lquery;
     integer lw1, lw2;
-    extern /* Subroutine */ int ztrtrs_(char *, char *, char *, integer *, 
+    extern /* Subroutine */ void ztrtrs_(char *, char *, char *, integer *, 
 	    integer *, doublecomplex *, integer *, doublecomplex *, integer *,
 	     integer *);
     integer mnk;

--- a/lapack-netlib/SRC/zggglm.c
+++ b/lapack-netlib/SRC/zggglm.c
@@ -730,7 +730,7 @@ f"> */
 	    doublecomplex *, integer *, doublecomplex *, integer *, integer *), zunmrq_(char *, char *, integer *, integer *, 
 	    integer *, doublecomplex *, integer *, doublecomplex *, 
 	    doublecomplex *, integer *, doublecomplex *, integer *, integer *);
-    extern int ztrtrs_(char *, char *, char *, integer *, 
+    extern void ztrtrs_(char *, char *, char *, integer *, 
 	    integer *, doublecomplex *, integer *, doublecomplex *, integer *,
 	     integer *);
 

--- a/lapack-netlib/SRC/zgglse.c
+++ b/lapack-netlib/SRC/zgglse.c
@@ -727,7 +727,7 @@ f"> */
 	    integer *, doublecomplex *, integer *, doublecomplex *, 
 	    doublecomplex *, integer *, doublecomplex *, integer *, integer *), zunmrq_(char *, char *, integer *, integer *, 
 	    integer *, doublecomplex *, integer *, doublecomplex *, 
-	    doublecomplex *, integer *, doublecomplex *, integer *, integer *);     extern int ztrtrs_(char *, char *, char *, integer *, 
+	    doublecomplex *, integer *, doublecomplex *, integer *, integer *), ztrtrs_(char *, char *, char *, integer *, 
 	    integer *, doublecomplex *, integer *, doublecomplex *, integer *,
 	     integer *);
 


### PR DESCRIPTION
There are still mismatches of function signatures for the f2c'ed lapack sources.

This PR fixes those mismatches for the trtrs routine family.