### PR TITLE
CI: remove the express NeoverseN2 target from the Cobalt100 job in the gh workflow

### DIFF
--- a/.github/workflows/dynamic_arch.yml
+++ b/.github/workflows/dynamic_arch.yml
@@ -372,7 +372,7 @@ jobs:
           
       - name: Build OpenBLAS
         run: |
-          make -j${nproc} TARGET=NEOVERSEN2
-          make -j${nproc} TARGET=NEOVERSEN2 lapack-test
+          make -j${nproc} 
+          make -j${nproc} lapack-test
     
           


### PR DESCRIPTION
Apparently the "public preview" access phase to the Cobalt 100 (Neoverse N2) hardware has ended without announcement after exactly 4 weeks, or jobs now get randomly scheduled on NeoverseN1 hardware as well 