### PR TITLE
Temporarily disable the default S/DSCAL kernel on PPC970

### DIFF
--- a/kernel/power/KERNEL.PPC970
+++ b/kernel/power/KERNEL.PPC970
@@ -89,3 +89,6 @@ DROTKERNEL   = ../arm/rot.c
 CROTKERNEL   = ../arm/zrot.c
 ZROTKERNEL   = ../arm/zrot.c
 endif
+
+SSCALKERNEL = ../arm/scal.c
+DSCALKERNEL = ../arm/scal.c


### PR DESCRIPTION
fixes #5034 until there's an opportunity to test on Apple G5 again