### PR TITLE
Fix regression issue for higher batch size on PPC64LE

### DIFF
--- a/driver/level3/level3_thread.c
+++ b/driver/level3/level3_thread.c
@@ -742,7 +742,11 @@ static int gemm_driver(blas_arg_t *args, BLASLONG *range_m, BLASLONG
     num_parts  = 0;
     while (n > 0){
       width = blas_quickdivide(n + nthreads - num_parts - 1, nthreads - num_parts);
+#if defined(POWER) 
+      if (width < switch_ratio ) {
+#else
       if (width < switch_ratio && width > 1) {
+#endif 
         width = switch_ratio;
       }
       width = round_up(n, width, GEMM_PREFERED_SIZE);


### PR DESCRIPTION
Hi, currently we are observing 2x regression On PPC64LE machine for FP32 models which i have mentioned in #5085 . This PR will help in resolving issue by falling back to the old changes. 

<img width="394" alt="Screenshot 2025-02-14 at 9 43 18 AM" src="https://github.com/user-attachments/assets/229f42db-670e-4bd4-90f2-37d9260dc8a7" />
