### PR TITLE
Fix compilation and linking of the ctests on Windows/LLVM19

### DIFF
--- a/ctest/c_c2chke.c
+++ b/ctest/c_c2chke.c
@@ -33,7 +33,11 @@ void F77_c2chke(char *rout) {
           BETA[2]  = {0.0,0.0},
           RALPHA = 0.0;
    extern int cblas_info, cblas_lerr, cblas_ok;
+#ifdef OS_WINDOWS
+   int RowMajorStrg = TRUE;
+#else   
    extern int RowMajorStrg;
+#endif
    extern char *cblas_rout;
 
    if (link_xerbla) /* call these first to link */

--- a/ctest/c_c3chke.c
+++ b/ctest/c_c3chke.c
@@ -33,7 +33,11 @@ void  F77_c3chke(char *  rout) {
            BETA[2]  = {0.0,0.0},
            RALPHA   = 0.0, RBETA = 0.0;
    extern int cblas_info, cblas_lerr, cblas_ok;
+#ifdef OS_WINDOWS
+   int RowMajorStrg = TRUE;
+#else
    extern int RowMajorStrg;
+#endif
    extern char *cblas_rout;
 
    cblas_ok = TRUE ;

--- a/ctest/c_d2chke.c
+++ b/ctest/c_d2chke.c
@@ -31,7 +31,11 @@ void F77_d2chke(char *rout) {
           Y[2] = {0.0,0.0},
           ALPHA=0.0, BETA=0.0;
    extern int cblas_info, cblas_lerr, cblas_ok;
+#ifdef OS_WINDOWS
+   int RowMajorStrg = TRUE;
+#else
    extern int RowMajorStrg;
+#endif
    extern char *cblas_rout;
 
    if (link_xerbla) /* call these first to link */

--- a/ctest/c_d3chke.c
+++ b/ctest/c_d3chke.c
@@ -31,7 +31,11 @@ void F77_d3chke(char *rout) {
           C[2] = {0.0,0.0},
           ALPHA=0.0, BETA=0.0;
    extern int cblas_info, cblas_lerr, cblas_ok;
+#ifdef OS_WINDOWS
+   int RowMajorStrg = TRUE;
+#else
    extern int RowMajorStrg;
+#endif
    extern char *cblas_rout;
 
    if (link_xerbla) /* call these first to link */

--- a/ctest/c_s2chke.c
+++ b/ctest/c_s2chke.c
@@ -31,7 +31,11 @@ void F77_s2chke(char *rout) {
           Y[2] = {0.0,0.0},
           ALPHA=0.0, BETA=0.0;
    extern int cblas_info, cblas_lerr, cblas_ok;
+#ifdef OS_WINDOWS
+   int RowMajorStrg = TRUE;
+#else
    extern int RowMajorStrg;
+#endif
    extern char *cblas_rout;
 
    if (link_xerbla) /* call these first to link */

--- a/ctest/c_s3chke.c
+++ b/ctest/c_s3chke.c
@@ -31,7 +31,11 @@ void F77_s3chke(char *rout) {
           C[2] = {0.0,0.0},
           ALPHA=0.0, BETA=0.0;
    extern int cblas_info, cblas_lerr, cblas_ok;
+#ifdef OS_WINDOWS
+   int RowMajorStrg = TRUE;
+#else
    extern int RowMajorStrg;
+#endif
    extern char *cblas_rout;
 
    if (link_xerbla) /* call these first to link */

--- a/ctest/c_xerbla.c
+++ b/ctest/c_xerbla.c
@@ -9,7 +9,11 @@ void cblas_xerbla(blasint info, char *rout, char *form, ...)
 {
    extern int cblas_lerr, cblas_info, cblas_ok;
    extern int link_xerbla;
+#ifdef OS_WINDOWS
+   extern __declspec(selectany) int RowMajorStrg;
+#else
    extern int RowMajorStrg;
+#endif
    extern char *cblas_rout;
 
    /* Initially, c__3chke will call this routine with

--- a/ctest/c_z2chke.c
+++ b/ctest/c_z2chke.c
@@ -33,7 +33,11 @@ void F77_z2chke(char *rout) {
           BETA[2]  = {0.0,0.0},
           RALPHA = 0.0;
    extern int cblas_info, cblas_lerr, cblas_ok;
+#ifdef OS_WINDOWS
+   int RowMajorStrg = TRUE;
+#else
    extern int RowMajorStrg;
+#endif
    extern char *cblas_rout;
 
    if (link_xerbla) /* call these first to link */

--- a/ctest/c_z3chke.c
+++ b/ctest/c_z3chke.c
@@ -33,7 +33,11 @@ void  F77_z3chke(char *  rout) {
            BETA[2]  = {0.0,0.0},
            RALPHA   = 0.0, RBETA = 0.0;
    extern int cblas_info, cblas_lerr, cblas_ok;
+#ifdef OS_WINDOWS
+   int RowMajorStrg = TRUE;
+#else
    extern int RowMajorStrg;
+#endif
    extern char *cblas_rout;
 
    cblas_ok = TRUE ;


### PR DESCRIPTION
as implemented by h-vetinari in the LAPACK feedstock for conda-forge