### PR TITLE
Run CI on Github-hosted Arm instances too

### DIFF
--- a/.github/workflows/arm64_graviton.yml
+++ b/.github/workflows/arm64_graviton.yml
@@ -20,13 +20,15 @@ permissions:
 jobs:
   build:
     if: "github.repository == 'OpenMathLib/OpenBLAS'"
-    runs-on: "cirun-aws-runner-graviton--${{ github.run_id }}"
 
     strategy:
       fail-fast: false
       matrix:
         fortran: [gfortran]
         build: [cmake, make]
+        os: ["cirun-aws-runner-graviton--${{ github.run_id }}", ubuntu-22.04-arm]
+    
+    runs-on: ${{ matrix.os }}
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Extend the CI to run on Github-hosted Arm instances that are now [available](https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/).

Note that running on `ubuntu-24.04-arm` currently fails with `E: Unable to locate package libtinfo5`.