### PR TITLE
Restore libsuffix support in pkg-config file

### DIFF
--- a/openblas.pc.in
+++ b/openblas.pc.in
@@ -2,6 +2,6 @@ Name: openblas
 Description: OpenBLAS is an optimized BLAS library based on GotoBLAS2 1.13 BSD version
 Version: ${version}
 URL: https://github.com/xianyi/OpenBLAS
-Libs: -L${libdir} -l${libprefix}openblas${libnamesuffix}
+Libs: -L${libdir} -l${libprefix}openblas${libnamesuffix}${libsuffix}
 Libs.private: ${extralib}
 Cflags: -I${includedir} ${omp_opt}


### PR DESCRIPTION
It had been mistakenly removed in 9ef10ffa496b919c25aedbb4aa2fdb930901475a.