### PR TITLE
CMake: Make sure to find OpenMP dependency before usage.

### DIFF
--- a/.github/workflows/apple_m.yml
+++ b/.github/workflows/apple_m.yml
@@ -104,7 +104,7 @@ jobs:
                     -DUSE_OPENMP=${{matrix.openmp}} \
                     -DOpenMP_Fortran_LIB_NAMES=omp \
                     -DINTERFACE64=${{matrix.ilp64}} \
-                    -DNOFORTRAN=0 \
+                    -DNOFORTRAN=OFF \
                     -DBUILD_WITHOUT_LAPACK=0 \
                     -DCMAKE_VERBOSE_MAKEFILE=ON \
                     -DCMAKE_BUILD_TYPE=Release \

--- a/.github/workflows/arm64_graviton.yml
+++ b/.github/workflows/arm64_graviton.yml
@@ -93,7 +93,7 @@ jobs:
             "cmake")
               mkdir build && cd build
               cmake -DDYNAMIC_ARCH=1 \
-                    -DNOFORTRAN=0 \
+                    -DNOFORTRAN=OFF \
                     -DBUILD_WITHOUT_LAPACK=0 \
                     -DCMAKE_VERBOSE_MAKEFILE=ON \
                     -DCMAKE_BUILD_TYPE=Release \

--- a/.github/workflows/codspeed-bench.yml
+++ b/.github/workflows/codspeed-bench.yml
@@ -105,7 +105,7 @@ jobs:
             "cmake")
               mkdir build && cd build
               cmake -DDYNAMIC_ARCH=1 \
-                    -DNOFORTRAN=0 \
+                    -DNOFORTRAN=OFF \
                     -DBUILD_WITHOUT_LAPACK=0 \
                     -DCMAKE_VERBOSE_MAKEFILE=ON \
                     -DCMAKE_BUILD_TYPE=Release \

--- a/.github/workflows/dynamic_arch.yml
+++ b/.github/workflows/dynamic_arch.yml
@@ -107,7 +107,7 @@ jobs:
             "cmake")
               mkdir build && cd build
               cmake -DDYNAMIC_ARCH=1 \
-                    -DNOFORTRAN=0 \
+                    -DNOFORTRAN=OFF \
                     -DBUILD_WITHOUT_LAPACK=0 \
                     -DCMAKE_VERBOSE_MAKEFILE=ON \
                     -DCMAKE_BUILD_TYPE=Release \

--- a/.github/workflows/harmonyos.yml
+++ b/.github/workflows/harmonyos.yml
@@ -32,6 +32,6 @@ jobs:
       run: |
        mkdir build && cd build
        ${{ env.OHOS_NDK_CMAKE }} ${{ env.COMMON_CMAKE_OPTIONS }} -DOHOS_ARCH="arm64-v8a" \
-       -DTARGET=ARMV8 -DNOFORTRAN=1 ..
+       -DTARGET=ARMV8 -DNOFORTRAN=ON ..
        ${{ env.OHOS_NDK_CMAKE }} --build . -j $(nproc)
        

--- a/.travis.yml
+++ b/.travis.yml
@@ -211,7 +211,7 @@ matrix:
 #        - CMAKE=1
 #    - <<: *test-cmake
 #      env:
-#        - CMAKE=1 CMAKE_ARGS="-DNOFORTRAN=1"
+#        - CMAKE=1 CMAKE_ARGS="-DNOFORTRAN=ON"
 #    - <<: *test-cmake
 #      compiler: gcc
 #      env:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -62,11 +62,11 @@ before_build:
   - if [%COMPILER%]==[MinGW64-gcc-7.2.0-mingw] set PATH=C:\MinGW\bin;C:\mingw-w64\x86_64-7.2.0-posix-seh-rt_v5-rev1\mingw64\bin;%PATH%
   - if [%COMPILER%]==[MinGW-gcc-6.3.0-32] set PATH=C:\msys64\usr\bin;C:\mingw-w64\i686-6.3.0-posix-dwarf-rt_v5-rev1\mingw64\bin;%PATH%
   - if [%COMPILER%]==[cl] cmake -G "Visual Studio 15 2017 Win64" ..
-  - if [%COMPILER%]==[MinGW64-gcc-7.2.0-mingw] cmake -G "MinGW Makefiles" -DNOFORTRAN=1 ..
-  - if [%COMPILER%]==[MinGW-gcc-6.3.0-32] cmake -G "MSYS Makefiles" -DNOFORTRAN=1 ..
-  - if [%COMPILER%]==[MinGW-gcc-5.3.0] cmake -G "MSYS Makefiles" -DNOFORTRAN=1 ..
+  - if [%COMPILER%]==[MinGW64-gcc-7.2.0-mingw] cmake -G "MinGW Makefiles" -DNOFORTRAN=ON ..
+  - if [%COMPILER%]==[MinGW-gcc-6.3.0-32] cmake -G "MSYS Makefiles" -DNOFORTRAN=ON ..
+  - if [%COMPILER%]==[MinGW-gcc-5.3.0] cmake -G "MSYS Makefiles" -DNOFORTRAN=ON ..
   - if [%WITH_FORTRAN%]==[OFF] cmake -G "Ninja" -DCMAKE_CXX_COMPILER=clang-cl -DCMAKE_C_COMPILER=clang-cl -DCMAKE_MT=mt -DMSVC_STATIC_CRT=ON ..
