### PR TITLE
Add dispatch of SBGEMVNKERNEL for NEOVERSEN2 and NEOVERSEV2

### DIFF
--- a/kernel/arm64/KERNEL.NEOVERSEN2
+++ b/kernel/arm64/KERNEL.NEOVERSEN2
@@ -199,3 +199,4 @@ SBGEMMITCOPYOBJ =  sbgemm_itcopy$(TSUFFIX).$(SUFFIX)
 SBGEMMONCOPYOBJ =  sbgemm_oncopy$(TSUFFIX).$(SUFFIX)
 SBGEMMOTCOPYOBJ =  sbgemm_otcopy$(TSUFFIX).$(SUFFIX)
 SBGEMVTKERNEL = sbgemv_t_bfdot.c
+SBGEMVNKERNEL = sbgemv_n_neon.c

--- a/kernel/arm64/KERNEL.NEOVERSEV2
+++ b/kernel/arm64/KERNEL.NEOVERSEV2
@@ -2,4 +2,5 @@ include $(KERNELDIR)/KERNEL.ARMV8SVE
 
 ifeq ($(BUILD_BFLOAT16), 1)
 SBGEMVTKERNEL = sbgemv_t_bfdot.c
+SBGEMVNKERNEL = sbgemv_n_neon.c
 endif


### PR DESCRIPTION
Add SBGEMVNKERNEL on KERNEL. NEOVERSEN2, KERNEL. NEOVERSEV2. KERNEL. NEOVERSEV2 is of no effect now. 