### PR TITLE
Optimize gemv_n_sve kernel

### DIFF
--- a/kernel/arm64/KERNEL.ARMV8SVE
+++ b/kernel/arm64/KERNEL.ARMV8SVE
@@ -74,7 +74,7 @@ DSCALKERNEL  = scal.S
 CSCALKERNEL  = zscal.S
 ZSCALKERNEL  = zscal.S
 
-SGEMVNKERNEL = gemv_n.S
+SGEMVNKERNEL = gemv_n_sve.c
 DGEMVNKERNEL = gemv_n.S
 CGEMVNKERNEL = zgemv_n.S
 ZGEMVNKERNEL = zgemv_n.S


### PR DESCRIPTION
Loop-unrolling of sgemv_n kernel is implemented with svmla_lane, along with a main loop and a tail loop.
The graph below shows performance improvement for OMP_NUM_THREADS=1 on Graviton-3:

![speedup](https://github.com/user-attachments/assets/c9b84cc5-4c53-4ede-829e-37acb3a67855)