### PR TITLE
Update Makefile.riscv64, remove --fast-math from default build options on x280

### DIFF
--- a/Makefile.riscv64
+++ b/Makefile.riscv64
@@ -3,7 +3,7 @@ CCOMMON_OPT += -march=rv64imafdcv0p7_zfh_xtheadc -mabi=lp64d -mtune=c920
 FCOMMON_OPT += -march=rv64imafdcv0p7_zfh_xtheadc -mabi=lp64d -mtune=c920 -static
 endif
 ifeq ($(CORE), x280)
-CCOMMON_OPT += -march=rv64imafdcv_zba_zbb_zfh_zvl512b -mabi=lp64d -ffast-math
+CCOMMON_OPT += -march=rv64imafdcv_zba_zbb_zfh_zvl512b -mabi=lp64d 
 FCOMMON_OPT += -march=rv64imafdcv_zba_zbb_zfh -mabi=lp64d -static
 endif
 ifeq ($(CORE), RISCV64_ZVL256B)

--- a/Makefile.riscv64
+++ b/Makefile.riscv64
@@ -1,3 +1,7 @@
+ifeq ($(CORE), tt-ascalon-d8)
+CCOMMON_OPT += -march=rv64imafdhcv_zba_zbb_zfh_zvl256b_zvfh_zvkn_zvkg_zvbc_zvbb_zvfbfwma_xsfvqdotq -mabi=lp64d 
+FCOMMON_OPT += -march=rv64imafdhcv_zba_zbb_zfh_zvl256b_zvfh_zvkn_zvkg_zvbc_zvbb_zvfbfwma_xsfvqdotq -mabi=lp64d -static
+endif
 ifeq ($(CORE), C910V)
 CCOMMON_OPT += -march=rv64imafdcv0p7_zfh_xtheadc -mabi=lp64d -mtune=c920
 FCOMMON_OPT += -march=rv64imafdcv0p7_zfh_xtheadc -mabi=lp64d -mtune=c920 -static


### PR DESCRIPTION
The default flags for various targets should assume compliance with IEEE-754. fast math and co should be opt in only