### PR TITLE
Revert "Fix out-of-bounds accesses in ?/SCAL/?GEEV triggered by preceding errrors/invalid inputs"

### DIFF
--- a/lapack-netlib/SRC/cgeev.f
+++ b/lapack-netlib/SRC/cgeev.f
@@ -485,12 +485,12 @@
 *     Undo scaling if necessary
 *
    50 CONTINUE
-      IF( SCALEA .AND. INFO.GT.0 ) THEN
+      IF( SCALEA ) THEN
          CALL CLASCL( 'G', 0, 0, CSCALE, ANRM, N-INFO, 1, W( INFO+1 ),
      $                MAX( N-INFO, 1 ), IERR )
-
+         IF( INFO.GT.0 ) THEN
             CALL CLASCL( 'G', 0, 0, CSCALE, ANRM, ILO-1, 1, W, N, IERR )
-
+         END IF
       END IF
 *
       WORK( 1 ) = SROUNDUP_LWORK(MAXWRK)

--- a/lapack-netlib/SRC/dgeev.f
+++ b/lapack-netlib/SRC/dgeev.f
@@ -506,17 +506,17 @@
 *     Undo scaling if necessary
 *
    50 CONTINUE
-      IF( SCALEA .AND. INFO.GT.0) THEN
+      IF( SCALEA ) THEN
          CALL DLASCL( 'G', 0, 0, CSCALE, ANRM, N-INFO, 1, WR( INFO+1 ),
      $                MAX( N-INFO, 1 ), IERR )
          CALL DLASCL( 'G', 0, 0, CSCALE, ANRM, N-INFO, 1, WI( INFO+1 ),
      $                MAX( N-INFO, 1 ), IERR )
-
+         IF( INFO.GT.0 ) THEN
             CALL DLASCL( 'G', 0, 0, CSCALE, ANRM, ILO-1, 1, WR, N,
      $                   IERR )
             CALL DLASCL( 'G', 0, 0, CSCALE, ANRM, ILO-1, 1, WI, N,
      $                   IERR )
-
+         END IF
       END IF
 *
       WORK( 1 ) = MAXWRK

--- a/lapack-netlib/SRC/sgeev.f
+++ b/lapack-netlib/SRC/sgeev.f
@@ -504,17 +504,17 @@
 *     Undo scaling if necessary
 *
    50 CONTINUE
-      IF( SCALEA .AND. INFO.GT.0) THEN
+      IF( SCALEA ) THEN
          CALL SLASCL( 'G', 0, 0, CSCALE, ANRM, N-INFO, 1, WR( INFO+1 ),
      $                MAX( N-INFO, 1 ), IERR )
          CALL SLASCL( 'G', 0, 0, CSCALE, ANRM, N-INFO, 1, WI( INFO+1 ),
      $                MAX( N-INFO, 1 ), IERR )
-
+         IF( INFO.GT.0 ) THEN
             CALL SLASCL( 'G', 0, 0, CSCALE, ANRM, ILO-1, 1, WR, N,
      $                   IERR )
             CALL SLASCL( 'G', 0, 0, CSCALE, ANRM, ILO-1, 1, WI, N,
      $                   IERR )
-
+         END IF
       END IF
 *
       WORK( 1 ) = SROUNDUP_LWORK(MAXWRK)

--- a/lapack-netlib/SRC/zgeev.f
+++ b/lapack-netlib/SRC/zgeev.f
@@ -485,12 +485,12 @@
 *     Undo scaling if necessary
 *
    50 CONTINUE
-      IF( SCALEA .AND. INFO.GT.0) THEN
+      IF( SCALEA ) THEN
          CALL ZLASCL( 'G', 0, 0, CSCALE, ANRM, N-INFO, 1, W( INFO+1 ),
      $                MAX( N-INFO, 1 ), IERR )
-
+         IF( INFO.GT.0 ) THEN
             CALL ZLASCL( 'G', 0, 0, CSCALE, ANRM, ILO-1, 1, W, N, IERR )
-
+         END IF
       END IF
 *
       WORK( 1 ) = MAXWRK


### PR DESCRIPTION
Reverts OpenMathLib/OpenBLAS#5251 as it causes regressions in legitimate situations (e.g. in the lapack testsuite). The actual fault lies in continuing past the initial error (due to OpenBLAS' xerbla only calling return instead of exit) 