### PR TITLE
optimise dot using thread throttling for NEOVERSE V1

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -251,3 +251,6 @@ In chronological order:
 * Ye Tao <ye.tao@arm.com>
   * [2025-02-03] Optimize SBGEMM kernel on NEOVERSEV1
   * [2025-02-27] Add sbgemv_n_neon kernel
+
+* Abhishek Kumar <https://github.com/abhishek-iitmadras>
+  * [2025-04-22] Optimise dot kernel for NEOVERSE V1

--- a/kernel/arm64/dot.c
+++ b/kernel/arm64/dot.c
@@ -48,6 +48,53 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 extern int blas_level1_thread_with_return_value(int mode, BLASLONG m, BLASLONG n,
 	BLASLONG k, void *alpha, void *a, BLASLONG lda, void *b, BLASLONG ldb,
 	void *c, BLASLONG ldc, int (*function)(), int nthreads);
+
+#ifdef DYNAMIC_ARCH
+extern char* gotoblas_corename(void);
+#endif
+
+#if defined(DYNAMIC_ARCH) || defined(NEOVERSEV1)
+static inline int get_dot_optimal_nthreads_neoversev1(BLASLONG N, int ncpu) {
+  #ifdef DOUBLE
+  return (N <= 10000L) ? 1 
+      : (N <= 64500L)   ? 1
+      : (N <= 100000L)  ? MIN(ncpu, 2)
+      : (N <= 150000L)  ? MIN(ncpu, 4)
+      : (N <= 260000L)  ? MIN(ncpu, 8)
+      : (N <= 360000L)  ? MIN(ncpu, 16)
+      : (N <= 520000L)  ? MIN(ncpu, 24)
+      : (N <= 1010000L) ? MIN(ncpu, 56)
+      : ncpu;
+  #else
+  return (N <= 10000L) ? 1 
+      : (N <= 110000L)   ? 1
+      : (N <= 200000L)  ? MIN(ncpu, 2)
+      : (N <= 280000L)  ? MIN(ncpu, 4)
+      : (N <= 520000L)  ? MIN(ncpu, 8)
+      : (N <= 830000L)  ? MIN(ncpu, 16)
+      : (N <= 1010000L)  ? MIN(ncpu, 24)
+      : ncpu;
+  #endif
+}
+#endif
+
+static inline int get_dot_optimal_nthreads(BLASLONG n) {
+  int ncpu = num_cpu_avail(1);
+
+#if defined(NEOVERSEV1) && !defined(COMPLEX) && !defined(BFLOAT16)
+  return get_dot_optimal_nthreads_neoversev1(n, ncpu);
+#elif defined(DYNAMIC_ARCH) && !defined(COMPLEX) && !defined(BFLOAT16)
+  if (strcmp(gotoblas_corename(), "neoversev1") == 0) {
+    return get_dot_optimal_nthreads_neoversev1(n, ncpu);
+  }
+#endif
+
+  // Default case
+  if (n <= 10000L)
+    return 1;
+  else
+    return num_cpu_avail(1);
+}
 #endif
 
 static RETURN_TYPE dot_compute(BLASLONG n, FLOAT *x, BLASLONG inc_x, FLOAT *y, BLASLONG inc_y)
@@ -85,10 +132,10 @@ RETURN_TYPE CNAME(BLASLONG n, FLOAT *x, BLASLONG inc_x, FLOAT *y, BLASLONG inc_y
 	RETURN_TYPE dot = 0.0;
 
 #if defined(SMP)
-	if (inc_x == 0 || inc_y == 0 || n <= 10000)
+	if (inc_x == 0 || inc_y == 0)
 		nthreads = 1;
 	else
-		nthreads = num_cpu_avail(1);
+		nthreads = get_dot_optimal_nthreads(n);
 
 	if (nthreads == 1) {
 		dot = dot_compute(n, x, inc_x, y, inc_y);
@@ -105,7 +152,7 @@ RETURN_TYPE CNAME(BLASLONG n, FLOAT *x, BLASLONG inc_x, FLOAT *y, BLASLONG inc_y
 
 		blas_level1_thread_with_return_value(mode, n, 0, 0, &dummy_alpha,
 				   x, inc_x, y, inc_y, result, 0,
-				   ( void *)dot_thread_function, nthreads);
+				   (void *)dot_thread_function, nthreads);
 
 		ptr = (RETURN_TYPE *)result;
 		for (i = 0; i < nthreads; i++) {


### PR DESCRIPTION
optimise dot kernel using thread throttling give upto 2x to 3x perf boost.

**SDOT : 10000 < SIZE<= 100000L**

![image](https://github.com/user-attachments/assets/ed471857-b2de-408e-a70f-9753bf8fa8d5)

**SDOT : 100000 < SIZE<= 1000000L**

![image](https://github.com/user-attachments/assets/59a140d7-5ad9-4f47-a7a3-e81ca0322e4a)

**DDOT : 10000 < SIZE<= 100000L**

![image](https://github.com/user-attachments/assets/ff324419-30f2-4899-abc5-a655c1f1b8c9)

**DDOT : 100000 < SIZE<= 1000000L**

![image](https://github.com/user-attachments/assets/51218c68-fde5-485d-af1b-11bca1ebbacd)
