### PR TITLE
On zarch don't produce objects from assembler with a writable stack s…

### DIFF
--- a/common_zarch.h
+++ b/common_zarch.h
@@ -103,9 +103,16 @@ static inline int blas_quickdivide(blasint x, blasint y){
 	.global	REALNAME ;\
 	.type	REALNAME, %function ;\
 REALNAME:
- 
 
-#define EPILOGUE
+#if defined(__ELF__) && defined(__linux__)
+# define GNUSTACK .section        .note.GNU-stack,"",@progbits
+#else
+# define GNUSTACK
+#endif
+
+#define EPILOGUE \
+        .size    REALNAME, .-REALNAME;	\
+        GNUSTACK
 
 #define PROFCODE
 

--- a/cpuid.S
+++ b/cpuid.S
@@ -65,3 +65,6 @@ _cpuid:
 	.subsections_via_symbols
 
 #endif
+#if defined(__ELF__) && defined(__linux__)
+        .section        .note.GNU-stack,"",@progbits
+#endif

--- a/kernel/zarch/ctrmm4x4V.S
+++ b/kernel/zarch/ctrmm4x4V.S
@@ -714,6 +714,8 @@ ld %f10,136(%r15)
 ld %f11,144(%r15)
 ld %f12,152(%r15)
 br %r14
+
+EPILOGUE
 .end
 
 

--- a/kernel/zarch/gemm8x4V.S
+++ b/kernel/zarch/gemm8x4V.S
@@ -604,6 +604,8 @@ ALIGN_2
 /*end*/
 lmg %r6,%r12,48(%r15) 
 br %r14
+
+EPILOGUE
 .end
 
 

--- a/kernel/zarch/strmm8x4V.S
+++ b/kernel/zarch/strmm8x4V.S
@@ -845,6 +845,8 @@ ALIGN_2
     lmg %r6,%r12,48(%r15) 
 #endif
 br %r14
+
+EPILOGUE
 .end
 
 

--- a/kernel/zarch/trmm8x4V.S
+++ b/kernel/zarch/trmm8x4V.S
@@ -864,6 +864,8 @@ ALIGN_2
     lmg %r6,%r12,48(%r15) 
 #endif
 br %r14
+
+EPILOGUE
 .end
 
 

--- a/kernel/zarch/ztrmm4x4V.S
+++ b/kernel/zarch/ztrmm4x4V.S
@@ -719,6 +719,8 @@ ld %f10,136(%r15)
 ld %f11,144(%r15)
 ld %f12,152(%r15)
 br %r14
+
+EPILOGUE
 .end
 
 


### PR DESCRIPTION
…ection

On z-series, the current version of the GNU toolchain produces warnings such as:
```
/usr/lib64/gcc/[...]/s390x-suse-linux/bin/ld: warning: ztrmm_kernel_RC_Z14.o: missing .note.GNU-stack section implies
executable stack
/usr/lib64/[...]/s390x-suse-linux/bin/ld: NOTE: This behaviour is deprecated and will be removed in a future version of the linker
```
To prevent this message and make sure we are future proof, add
```
	.section        .note.GNU-stack,"",@progbits
```