### PR TITLE
CI (MinGW): Remove CLANG32 environment from build matrix.

### DIFF
--- a/.github/workflows/dynamic_arch.yml
+++ b/.github/workflows/dynamic_arch.yml
@@ -158,7 +158,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        msystem: [UCRT64, MINGW32, CLANG64, CLANG32]
+        msystem: [UCRT64, MINGW32, CLANG64]
         idx: [int32, int64]
         build-type: [Release]
         include:
@@ -174,11 +174,6 @@ jobs:
             idx: int32
             target-prefix: mingw-w64-clang-x86_64
             fc-pkg: fc
-          - msystem: CLANG32
-            idx: int32
-            target-prefix: mingw-w64-clang-i686
-            fc-pkg: cc
-            c-lapack-flags: -DC_LAPACK=ON
           - msystem: UCRT64
             idx: int64
             idx64-flags: -DBINARY=64 -DINTERFACE64=1
@@ -196,8 +191,6 @@ jobs:
             build-type: None
         exclude:
           - msystem: MINGW32
-            idx: int64
-          - msystem: CLANG32
             idx: int64
 
     defaults:
@@ -274,7 +267,6 @@ jobs:
                 -DNUM_THREADS=64 \
                 -DTARGET=CORE2 \
                 ${{ matrix.idx64-flags }} \
-                ${{ matrix.c-lapack-flags }} \
                 -DCMAKE_C_COMPILER_LAUNCHER=ccache \
                 -DCMAKE_Fortran_COMPILER_LAUNCHER=ccache \
                 ..


### PR DESCRIPTION
The CLANG32 environment is in the process of being removed from MSYS2 currently:
https://www.msys2.org/news/#2024-09-23-starting-to-drop-the-clang32-environment

Remove it from the build matrix ahead of its complete removal from MSYS2.