### PR TITLE
kernel/arm64: fixed cscal and zscal

### DIFF
--- a/kernel/arm64/zscal.S
+++ b/kernel/arm64/zscal.S
@@ -33,7 +33,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define	INC_X	x4	/* X stride */
 #define I	x5	/* loop variable */
 #define X_COPY	x6	/* Copy of X */
-
+#define FLAG    x7      /* NaN handling level */
 /*******************************************************************************
 * Macro definitions
 *******************************************************************************/
@@ -217,11 +217,15 @@ zscal_begin:
 	cmp	N, xzr
 	ble	.Lzscal_kernel_L999
 
+	ldr	FLAG, [sp]
+	cmp	FLAG, #1
+	beq	.Lzscal_kernel_R_non_zero
+
 	fcmp	DA_R, #0.0
 	bne	.Lzscal_kernel_R_non_zero
 
-	fcmp	DA_I, #0.0
-	beq	.Lzscal_kernel_RI_zero
+//	fcmp	DA_I, #0.0
+//	beq	.Lzscal_kernel_RI_zero
 
 //	b	.Lzscal_kernel_R_zero
 


### PR DESCRIPTION
to be merged after #5078 #5081