### PR TITLE
Bug Fix: Problem with identifying some ARM64 processors

### DIFF
--- a/cpuid_arm64.c
+++ b/cpuid_arm64.c
@@ -276,11 +276,11 @@ int detect(void)
         		fclose(infile);
 			}
 		}
-		sprintf(cpuimpl,"0x%2x",implementer);
+		sprintf(cpuimpl,"0x%02x",implementer);
 		cpu_implementer=strdup(cpuimpl);
 	}
 	qsort(cpucores,1024,sizeof(int),cpusort);
-	sprintf(cpupart,"0x%3x",cpucores[0]);
+	sprintf(cpupart,"0x%03x",cpucores[0]);
 	cpu_part=strdup(cpupart);
 	if(cpu_part != NULL && cpu_implementer != NULL) {
     // Arm


### PR DESCRIPTION
getarch command have a problem that it can not identify some ARM64 processors.
I have fixed this problem with implementing to get the correct values of cpu_implementer and cpu_part.