### PR TITLE
Fix two compiler warnings in `memory.c`

### DIFF
--- a/driver/others/memory.c
+++ b/driver/others/memory.c
@@ -3254,7 +3254,7 @@ void blas_shutdown(void){
 #endif
       newmemory[pos].lock   = 0;
     }
-    free(newmemory);
+    free((void*)newmemory);
     newmemory = NULL;
     memory_overflowed = 0;  
   }

--- a/driver/others/memory.c
+++ b/driver/others/memory.c
@@ -2538,7 +2538,7 @@ static void *alloc_shm(void *address){
 }
 #endif
 
-#if defined OS_LINUX  || defined OS_AIX  || defined __sun__  || defined OS_WINDOWS
+#if ((defined ALLOC_HUGETLB) && (defined OS_LINUX  || defined OS_AIX  || defined __sun__  || defined OS_WINDOWS))
 
 static void alloc_hugetlb_free(struct release_t *release){
 


### PR DESCRIPTION
First warning:
```
[4339/5327] Building C object driver/others/CMakeFiles/driver_others.dir/memory.c.o
.../OpenBLAS/driver/others/memory.c: In function 'blas_shutdown':
.../OpenBLAS/driver/others/memory.c:3257:10: warning: passing argument 1 of 'free' discards 'volatile' qualifier from pointer target type [-Wdiscarded-qualifiers]
 3257 |     free(newmemory);
      |          ^~~~~~~~~
In file included from .../OpenBLAS/common.h:83,
                 from .../OpenBLAS/driver/others/memory.c:74:
.../.pixi/envs/default/x86_64-conda-linux-gnu/sysroot/usr/include/stdlib.h:482:25: note: expected 'void *' but argument is of type 'volatile struct newmemstruct *'
  482 | extern void free (void *__ptr) __THROW;
      |                   ~~~~~~^~~~~
```
The use of `volatile` for `newmemstruct` seems on purpose, and there are more such constructs in this file. The warning appeared after gh-4451 and is correct. The `free` prototype doesn't expect a volatile pointer, hence this change adds a cast to silence the warning.

Second warning:
```
...OpenBLAS/driver/others/memory.c:2565:14: warning: 'alloc_hugetlb' defined but not used [-Wunused-function]
 2565 | static void *alloc_hugetlb(void *address){
```
The added define is the same as is already present in the TLS part of `memory.c`. This follows up on gh-4681.