### PR TITLE
Improve bgemm and sbgemm testing

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -13,7 +13,7 @@
 # 3. Neither the name of the OpenBLAS project nor the names of
 #    its contributors may be used to endorse or promote products
 #    derived from this software without specific prior written permission.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -34,6 +34,7 @@ ifneq (, $(filter $(CORE),LOONGSON3R3 LOONGSON3R4))
 endif
         override FFLAGS += -fno-tree-vectorize
 endif
+override CFLAGS += -std=c11 -Wall -Werror
 
 SUPPORT_GEMM3M = 0
 
@@ -402,10 +403,10 @@ zblat3 : zblat3.$(SUFFIX) ../$(LIBNAME)
 endif
 
 ifeq ($(BUILD_BFLOAT16),1)
-test_bgemm : compare_sgemm_bgemm.c ../$(LIBNAME)
+test_bgemm : compare_sgemm_bgemm.c test_helpers.h ../$(LIBNAME)
 	$(CC) $(CLDFLAGS) -o test_bgemm compare_sgemm_bgemm.c ../$(LIBNAME) $(EXTRALIB) $(CEXTRALIB)
 
-test_sbgemm : compare_sgemm_sbgemm.c ../$(LIBNAME)
+test_sbgemm : compare_sgemm_sbgemm.c test_helpers.h ../$(LIBNAME)
 	$(CC) $(CLDFLAGS) -o test_sbgemm compare_sgemm_sbgemm.c ../$(LIBNAME) $(EXTRALIB) $(CEXTRALIB)
 endif
 

--- a/test/compare_sgemm_bgemm.c
+++ b/test/compare_sgemm_bgemm.c
@@ -28,37 +28,19 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdint.h>
 #include <stdio.h>
 
+#include "test_helpers.h"
 
 #define SGEMM BLASFUNC(sgemm)
 #define BGEMM BLASFUNC(bgemm)
 #define BGEMM_LARGEST 256
 
-static float float16to32(bfloat16 value)
-{
-  blasint one = 1;
-  float result;
-  sbf16tos_(&one, &value, &one, &result, &one);
-  return result;
-}
-
-static float truncate_float(float value) {
+static float truncate_float32_to_bfloat16(float value) {
   blasint one = 1;
   bfloat16 tmp;
   float result;
   sbstobf16_(&one, &value, &one, &tmp, &one);
   sbf16tos_(&one, &tmp, &one, &result, &one);
   return result;
-}
-
-static void *malloc_safe(size_t size) {
-  if (size == 0)
-    return malloc(1);
-  else
-    return malloc(size);
-}
-
-static float is_close(float a, float b, float rtol, float atol) {
-  return fabs(a - b) <= (atol + rtol*fabs(b));
 }
 
 int
@@ -151,15 +133,15 @@ main (int argc, char *argv[])
               DD[i * m + j] +=
                 float16to32 (AA[k * j + l]) * float16to32 (BB[i + l * n]);
             }
-          if (!is_close(float16to32(CC[i * m + j]), truncate_float(C[i * m + j]), 0.01, 0.001)) {
+          if (!is_close(float16to32(CC[i * m + j]), truncate_float32_to_bfloat16(C[i * m + j]), 0.01, 0.001)) {
             printf("Mismatch at i=%d, j=%d, k=%d: CC=%.6f, C=%.6f\n",
-                    i, j, k, float16to32(CC[i * m + j]), truncate_float(C[i * m + j]));
+                    i, j, k, float16to32(CC[i * m + j]), truncate_float32_to_bfloat16(C[i * m + j]));
             ret++;
           }
 
-          if (!is_close(float16to32(CC[i * m + j]), truncate_float(DD[i * m + j]), 0.0001, 0.00001)) {
+          if (!is_close(float16to32(CC[i * m + j]), truncate_float32_to_bfloat16(DD[i * m + j]), 0.0001, 0.00001)) {
             printf("Mismatch at i=%d, j=%d, k=%d: CC=%.6f, DD=%.6f\n",
-                    i, j, k, float16to32(CC[i * m + j]), truncate_float(DD[i * m + j]));
+                    i, j, k, float16to32(CC[i * m + j]), truncate_float32_to_bfloat16(DD[i * m + j]));
             ret++;
           }
             

--- a/test/test_helpers.h
+++ b/test/test_helpers.h
@@ -1,0 +1,55 @@
+/***************************************************************************
+Copyright (c) 2025 The OpenBLAS Project
+All rights reserved.
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in
+the documentation and/or other materials provided with the
+distribution.
+3. Neither the name of the OpenBLAS project nor the names of
+its contributors may be used to endorse or promote products
+derived from this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE OPENBLAS PROJECT OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+#ifndef TEST_HELPERS_H
+#define TEST_HELPERS_H
+#include <stdbool.h>
+
+#include "../common.h"
+
+#if IFLOAT == bfloat16
+static float float16to32(bfloat16 value)
+{
+  blasint one = 1;
+  float result;
+  sbf16tos_(&one, &value, &one, &result, &one);
+  return result;
+}
+#endif
+
+static void *malloc_safe(size_t size) {
+  if (size == 0)
+    return malloc(1);
+  else
+    return malloc(size);
+}
+
+static bool is_close(float a, float b, float rtol, float atol) {
+  return fabs(a - b) <= (atol + rtol*fabs(b));
+}
+
+#endif


### PR DESCRIPTION
- Fixes wrong return type for `is_close`
- Adds stricter compiler flags for test files so we don't see the above issue again
- Re-uses test helper functions between compare_sgemm_sbgemm/bgemm.c