### PR TITLE
Fix: Potential out-of-bounds read in non-transposed [SD]GEMV kernels for A64FX and Neoverse V1.

### DIFF
--- a/kernel/arm64/gemv_n_sve_v1x3.c
+++ b/kernel/arm64/gemv_n_sve_v1x3.c
@@ -77,9 +77,9 @@ int CNAME(BLASLONG m, BLASLONG n, BLASLONG dummy1, FLOAT alpha, FLOAT *a,
       svbool_t pg01 = ((j + width * 1) < n) ? SV_TRUE() : svpfalse();
       svbool_t pg02 = ((j + width * 2) < n) ? SV_TRUE() : svpfalse();
 
-      SV_TYPE temp0_vec = SV_DUP(alpha * x0_ptr[ix]);
-      SV_TYPE temp1_vec = SV_DUP(alpha * x1_ptr[ix]);
-      SV_TYPE temp2_vec = SV_DUP(alpha * x2_ptr[ix]);
+      SV_TYPE temp0_vec = ((j + width * 0) < n) ? SV_DUP(alpha * x0_ptr[ix]) : SV_DUP(0.0);
+      SV_TYPE temp1_vec = ((j + width * 1) < n) ? SV_DUP(alpha * x1_ptr[ix]) : SV_DUP(0.0);
+      SV_TYPE temp2_vec = ((j + width * 2) < n) ? SV_DUP(alpha * x2_ptr[ix]) : SV_DUP(0.0);
       i = 0;
       BLASLONG sve_size = SV_COUNT();
       while ((i + sve_size * 1 - 1) < m) {

--- a/kernel/arm64/gemv_n_sve_v4x3.c
+++ b/kernel/arm64/gemv_n_sve_v4x3.c
@@ -86,9 +86,9 @@ int CNAME(BLASLONG m, BLASLONG n, BLASLONG dummy1, FLOAT alpha, FLOAT *a,
       svbool_t pg22 = ((j + width * 2) < n) ? SV_TRUE() : svpfalse();
       svbool_t pg32 = ((j + width * 2) < n) ? SV_TRUE() : svpfalse();
 
-      SV_TYPE temp0_vec = SV_DUP(alpha * x0_ptr[ix]);
-      SV_TYPE temp1_vec = SV_DUP(alpha * x1_ptr[ix]);
-      SV_TYPE temp2_vec = SV_DUP(alpha * x2_ptr[ix]);
+      SV_TYPE temp0_vec = ((j + width * 0) < n) ? SV_DUP(alpha * x0_ptr[ix]) : SV_DUP(0.0);
+      SV_TYPE temp1_vec = ((j + width * 1) < n) ? SV_DUP(alpha * x1_ptr[ix]) : SV_DUP(0.0);
+      SV_TYPE temp2_vec = ((j + width * 2) < n) ? SV_DUP(alpha * x2_ptr[ix]) : SV_DUP(0.0);
       i = 0;
       BLASLONG sve_size = SV_COUNT();
       while ((i + sve_size * 4 - 1) < m) {


### PR DESCRIPTION
close #5231
This pull request fixes a potential out-of-bounds read problem that was reported for [SD]GEMV merged as #5220. 
The loop unrolling implementation referenced an out-of-bounds area, so I fixed it to reference the area needed for the calculation.