### PR TITLE
test_potrs.c: do not use GCC pragma on darwin-aarch64

### DIFF
--- a/Makefile.system
+++ b/Makefile.system
@@ -436,10 +436,6 @@ CCOMMON_OPT += -Wl,-ld_classic
 FCOMMON_OPT += -Wl,-ld_classic
 endif
 ifeq (x$(XCVER), x 16)
-ifeq ($(C_COMPILER), GCC)
-CCOMMON_OPT += -Wl,-ld_classic
-FCOMMON_OPT += -Wl,-ld_classic
-endif
 ifeq ($(F_COMPILER), GFORTRAN)
 override CEXTRALIB := $(filter-out(-lto_library, $(CEXTRALIB))) 
 endif

--- a/utest/test_potrs.c
+++ b/utest/test_potrs.c
@@ -32,7 +32,6 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 **********************************************************************************/
 
 #include "openblas_utest.h"
-#pragma GCC optimize("no-gcse")
 /*
 void BLASFUNC(cpotrf)(char*, BLASINT*, complex float*, BLASINT*, BLASINT*);
 void BLASFUNC(zpotrs_(char*, BLASINT*, BLASINT*, complex double*,

--- a/utest/test_potrs.c
+++ b/utest/test_potrs.c
@@ -32,6 +32,9 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 **********************************************************************************/
 
 #include "openblas_utest.h"
+#if defined(ARCH_LOONGARCH64)
+#pragma GCC optimize("no-gcse")
+#endif
 /*
 void BLASFUNC(cpotrf)(char*, BLASINT*, complex float*, BLASINT*, BLASINT*);
 void BLASFUNC(zpotrs_(char*, BLASINT*, BLASINT*, complex double*,


### PR DESCRIPTION
Using GCC 14.2.0 on darwin aarch64, the pragma ultimately causes a linker
error "ld: invalid r_symbolnum=".  As a minimal example:

```c
#pragma GCC optimize("no-gcse")
float a = 1.0;
void b();
void c() { b(a); }
```

```console
$ gcc-14 -O1 -c example.c
$ ld example.o
ld: invalid r_symbolnum=1 in 'example.o'
```

The current workaround is to use the old linker, but (a) it's deprecated and
(b) it can produce libraries that are subsequently not linkable with the newer
linker in dependents: the new ld64 pedantically errors when linking libraries
with duplicate rpaths created by the classic linker.

In my opinion that's sufficient reason for build systems not to force `-ld_classic`