### PR TITLE
fix: broken cblas installation when using makefile based builds

### DIFF
--- a/Makefile.install
+++ b/Makefile.install
@@ -71,7 +71,7 @@ install : 	lib.grd
 	@cat common_interface.h >> "$(DESTDIR)$(OPENBLAS_INCLUDE_DIR)/f77blas.h"
 	@echo \#endif >> "$(DESTDIR)$(OPENBLAS_INCLUDE_DIR)/f77blas.h"
 
-ifndef NO_CBLAS
+ifneq ($(NO_CBLAS),1)
 	@echo Generating cblas.h in $(DESTDIR)$(OPENBLAS_INCLUDE_DIR)
 	@cp cblas.h cblas.tmp
 ifdef SYMBOLPREFIX


### PR DESCRIPTION
Fix cblas.h missing from target directory if NO_CBLAS is defined but has a value that indicates you do want cblas built and installed.