### PR TITLE
Fix cpuid.S on arm

### DIFF
--- a/cpuid.S
+++ b/cpuid.S
@@ -66,5 +66,9 @@ _cpuid:
 
 #endif
 #if defined(__ELF__) && defined(__linux__)
+#if defined(__arm__)
+        .section        .note.GNU-stack,"",%progbits
+#else
         .section        .note.GNU-stack,"",@progbits
+#endif
 #endif


### PR DESCRIPTION
The ARM assembly syntax differs a bit

Fixes 61b9339d3a1f getarch/cpuid.S: Fix warning about executable stack

Ref https://github.com/OpenMathLib/OpenBLAS/discussions/5313#discussioncomment-13674817