### PR TITLE
enable sbgemm to be forward to sbgemv on arm64

### DIFF
--- a/Makefile.system
+++ b/Makefile.system
@@ -276,6 +276,7 @@ SMALL_MATRIX_OPT = 1
 endif
 ifeq ($(ARCH), arm64)
 GEMM_GEMV_FORWARD = 1
+GEMM_GEMV_FORWARD_BF16 = 1
 endif
 ifeq ($(ARCH), riscv)
 GEMM_GEMV_FORWARD = 1


### PR DESCRIPTION
we've new sbgemv kernels for arm neoversev1 and neoversev2 in previous prs:

https://github.com/OpenMathLib/OpenBLAS/pull/5160
https://github.com/OpenMathLib/OpenBLAS/pull/5159

This PR is to enable dispatching sbgemm to sbgemv on arm64.

@annop-w @Mousius @aditew01 @martin-frbg 