-  - if [%WITH_FORTRAN%]==[ON] cmake -G "Ninja" -DCMAKE_CXX_COMPILER=clang-cl -DCMAKE_C_COMPILER=clang-cl -DCMAKE_Fortran_COMPILER=flang -DCMAKE_MT=mt -DBUILD_WITHOUT_LAPACK=no -DNOFORTRAN=0 ..
+  - if [%WITH_FORTRAN%]==[ON] cmake -G "Ninja" -DCMAKE_CXX_COMPILER=clang-cl -DCMAKE_C_COMPILER=clang-cl -DCMAKE_Fortran_COMPILER=flang -DCMAKE_MT=mt -DBUILD_WITHOUT_LAPACK=no -DNOFORTRAN=OFF ..
   - if [%USE_OPENMP%]==[ON] cmake -DUSE_OPENMP=ON ..
   - if [%DYNAMIC_ARCH%]==[ON] cmake -DDYNAMIC_ARCH=ON -DDYNAMIC_LIST='CORE2;NEHALEM;SANDYBRIDGE;BULLDOZER;HASWELL' ..
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -111,7 +111,7 @@ jobs:
       call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
       mkdir build 
       cd build
-      cmake -G "Ninja" -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DCMAKE_MT=mt -DCMAKE_BUILD_TYPE=Release -DNOFORTRAN=1 -DMSVC_STATIC_CRT=ON ..
+      cmake -G "Ninja" -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DCMAKE_MT=mt -DCMAKE_BUILD_TYPE=Release -DNOFORTRAN=ON -DMSVC_STATIC_CRT=ON ..
       cmake --build . --config Release
       ctest
 
@@ -215,7 +215,7 @@ jobs:
       brew install llvm libomp
       mkdir build
       cd build
-      cmake -DTARGET=CORE2 -DUSE_OPENMP=1 -DINTERFACE64=1 -DDYNAMIC_ARCH=1 -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang -DNOFORTRAN=1 -DNO_AVX512=1 ..
+      cmake -DTARGET=CORE2 -DUSE_OPENMP=1 -DINTERFACE64=1 -DDYNAMIC_ARCH=1 -DCMAKE_C_COMPILER=/usr/local/opt/llvm/bin/clang -DNOFORTRAN=ON -DNO_AVX512=1 ..
       make
       ctest
       

--- a/cmake/OpenBLASConfig.cmake.in
+++ b/cmake/OpenBLASConfig.cmake.in
@@ -48,9 +48,17 @@
 
 set(PN OpenBLAS)
 
+include(CMakeFindDependencyMacro)
+
 # need to check that the @USE_*@ evaluate to something cmake can perform boolean logic upon
 if(@USE_OPENMP@)
     set(${PN}_openmp_FOUND 1)
+    enable_language(C)
+    find_dependency(OpenMP COMPONENTS C REQUIRED)
+    if(NOT @NOFORTRAN@)
+        enable_language(Fortran)
+        find_package(OpenMP COMPONENTS Fortran REQUIRED)
+    endif()
 elseif(@USE_THREAD@)
     set(${PN}_pthread_FOUND 1)
 else()

--- a/cmake/f_check.cmake
+++ b/cmake/f_check.cmake
@@ -25,18 +25,14 @@ check_language(Fortran)
 if(CMAKE_Fortran_COMPILER)
   enable_language(Fortran)
 else()
-  set (NOFORTRAN 1)
+  set(NOFORTRAN ON)
   if (NOT NO_LAPACK)
-     if (NOT XXXXX)
-	message(STATUS "No Fortran compiler found, can build only BLAS and f2c-converted LAPACK")
-	set(C_LAPACK 1)
-	if (INTERFACE64)
-	  set (CCOMMON_OPT "${CCOMMON_OPT} -DLAPACK_ILP64")
-  	endif ()
-	set(TIMER "NONE")
-     else ()
-       message(STATUS "No Fortran compiler found, can build only BLAS")
-     endif()  
+    message(STATUS "No Fortran compiler found, can build only BLAS and f2c-converted LAPACK")
+    set(C_LAPACK 1)
+    if (INTERFACE64)
+      set (CCOMMON_OPT "${CCOMMON_OPT} -DLAPACK_ILP64")
+    endif ()
+    set(TIMER "NONE")
   endif()
 endif()
 
