### PR TITLE
Fix INTERFACE64 builds on Loongarch64 with LLVM

### DIFF
--- a/Makefile.system
+++ b/Makefile.system
@@ -1191,6 +1191,13 @@ endif
 else ifeq ($(ARCH), $(filter $(ARCH),mips))
 FCOMMON_OPT += -mabi=32
 endif
+ifeq ($(ARCH), $(filter $(ARCH),loongarch64))
+ifdef INTERFACE64
+ifneq ($(INTERFACE64), 0)
+FCOMMON_OPT +=  -fdefault-integer-8
+endif
+endif
+endif
 else
 ifdef BINARY64
 ifneq ($(OSNAME), AIX)


### PR DESCRIPTION
fix https://github.com/OpenMathLib/OpenBLAS/issues/5331

Compilation of OpenBLAS on loongarch64 is now possible with LLVM clang/flang(flang-new) version 20 and above. Recently I tried to build OpenBLAS 0.3.30 (should also apply to current develop version) on Debian sid with different parameters and found gmake compilation failure when INTERFACE64=1 is set.

During the compilation I found that `INTERFACE64=1` is not implemented by flang and finally I got the following error message:
```
...
/usr/local/llvm-20.1.7/bin/flang -O2 -march=loongarch64   -o zblat2 zblat2.o ../libopenblas_la464p-r0.3.30.a -lm -lpthread -lm -lpthread -L/usr/local/llvm-20.1.7/bin/../lib/loongarch64-unknown-linux-gnu -L/usr/local/llvm-20.1.7/lib/clang/20/lib/loongarch64-unknown-linux-gnu -L/usr/lib/gcc/loongarch64-linux-gnu/14 -L/usr/lib/gcc/loongarch64-linux-gnu/14/../../../../lib64 -L/lib/loongarch64-linux-gnu -L/lib/../lib64 -L/usr/lib/loongarch64-linux-gnu -L/usr/lib/../lib64 -L/lib -L/usr/lib  -lc 
OPENBLAS_NUM_THREADS=1 OMP_NUM_THREADS=1 ./sblat1
 Real BLAS Test Program Results


 Test of subprogram number  1             SDOT 
Bus error
make[1]: *** [Makefile:51: level1] Error 135
...
```

To fix the above error, I added a few lines in `Makefile.system` to specify the support of  INTERFACE64. After these changes the compilation error disappears.