### PR TITLE
Disable the default SSE kernels for x86_64 CSCAL/ZSCAL for now

### DIFF
--- a/kernel/x86_64/KERNEL
+++ b/kernel/x86_64/KERNEL
@@ -323,11 +323,11 @@ DSCALKERNEL =  scal_sse2.S
 endif
 
 ifndef CSCALKERNEL
-CSCALKERNEL = zscal_sse.S
+CSCALKERNEL = ../arm/zscal.c
 endif
 
 ifndef ZSCALKERNEL
-ZSCALKERNEL = zscal_sse2.S
+ZSCALKERNEL = ../arm/zscal.c
 endif
 
 ifndef ASCALKERNEL


### PR DESCRIPTION
to work around issues with INF/NAN handling