### PR TITLE
arm: Declare symbols as .type function

### DIFF
--- a/common_arm.h
+++ b/common_arm.h
@@ -102,9 +102,16 @@ static inline int blas_quickdivide(blasint x, blasint y){
 
 #if defined(ASSEMBLER) && !defined(NEEDPARAM)
 
+#if !defined(__APPLE__) && !defined(_WIN32)
+#define OPENBLAS_ARM_TYPE_FUNCTION .type	REALNAME, %function ;
+#else
+#define OPENBLAS_ARM_TYPE_FUNCTION
+#endif
+
 #define PROLOGUE \
 	.arm		 ;\
 	.global	REALNAME ;\
+	OPENBLAS_ARM_TYPE_FUNCTION \
 REALNAME:
 
 #define EPILOGUE


### PR DESCRIPTION
While revising the vcpkg port, I ran into this error pattern when building a test project for arm-neon-android (NDK r27c, static linkage) during a `find_package(BLAS)` in CMake:
~~~
ld.lld: error: /vcpkg/installed/arm-neon-android/debug/lib/libopenblas.a(sgemm_nn.c.o):(function sgemm_nn: .text.sgemm_nn+0x232): branch and link relocation: R_ARM_THM_CALL to non STT_FUNC symbol: sgemm_otcopy interworking not performed; consider using directive '.type sgemm_otcopy, %function' to give symbol type STT_FUNC if interworking between ARM and Thumb is required; level3.c:332 (/vcpkg/buildtrees/openblas/src/v0.3.28-a14d95ad12.clean/driver/level3/level3.c:332)
~~~

The solution is adapted from `common_arm64.h` etc.