### PR TITLE
Update README.md to include Windows on Arm64

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ For a general introduction to the BLAS routines, please refer to the extensive d
 We provide official binary packages for the following platform:
 
   * Windows x86/x86_64
+  * Windows arm64 (woa)
 
 You can download them from [file hosting on sourceforge.net](https://sourceforge.net/projects/openblas/files/) or from the [Releases section of the GitHub project page](https://github.com/OpenMathLib/OpenBLAS/releases).
 


### PR DESCRIPTION
Update README.md to indicate that binaries are available for Windows on ARM64 in addition to x86 and x86_64.