### PR TITLE
Fix redefinition of FAILED

### DIFF
--- a/ctest/cblas_test.h
+++ b/ctest/cblas_test.h
@@ -10,6 +10,11 @@
 #define int long
 #endif
 
+/* e.g. mingw64/x86_64-w64-mingw32/include/winerror.h */
+#ifdef FAILED
+#undef FAILED
+#endif
+
 #define  TRUE           1
 #define  PASSED         1
 #define  TEST_ROW_MJR	1


### PR DESCRIPTION
https://dev.azure.com/martinkroeker/martinkroeker/_build/results?buildId=1472&view=logs&j=0f344e18-ca8b-5780-26f4-6ba48d8d5454&t=33e34d53-76bc-5543-18c4-9ff7691b1623:
~~~
In file included from c_sblas1.c:10:
cblas_test.h:18: warning: "FAILED" redefined
   18 | #define  FAILED         0
      | 
In file included from C:/mingw64/x86_64-w64-mingw32/include/winbase.h:2811,
                 from C:/mingw64/x86_64-w64-mingw32/include/windows.h:70,
                 from ../common.h:119,
                 from c_sblas1.c:9:
C:/mingw64/x86_64-w64-mingw32/include/winerror.h:2235: note: this is the location of the previous definition
 2235 | #define FAILED(hr) ((HRESULT)(hr) < 0)
~~~

The more invasive alternative is to use a unique prefix.