### PR TITLE
PPC970: fix scal

### DIFF
--- a/kernel/power/KERNEL.PPC970
+++ b/kernel/power/KERNEL.PPC970
@@ -89,6 +89,3 @@ DROTKERNEL   = ../arm/rot.c
 CROTKERNEL   = ../arm/zrot.c
 ZROTKERNEL   = ../arm/zrot.c
 endif
-
-SSCALKERNEL = ../arm/scal.c
-DSCALKERNEL = ../arm/scal.c

--- a/kernel/power/scal.S
+++ b/kernel/power/scal.S
@@ -59,7 +59,7 @@
 #if !defined(__64BIT__) && defined(DOUBLE)
 #define X r8
 #define INCX r9
-#define FLAG r13
+#define FLAG r11
 #else
 #define X r7
 #define INCX r8
@@ -91,7 +91,7 @@
 	fcmpu	cr0, FZERO, ALPHA
 	bne-	cr0, LL(A1I1)
 
-	ld      FLAG,    48+64+8(SP)
+	LDLONG  FLAG,    48+64+8(SP)
 	cmpwi   cr0, FLAG, 1
 	beq-   cr0, LL(A1I1)
 


### PR DESCRIPTION
@martin-frbg This seems to work for `py-scipy`. Does it look reasonable? Can I test it more specifically, besides `scipy` building?

Disclaimer: I cannot test this right now for Darwin ppc64, so that may be or not be broken. The fix is specific to Darwin ppc (32-bit ABI).