### PR TITLE
Improve thread safety of pthreads builds that rely on C11 atomic operations for locking

### DIFF
--- a/driver/others/blas_server.c
+++ b/driver/others/blas_server.c
@@ -146,8 +146,8 @@ typedef struct {
 } thread_status_t;
 
 #ifdef HAVE_C11
-#define	atomic_load_queue(p)		__atomic_load_n(p, __ATOMIC_RELAXED)
-#define	atomic_store_queue(p, v)	__atomic_store_n(p, v, __ATOMIC_RELAXED)
+#define	atomic_load_queue(p)		__atomic_load_n(p, __ATOMIC_RELEASE)
+#define	atomic_store_queue(p, v)	__atomic_store_n(p, v, __ATOMIC_ACQUIRE)
 #else
 #define	atomic_load_queue(p)		(blas_queue_t*)(*(volatile blas_queue_t**)(p))
 #define	atomic_store_queue(p, v)	(*(volatile blas_queue_t* volatile*)(p) = (v))
@@ -637,7 +637,9 @@ int exec_blas_async(BLASLONG pos, blas_queue_t *queue){
 
 #ifdef SMP_SERVER
   // Handle lazy re-init of the thread-pool after a POSIX fork
+  LOCK_COMMAND(&server_lock);
   if (unlikely(blas_server_avail == 0)) blas_thread_init();
+  UNLOCK_COMMAND(&server_lock);
 #endif
   BLASLONG i = 0;
   blas_queue_t *current = queue;

--- a/driver/others/blas_server.c
+++ b/driver/others/blas_server.c
@@ -146,8 +146,8 @@ typedef struct {
 } thread_status_t;
 
 #ifdef HAVE_C11
-#define	atomic_load_queue(p)		__atomic_load_n(p, __ATOMIC_ACQ_REL)
-#define	atomic_store_queue(p, v)	__atomic_store_n(p, v, __ATOMIC_ACQ_REL)
+#define	atomic_load_queue(p)		__atomic_load_n(p, __ATOMIC_ACQUIRE)
+#define	atomic_store_queue(p, v)	__atomic_store_n(p, v, __ATOMIC_RELEASE)
 #else
 #define	atomic_load_queue(p)		(blas_queue_t*)(*(volatile blas_queue_t**)(p))
 #define	atomic_store_queue(p, v)	(*(volatile blas_queue_t* volatile*)(p) = (v))

--- a/driver/others/blas_server.c
+++ b/driver/others/blas_server.c
@@ -146,8 +146,8 @@ typedef struct {
 } thread_status_t;
 
 #ifdef HAVE_C11
-#define	atomic_load_queue(p)		__atomic_load_n(p, __ATOMIC_RELEASE)
-#define	atomic_store_queue(p, v)	__atomic_store_n(p, v, __ATOMIC_ACQUIRE)
+#define	atomic_load_queue(p)		__atomic_load_n(p, __ATOMIC_ACQ_REL)
+#define	atomic_store_queue(p, v)	__atomic_store_n(p, v, __ATOMIC_ACQ_REL)
 #else
 #define	atomic_load_queue(p)		(blas_queue_t*)(*(volatile blas_queue_t**)(p))
 #define	atomic_store_queue(p, v)	(*(volatile blas_queue_t* volatile*)(p) = (v))


### PR DESCRIPTION
fixes #5104
fixes #5147
and parts of #5153 as suggested there