### PR TITLE
Corrections for Cray and Nvidia Fortran compiler calling conventions

### DIFF
--- a/Makefile.system
+++ b/Makefile.system
@@ -1392,15 +1392,17 @@ endif
 endif
 
 ifeq ($(F_COMPILER), CRAY)
-CCOMMON_OPT += -DF_INTERFACE_INTEL
+CCOMMON_OPT += -DF_INTERFACE_CRAYFC
 FCOMMON_OPT += -hnopattern
 ifdef INTERFACE64
 ifneq ($(INTERFACE64), 0)
 FCOMMON_OPT += -s integer64
 endif
 endif
-ifneq ($(USE_OPENMP), 1)
-FCOMMON_OPT += -O noomp
+ifeq ($(USE_OPENMP), 1)
+FCOMMON_OPT += -fopenmp
+else
+FCOMMON_OPT += -fno-openmp
 endif
 endif
 

--- a/common_arm64.h
+++ b/common_arm64.h
@@ -44,7 +44,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define RMB  __asm__ __volatile__ ("dmb  ishld" : : : "memory")
 #endif
 
-#if defined( F_INTERFACE_FLANG) || defined(F_INTERFACE_PGI)
+#if defined( F_INTERFACE_FLANG) || (defined(F_INTERFACE_PGI) && (defined(__NVCOMPILER) && (__NVCOMPILER_MAJOR__ < 23 || (__NVCOMPILER_MAJOR__ == 23 && __NVCOMPILER_MINOR__ < 9))))
 #define RETURN_BY_STACK
 #else
 #define RETURN_BY_COMPLEX

--- a/common_x86_64.h
+++ b/common_x86_64.h
@@ -283,6 +283,10 @@ static __inline unsigned int blas_quickdivide(unsigned int x, unsigned int y){
 #define RETURN_BY_STACK
 #endif
 
+#ifdef F_INTERFACE_CRAYFC
+#define RETURN_BY_PACKED
+#endif
+
 #ifdef F_INTERFACE_FUJITSU
 #define RETURN_BY_STACK
 #endif


### PR DESCRIPTION
Corrections made for Fortran return for complex data types (Cray and Nvidia compilers). The Nvidia convention changed in version 23.9: https://docs.nvidia.com/hpc-sdk/archive/23.9/pdf/hpc-sdk239rn.pdf 