### PR TITLE
Implementing SVE in `[SD]AXPY` Kernels for `A64FX` and `Graviton3E`

### DIFF
--- a/kernel/arm64/KERNEL.A64FX
+++ b/kernel/arm64/KERNEL.A64FX
@@ -7,3 +7,6 @@ DGEMVTKERNEL = gemv_t_sve_v4x3.c
 
 DDOTKERNEL   = dot_sve_v8.c
 SDOTKERNEL   = dot_sve_v8.c
+
+SAXPYKERNEL  = axpy_sve.c
+DAXPYKERNEL  = axpy_sve.c

--- a/kernel/arm64/KERNEL.NEOVERSEV1
+++ b/kernel/arm64/KERNEL.NEOVERSEV1
@@ -32,6 +32,10 @@ SGEMVNKERNEL = gemv_n_sve_v1x3.c
 DGEMVNKERNEL = gemv_n_sve_v1x3.c
 SGEMVTKERNEL = gemv_t_sve_v1x3.c
 DGEMVTKERNEL = gemv_t_sve_v1x3.c
+
+SAXPYKERNEL = axpy_sve.c
+DAXPYKERNEL = axpy_sve.c
+
 ifeq ($(BUILD_BFLOAT16), 1)
 BGEMM_BETA    =  bgemm_beta_neon.c
 BGEMMKERNEL    = bgemm_kernel_2vlx4_neoversev1.c

--- a/kernel/arm64/axpy_sve.c
+++ b/kernel/arm64/axpy_sve.c
@@ -1,0 +1,86 @@
+/***************************************************************************
+Copyright (c) 2025, The OpenBLAS Project
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   1. Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in
+      the documentation and/or other materials provided with the
+      distribution.
+   3. Neither the name of the OpenBLAS project nor the names of 
+      its contributors may be used to endorse or promote products 
+      derived from this software without specific prior written 
+      permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*****************************************************************************/
+
+#include <arm_sve.h>
+
+#include "common.h"
+
+#ifdef DOUBLE
+#define SV_TYPE svfloat64_t
+#define SV_COUNT svcntd
+#define SV_DUP svdup_f64
+#define SV_WHILE svwhilelt_b64_s64
+#define SV_TRUE svptrue_b64
+#else
+#define SV_TYPE svfloat32_t
+#define SV_COUNT svcntw
+#define SV_DUP svdup_f32
+#define SV_WHILE svwhilelt_b32_s64
+#define SV_TRUE svptrue_b32
+#endif
+
+int CNAME(BLASLONG n, BLASLONG dummy0, BLASLONG dummy1, FLOAT da, FLOAT *x, BLASLONG inc_x, FLOAT *y, BLASLONG inc_y, FLOAT *dummy, BLASLONG dummy2) {
+  BLASLONG i = 0;
+  BLASLONG ix = 0, iy = 0;
+  BLASLONG sve_size = SV_COUNT();
+
+  if (n < 0) return (0);
+  if (da == 0.0) return (0);
+
+  if (inc_x == 1 && inc_y == 1) {
+    SV_TYPE da_vec = SV_DUP(da);
+    for (i = 0; i + sve_size - 1 < n; i += sve_size) {
+      SV_TYPE x_vec = svld1(SV_TRUE(), &x[i]);
+      SV_TYPE y_vec = svld1(SV_TRUE(), &y[i]);
+      y_vec = svmla_x(SV_TRUE(), y_vec, da_vec, x_vec);
+      svst1(SV_TRUE(), &y[i], y_vec);
+    }
+
+    if (i < n) {
+      svbool_t pg = SV_WHILE(i, n);
+      SV_TYPE x_vec = svld1(pg, &x[i]);
+      SV_TYPE y_vec = svld1(pg, &y[i]);
+      y_vec = svmla_x(pg, y_vec, da_vec, x_vec);
+      svst1(pg, &y[i], y_vec);
+    }
+    return (0);
+  }
+
+  while (i < n) {
+    y[iy] += da * x[ix];
+    ix += inc_x;
+    iy += inc_y;
+    i++;
+  }
+
+  return (0);
+}


### PR DESCRIPTION
Resolves #5417.
This change improves the performance of `[SD]AXPY` on both `A64FX` and `Graviton3E`. 
The graphs below show the single thread performance improvement of `[D]AXPY` on `A64FX` and `Graviton3E`, respectively.
![level1 daxpy](https://github.com/user-attachments/assets/0bff7b05-b7e7-49ac-acfd-69b149cbf194)
![level1 daxpy_](https://github.com/user-attachments/assets/c40366f1-6313-4ab0-8476-c442a2bcde16)

The performance improved by 2.57 times on the `A64FX` and 1.13 times on the `Graviton3E`.
I have confirmed that this optimization also yields performance benefits for Level 2 BLAS kernels that utilize `[SD]AXPY`, such as `[SD]SPMV` and `[SD]GER`.
