### PR TITLE
Multi-thread Performance Improvement of GEMM with DIVIDE_RATE=1 for A64FX

### DIFF
--- a/driver/level3/gemm.c
+++ b/driver/level3/gemm.c
@@ -59,6 +59,10 @@
 #define GEMM_Q 128
 #endif
 
+#ifdef GEMM_DIVIDE_RATE
+#define DIVIDE_RATE GEMM_DIVIDE_RATE
+#endif
+
 #ifdef THREADED_LEVEL3
 #include "level3_thread.c"
 #else

--- a/param.h
+++ b/param.h
@@ -3701,6 +3701,8 @@ is a big desktop or server with abundant cache rather than a phone or embedded d
 
 #elif defined(A64FX) // 512-bit SVE
 
+#define GEMM_DIVIDE_RATE  1
+
 #if defined(XDOUBLE) || defined(DOUBLE)
 #define GEMM_PREFERED_SIZE  8
 #else


### PR DESCRIPTION
Closes #5347
 This PR improves the multi-thread performance of GEMM on A64FX by setting `DIVIDE_RATE` to 1.
The thread control in GEMM currently uses default value of DIVIDE_RATE=2, which always splits N dimension of matrix into two parts for computation. However, this splitting occurs even when N is small (e.g., N=2), leading to a decrease in computational efficiency.
For GEMM on A64FX, I tried DIVIDE_RATE=1 and confirmed performance improvements as shown in the graphs below.
While improvements were expected for narrow matrices with small N dimensions, performance gains were also observed for square matrices.

![gemm_divide_rate_1](https://github.com/user-attachments/assets/e3f122d3-110a-41fb-8118-d946e08bac18)
![gemm_divide_rate_2](https://github.com/user-attachments/assets/577dfe02-5918-4607-93f8-796ad04f3843)
![gemm_divide_rate_3](https://github.com/user-attachments/assets/667faf3f-85f4-4fe3-89c3-481ede670992)
