### PR TITLE
remove fastmath from x280 target

### DIFF
--- a/Makefile.riscv64
+++ b/Makefile.riscv64
@@ -3,7 +3,7 @@ CCOMMON_OPT += -march=rv64imafdcv0p7_zfh_xtheadc -mabi=lp64d -mtune=c920
 FCOMMON_OPT += -march=rv64imafdcv0p7_zfh_xtheadc -mabi=lp64d -mtune=c920 -static
 endif
 ifeq ($(CORE), x280)
-CCOMMON_OPT += -march=rv64imafdcv_zba_zbb_zfh_zvl512b -mabi=lp64d -ffast-math
+CCOMMON_OPT += -march=rv64imafdcv_zba_zbb_zfh_zvl512b -mabi=lp64d 
 FCOMMON_OPT += -march=rv64imafdcv_zba_zbb_zfh -mabi=lp64d -static
 endif
 ifeq ($(CORE), RISCV64_ZVL256B)


### PR DESCRIPTION
Fast math typically disallows IEEE 754 compliance and is considered an opt in only feature. removing it from default stops it from being opt out to being opt-in 