### PR TITLE
Add .note.GNU-stack in ARM epilogue to avoid writable stack

### DIFF
--- a/common_arm.h
+++ b/common_arm.h
@@ -114,7 +114,15 @@ static inline int blas_quickdivide(blasint x, blasint y){
 	OPENBLAS_ARM_TYPE_FUNCTION \
 REALNAME:
 
-#define EPILOGUE
+#if defined(__ELF__) && defined(__linux__)
+# define GNUSTACK .section        .note.GNU-stack,"",%progbits
+#else
+# define GNUSTACK
+#endif
+
+#define EPILOGUE \
+        GNUSTACK
+
 
 #define PROFCODE
 


### PR DESCRIPTION
**Description:**
As [discussed](https://github.com/OpenMathLib/OpenBLAS/discussions/5313) building OpenBLAS on GNU toolchains can emit warnings about missing `.note.GNU-stack`, causing object files (and ultimately `libopenblas.so`) to be marked as requiring an executable stack. On Linux systems with strict security policies, a shared object requiring an executable stack may fail to load, leading to runtime errors when importing NumPy or other consumers of OpenBLAS. This PR introduces the same pattern used in the z/architecture fix to ARM: in `common_arm.h`, define a macro to emit `.section .note.GNU-stack` when targeting Linux/ELF, and include it in the EPILOGUE of assembly kernels.

* **Background:**

  * When assembling ARM kernels with very recent GNU binutils, warnings appear:

    ```
    warning: missing .note.GNU-stack section implies executable stack
    NOTE: This behaviour is deprecated and will be removed in a future version of the linker
    ```

    Without an explicit `.note.GNU-stack`, the resulting shared library may require an executable stack. On systems refusing executable stacks for shared libraries, imports (e.g., NumPy) will fail with errors like:

    ```
    ImportError: libopenblas.so.0: cannot enable executable stack as shared object requires: Invalid argument
    ```
  * A similar fix was merged for z/architecture in PR #5197, adding `.section .note.GNU-stack` in the EPILOGUE of assembly routines to silence warnings and ensure non-executable stacks. 

**Changes:**

* In `common_arm.h`, introduce a `GNUCSTACK` macro guarded by `__linux__` and `__ELF__`:

  ```c
  #if defined(__linux__) && defined(__ELF__)
  # define GNUSTACK .section .note.GNU-stack,"",@progbits
  #else
  # define GNUSTACK
  #endif
  ```
* Update the existing `EPILOGUE` definition in `common_arm.h` to include:

* Assembly kernels for ARM automatically pick up this EPILOGUE when compiled on Linux/ELF targets.