### PR TITLE
[Testing]revert change from PR 4920

### DIFF
--- a/driver/level3/level3_thread.c
+++ b/driver/level3/level3_thread.c
@@ -742,7 +742,7 @@ static int gemm_driver(blas_arg_t *args, BLASLONG *range_m, BLASLONG
     num_parts  = 0;
     while (n > 0){
       width = blas_quickdivide(n + nthreads - num_parts - 1, nthreads - num_parts);
-      if (width < switch_ratio && width > 1) {
+      if (width < switch_ratio) {
         width = switch_ratio;
       }
       width = round_up(n, width, GEMM_PREFERED_SIZE);


### PR DESCRIPTION
this is functionally identical to #5133 but created by a manual edit in my fork instead of using the "revert" button in the github user interface - trying to see where the sudden SDOT failure on NeoverseN2 comes from, that cannot possibly be related to the *intended* change in complex GEMM code 