### PR TITLE
Fix "dummy2" flag reading in PPC970 S/DSCAL

### DIFF
--- a/kernel/power/scal.S
+++ b/kernel/power/scal.S
@@ -51,7 +51,7 @@
 #else
 #define X r7
 #define INCX r8
-#define FLAG r12
+#define FLAG r11
 #endif
 #endif
 
@@ -63,7 +63,7 @@
 #else
 #define X r7
 #define INCX r8
-#define FLAG r12
+#define FLAG r11
 #endif
 #endif
 
@@ -91,7 +91,7 @@
 	fcmpu	cr0, FZERO, ALPHA
 	bne-	cr0, LL(A1I1)
 
-	LDLONG  FLAG,    48+64+8(SP)
+	LDLONG  FLAG,    104(SP)
 	cmpwi   cr0, FLAG, 1
 	beq-   cr0, LL(A1I1)
 


### PR DESCRIPTION
fixes #5123