### PR TITLE
Setting `GEMM_PREFERED_SIZE` parameter for `A64FX`

### DIFF
--- a/param.h
+++ b/param.h
@@ -3701,6 +3701,12 @@ is a big desktop or server with abundant cache rather than a phone or embedded d
 
 #elif defined(A64FX) // 512-bit SVE
 
+#if defined(XDOUBLE) || defined(DOUBLE)
+#define GEMM_PREFERED_SIZE  8
+#else
+#define GEMM_PREFERED_SIZE 16
+#endif
+
 /* When all BLAS3 routines are implemeted with SVE, SGEMM_DEFAULT_UNROLL_M should be "sve_vl".
 Until then, just keep it different than DGEMM_DEFAULT_UNROLL_N to keep copy routines in both directions seperated. */
 #define SGEMM_DEFAULT_UNROLL_M  4


### PR DESCRIPTION
Resolves #5343.
This change improves the overall performance of `[SD]GEMM`, `[SDCZ]SYMM`, and `[CZ]HEMM`. The graphs below show the 12-thread performance improvement of `[SD]GEMM` on `A64FX`.
![level3 sgemm nn](https://github.com/user-attachments/assets/f7094a66-bbdd-4203-9c83-9ff439f15434)
![level3 dgemm nn](https://github.com/user-attachments/assets/f12b348d-2fd1-4ed0-9df3-088634794b24)
