### PR TITLE
Repeat the libs target's "ln" in the all target to ensure completeness of copy on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,11 @@ ifeq ($(NOFORTRAN), $(filter 0,$(NOFORTRAN)))
 	   echo "  Fortran compiler ... $(F_COMPILER)  (command line : $(FC))";\
 	fi
 endif
+
+ifeq ($(OSNAME), WINNT)
+	@-$(LNCMD) $(LIBNAME) $(LIBPREFIX).$(LIBSUFFIX)
+endif
+
 ifneq ($(OSNAME), AIX)
 	@echo -n "  Library Name     ... $(LIBNAME)"
 else


### PR DESCRIPTION
as Windows does not support Unix-style softlinks, msys' ln silently performs a snapshot copy instead of an actual link, meaning that any (netlib lapack) objects added later do not end up in libopenblas.a when NO_SHARED=1 is chosen.
Fixes issue raised in discussion #4692