### PR TITLE
Wrong output from getarch on Apple M4

### DIFF
--- a/cpuid_arm64.c
+++ b/cpuid_arm64.c
@@ -378,9 +378,9 @@ int detect(void)
 	cpulowperf=value64;
 	sysctlbyname("hw.nperflevels",&value64,&length64,NULL,0);
 	if (value64 > 1) {
-	sysctlbyname("hw.perflevel0.cpusperl",&value64,&length64,NULL,0);
+	sysctlbyname("hw.perflevel0.cpusperl2",&value64,&length64,NULL,0);
 	cpuhiperf=value64;
-	sysctlbyname("hw.perflevel1.cpusperl",&value64,&length64,NULL,0);
+	sysctlbyname("hw.perflevel1.cpusperl2",&value64,&length64,NULL,0);
 	cpulowperf=value64;
 	}
 	sysctlbyname("hw.cpufamily",&value64,&length64,NULL,0);

--- a/cpuid_arm64.c
+++ b/cpuid_arm64.c
@@ -374,15 +374,20 @@ int detect(void)
 	}
 #else
 #ifdef __APPLE__
+	length64 = sizeof(value64);
 	sysctlbyname("hw.ncpu",&value64,&length64,NULL,0);
 	cpulowperf=value64;
+	length64 = sizeof(value64);
 	sysctlbyname("hw.nperflevels",&value64,&length64,NULL,0);
 	if (value64 > 1) {
+	length64 = sizeof(value64);
 	sysctlbyname("hw.perflevel0.cpusperl2",&value64,&length64,NULL,0);
 	cpuhiperf=value64;
+	length64 = sizeof(value64);
 	sysctlbyname("hw.perflevel1.cpusperl2",&value64,&length64,NULL,0);
 	cpulowperf=value64;
 	}
+	length64 = sizeof(value64);
 	sysctlbyname("hw.cpufamily",&value64,&length64,NULL,0);
 	if (value64 ==131287967|| value64 == 458787763 ) return CPU_VORTEX; //A12/M1
 	if (value64 == 3660830781) return CPU_VORTEX; //A15/M2
@@ -467,6 +472,7 @@ int n=0;
 	printf("#define NUM_CORES_HP %d\n",cpuhiperf);
 #endif
 #ifdef __APPLE__
+	length64 = sizeof(value64);
 	sysctlbyname("hw.physicalcpu_max",&value,&length,NULL,0);
 	printf("#define NUM_CORES %d\n",value);
 	if (cpulowperf >0)
@@ -698,13 +704,17 @@ void get_cpuconfig(void)
 	    case CPU_VORTEX:
 		printf("#define VORTEX			      \n");
 #ifdef __APPLE__
+		length64 = sizeof(value64);
 		sysctlbyname("hw.l1icachesize",&value64,&length64,NULL,0);
 		printf("#define L1_CODE_SIZE	     %lld       \n",value64);
+		length64 = sizeof(value64);
 		sysctlbyname("hw.cachelinesize",&value64,&length64,NULL,0);
 		printf("#define L1_CODE_LINESIZE     %lld       \n",value64);
 		printf("#define L1_DATA_LINESIZE     %lld       \n",value64);
+		length64 = sizeof(value64);
 		sysctlbyname("hw.l1dcachesize",&value64,&length64,NULL,0);
 		printf("#define L1_DATA_SIZE	     %lld       \n",value64);
+		length64 = sizeof(value64);
 		sysctlbyname("hw.l2cachesize",&value64,&length64,NULL,0);
 		printf("#define L2_SIZE	     %lld       \n",value64);
 #endif	

--- a/cpuid_arm64.c
+++ b/cpuid_arm64.c
@@ -702,6 +702,7 @@ void get_cpuconfig(void)
 		printf("#define L1_CODE_SIZE	     %lld       \n",value64);
 		sysctlbyname("hw.cachelinesize",&value64,&length64,NULL,0);
 		printf("#define L1_CODE_LINESIZE     %lld       \n",value64);
+		printf("#define L1_DATA_LINESIZE     %lld       \n",value64);
 		sysctlbyname("hw.l1dcachesize",&value64,&length64,NULL,0);
 		printf("#define L1_DATA_SIZE	     %lld       \n",value64);
 		sysctlbyname("hw.l2cachesize",&value64,&length64,NULL,0);


### PR DESCRIPTION
When I run `getarch 1` on Apple M4 it reports different values than `sysctl hw` run from the command line.

## Steps

1. `git clone`
2. `cd OpenBLAS`
3. `mkdir build`
4. `cmake -B build`
5. `./build/getarch 1`

output:
```
#define ARMV8
#define HAVE_NEON
#define HAVE_VFPV4
#define VORTEX
#define L1_CODE_SIZE	     1867590060
#define L1_CODE_LINESIZE     1867590060
#define L1_DATA_SIZE	     1867590060
#define L2_SIZE	     1867590060
#define DTB_DEFAULT_ENTRIES  64
#define DTB_SIZE             4096
#define NUM_CORES 10
#define NUM_CORES_LP 2
#define NUM_CORES_HP 2
#define CHAR_CORENAME "VORTEX"
```

When I run `sysctl hw` I get:

```
hw.ncpu: 10
hw.nperflevels: 2
hw.perflevel0.cpusperl2: 4
hw.perflevel1.cpusperl2: 6
hw.cpufamily: 1867590060
hw.physicalcpu_max: 10
hw.l1icachesize: 131072
hw.cachelinesize: 128
hw.l1dcachesize: 65536
hw.l2cachesize: 4194304
```

According to `man sysctlbyname`:

> sysctlbyname(const char *name, void *oldp, size_t *oldlenp, void *newp, size_t newlen)
> 
> The information is copied into the buffer specified by oldp. The size of the buffer is given by the location specified by oldlenp before the call, and _that location gives the amount of data copied after a successful call_ and after a call that returns with the error code ENOMEM.

In other words, `length64` in `cpuid_arm64.c` may have changed after every call to sysctlbyname.

## Changes

1. `length64 = sizeof(value64)` before every call to `sysctlbyname`.
2. Added L1_DATA_LINESIZE (needed in benchmarks)
3. `hw.perflevel0.cpusperl` is `hw.perflevel0.cpusperl2`, at least on my Apple M4.

## Result

```
#define ARMV8
#define HAVE_NEON
#define HAVE_VFPV4
#define VORTEX
#define L1_CODE_SIZE	     131072
#define L1_CODE_LINESIZE     128
#define L1_DATA_LINESIZE     128
#define L1_DATA_SIZE	     65536
#define L2_SIZE	     4194304
#define DTB_DEFAULT_ENTRIES  64
#define DTB_SIZE             4096
#define NUM_CORES 10
#define NUM_CORES_LP 6
#define NUM_CORES_HP 4
#define CHAR_CORENAME "VORTEX"
```
