### PR TITLE
added optimizations for RISC-V YIELDING

### DIFF
--- a/common.h
+++ b/common.h
@@ -372,6 +372,12 @@ typedef int blasint;
 #endif
 #endif
 
+#if defined(ARCH_RISCV64)
+#ifndef YIELDING
+#define YIELDING        __asm__ __volatile__ ("nop;nop;nop;nop;nop;nop;nop;nop;\n");
+#endif
+#endif
+
 
 #ifdef __EMSCRIPTEN__
 #define YIELDING


### PR DESCRIPTION
replace "sched_yield" with "nop", which will reduce overhead in schduling out and in while waiting other thread complete at other CPU.
