### PR TITLE
Temporarily disable the Cooper Lake/Sapphire Rapids microkernel for non-transpose SBGEMV

### DIFF
--- a/kernel/x86_64/sbgemv_n.c
+++ b/kernel/x86_64/sbgemv_n.c
@@ -28,9 +28,9 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "common.h"
 
-#if defined (COOPERLAKE) || defined (SAPPHIRERAPIDS)
-#include "sbgemv_n_microk_cooperlake.c"
-#endif
+//#if defined (COOPERLAKE) || defined (SAPPHIRERAPIDS)
+//#include "sbgemv_n_microk_cooperlake.c"
+//#endif
 
 #define ALIGN64_ALLOC(alloc_size, TYPE, ptr_align, ptr)   \
     ptr = (TYPE *) malloc(sizeof(TYPE)*alloc_size + 63); \


### PR DESCRIPTION
unfortunately the recently added SBGEMV test case in the sbgemm check indicates that it produces errors in all elements for all combinations of alpha and beta covered by the test (at least with gcc 14.2 on compatible AMD hardware)