### PR TITLE
Ensure that gmake builds with flang-new link the flang runtime into the shared library

### DIFF
--- a/exports/Makefile
+++ b/exports/Makefile
@@ -197,7 +197,7 @@ ifeq ($(F_COMPILER), INTEL)
 	-Wl,--whole-archive $< -Wl,--no-whole-archive \
 	-Wl,-soname,$(INTERNALNAME) $(EXTRALIB)
 	$(CC) $(CFLAGS) $(LDFLAGS) -w -o linktest linktest.c ../$(LIBSONAME) $(FEXTRALIB) && echo OK.
-else ifeq ($(F_COMPILER), FLANG)
+else ifeq ($(F_COMPILER), $(filter $(F_COMPILER),FLANG FLANGNEW))
 	$(FC) $(FFLAGS) $(LDFLAGS) -shared -o ../$(LIBSONAME) \
 	-Wl,--whole-archive $< -Wl,--no-whole-archive \
 	-Wl,-soname,$(INTERNALNAME) $(EXTRALIB)


### PR DESCRIPTION
special treatment of classic flang was not carried over for flang-new, probably fixes #5131