@@ -46,18 +42,18 @@ if (NOT ONLY_CBLAS)
   # TODO: detect whether underscore needed, set #defines and BU appropriately - use try_compile
   # TODO: set FEXTRALIB flags a la f_check?
   if (NOT (${CMAKE_SYSTEM_NAME} MATCHES "Windows" AND x${CMAKE_Fortran_COMPILER_ID} MATCHES "IntelLLVM"))
-  set(BU "_")
-  file(APPEND ${TARGET_CONF_TEMP}
-    "#define BUNDERSCORE _\n"
-    "#define NEEDBUNDERSCORE 1\n"
-    "#define NEED2UNDERSCORES 0\n")
+    set(BU "_")
+    file(APPEND ${TARGET_CONF_TEMP}
+      "#define BUNDERSCORE _\n"
+      "#define NEEDBUNDERSCORE 1\n"
+      "#define NEED2UNDERSCORES 0\n")
   else ()
-	  set (FCOMMON_OPT "${FCOMMON_OPT} /fp:precise /recursive /names:lowercase /assume:nounderscore")
+    set (FCOMMON_OPT "${FCOMMON_OPT} /fp:precise /recursive /names:lowercase /assume:nounderscore")
   endif()
 else ()
 
-  #When we only build CBLAS, we set NOFORTRAN=2
-  set(NOFORTRAN 2)
+  #When we only build CBLAS, we set NOFORTRAN=ON
+  set(NOFORTRAN ON)
   set(NO_FBLAS 1)
   #set(F_COMPILER GFORTRAN) # CMake handles the fortran compiler
   set(BU "_")
@@ -67,6 +63,6 @@ else ()
 endif()
 
 if (CMAKE_Fortran_COMPILER)
-get_filename_component(F_COMPILER ${CMAKE_Fortran_COMPILER} NAME_WE)
-string(TOUPPER ${F_COMPILER} F_COMPILER)
+  get_filename_component(F_COMPILER ${CMAKE_Fortran_COMPILER} NAME_WE)
+  string(TOUPPER ${F_COMPILER} F_COMPILER)
 endif()

--- a/docs/install.md
+++ b/docs/install.md
@@ -270,7 +270,7 @@ newer installed.
     set "CPATH=%CONDA_PREFIX%\Library\include;%CPATH%"
     mkdir build
     cd build
-    cmake .. -G "Ninja" -DCMAKE_CXX_COMPILER=clang-cl -DCMAKE_C_COMPILER=clang-cl -DCMAKE_Fortran_COMPILER=flang -DCMAKE_MT=mt -DBUILD_WITHOUT_LAPACK=no -DNOFORTRAN=0 -DDYNAMIC_ARCH=ON -DCMAKE_BUILD_TYPE=Release
+    cmake .. -G "Ninja" -DCMAKE_CXX_COMPILER=clang-cl -DCMAKE_C_COMPILER=clang-cl -DCMAKE_Fortran_COMPILER=flang -DCMAKE_MT=mt -DBUILD_WITHOUT_LAPACK=no -DNOFORTRAN=OFF -DDYNAMIC_ARCH=ON -DCMAKE_BUILD_TYPE=Release
     ```
 
     You may want to add further options in the `cmake` command here. For
@@ -736,7 +736,7 @@ contains no Fortran compiler):
 ```bash
 /opt/ohos-sdk/linux/native/build-tools/cmake/bin/cmake \
       -DCMAKE_TOOLCHAIN_FILE=/opt/ohos-sdk/linux/native/build/cmake/ohos.toolchain.cmake \
-      -DOHOS_ARCH="arm64-v8a" -DTARGET=ARMV8 -DNOFORTRAN=1 ..
+      -DOHOS_ARCH="arm64-v8a" -DTARGET=ARMV8 -DNOFORTRAN=ON ..
 ```
 Additional other OpenBLAS build options like `USE_OPENMP=1` or `DYNAMIC_ARCH=1`
 will probably work too. Finally do the build:
@@ -823,7 +823,7 @@ set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
 
 Then build OpenBLAS with:
 ```bash
-$ cmake .. -G Ninja -DCMAKE_C_COMPILER=arm-none-eabi-gcc -DCMAKE_TOOLCHAIN_FILE:PATH="toolchain.cmake" -DNOFORTRAN=1 -DTARGET=ARMV5 -DEMBEDDED=1
+$ cmake .. -G Ninja -DCMAKE_C_COMPILER=arm-none-eabi-gcc -DCMAKE_TOOLCHAIN_FILE:PATH="toolchain.cmake" -DNOFORTRAN=ON -DTARGET=ARMV5 -DEMBEDDED=1
 ```
 
 In your embedded application, the following functions need to be provided for OpenBLAS to work correctly:


### PR DESCRIPTION
cmake will throw an error if OpenMP::OpenMP_C or OpenMP::OpenMP_Fortran were not found first. see: https://github.com/msys2/MINGW-packages/issues/24616