### PR TITLE
CI: Update upload-artifacts version in the homebrew workflow again

### DIFF
--- a/.github/workflows/nightly-Homebrew-build.yml
+++ b/.github/workflows/nightly-Homebrew-build.yml
@@ -69,7 +69,7 @@ jobs:
           mv *.bottle.tar.gz bottles
 
       - name: Upload bottle
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: openblas--HEAD.catalina.bottle.tar.gz
           path: bottles


### PR DESCRIPTION
in response to another deprecation alert