### PR TITLE
Small gemm kernel improvements for AArch64

### DIFF
--- a/kernel/arm64/dgemm_small_kernel_tn_sve.c
+++ b/kernel/arm64/dgemm_small_kernel_tn_sve.c
@@ -213,7 +213,7 @@ CNAME(BLASLONG M,
   const BLASLONG n2 = N & -2;
   const BLASLONG n8 = N & -8;
 
-  const int pack_a = M >= v_size2 && N >= 8 && K >= 8 ? 1 : 0;
+  const int pack_a = M >= v_size2 && N >= 8 ? 1 : 0;
   FLOAT* packed_a =
     (pack_a) ? packed_a = (FLOAT*)malloc(K * v_size2 * sizeof(FLOAT)) : NULL;
 

--- a/kernel/arm64/dgemm_small_kernel_tt_sve.c
+++ b/kernel/arm64/dgemm_small_kernel_tt_sve.c
@@ -219,7 +219,7 @@ CNAME(BLASLONG M,
   const BLASLONG n4 = N & -4;
   const BLASLONG n2 = N & -2;
 
-  const int pack_a = M >= v_size2 && N >= 8 && K >= 8 ? 1 : 0;
+  const int pack_a = M >= v_size2 && N >= 8 ? 1 : 0;
   FLOAT* packed_a =
     (pack_a) ? packed_a = (FLOAT*)malloc(K * v_size2 * sizeof(FLOAT)) : NULL;
 

--- a/kernel/arm64/sgemm_small_kernel_tn_sve.c
+++ b/kernel/arm64/sgemm_small_kernel_tn_sve.c
@@ -222,7 +222,7 @@ CNAME(BLASLONG M,
   const BLASLONG n8 = N & -8;
   const BLASLONG n4 = N & -4;
 
-  const int pack_a = M >= v_size2 && N >= 8 && K >= 8 ? 1 : 0;
+  const int pack_a = M >= v_size2 && N >= 8 ? 1 : 0;
   FLOAT* packed_a =
     (pack_a) ? packed_a = (FLOAT*)malloc(K * v_size2 * sizeof(FLOAT)) : NULL;
 

--- a/kernel/arm64/sgemm_small_kernel_tt_sve.c
+++ b/kernel/arm64/sgemm_small_kernel_tt_sve.c
@@ -223,7 +223,7 @@ CNAME(BLASLONG M,
   const BLASLONG n8 = N & -8;
   const BLASLONG n4 = N & -4;
 
-  const int pack_a = M >= v_size2 && N >= 8 && K >= 8 ? 1 : 0;
+  const int pack_a = M >= v_size2 && N >= 8 ? 1 : 0;
   FLOAT* packed_a =
     (pack_a) ? packed_a = (FLOAT*)malloc(K * v_size2 * sizeof(FLOAT)) : NULL;
 


### PR DESCRIPTION
This change modifies the packing condition in TT and TN small gemm kernels and helps to improve the performance for rectangular matrix where M, N are large, and K is small. These shapes are widely used in ML and DL workloads.

1. ~20% gain seen for shapes M=N=128, K=1…7.
2. This modification has no degradation in smaller rectangular and square matrix shapes.

![image](https://github.com/user-attachments/assets/f32dd749-ca7a-4ca9-8a7d-a931220e9b0b)
![image](https://github.com/user-attachments/assets/f4e11037-bf45-44f4-ac28-9cfc9db56662)
![image](https://github.com/user-attachments/assets/b9936c27-fe96-41ed-bdbf-8868db284317)
![image](https://github.com/user-attachments/assets/0580849d-cbc3-4dd4-99e3-4ce65a166793)
