### PR TITLE
disable fp16 flags on RISC-V unless BUILD_HFLOAT16=1

### DIFF
--- a/Makefile.prebuild
+++ b/Makefile.prebuild
@@ -64,11 +64,11 @@ TARGET_FLAGS = -march=rv64imafdcv_zba_zbb_zfh -mabi=lp64d
 endif
 
 ifeq ($(TARGET), RISCV64_ZVL256B)
-TARGET_FLAGS = -march=rv64imafdcv_zvfh_zfh -mabi=lp64d
+TARGET_FLAGS = -march=rv64imafdcv -mabi=lp64d
 endif
 
 ifeq ($(TARGET), RISCV64_ZVL128B)
-TARGET_FLAGS = -march=rv64imafdcv_zvfh_zfh -mabi=lp64d
+TARGET_FLAGS = -march=rv64imafdcv -mabi=lp64d
 endif
 
 ifeq ($(TARGET), RISCV64_GENERIC)

--- a/Makefile.riscv64
+++ b/Makefile.riscv64
@@ -7,12 +7,22 @@ CCOMMON_OPT += -march=rv64imafdcv_zba_zbb_zfh_zvl512b -mabi=lp64d
 FCOMMON_OPT += -march=rv64imafdcv_zba_zbb_zfh -mabi=lp64d -static
 endif
 ifeq ($(CORE), RISCV64_ZVL256B)
+ifeq ($(BUILD_HFLOAT16), 1)
 CCOMMON_OPT += -march=rv64imafdcv_zvl256b_zvfh_zfh -mabi=lp64d
 FCOMMON_OPT += -march=rv64imafdcv_zvfh_zfh -mabi=lp64d
+else
+CCOMMON_OPT += -march=rv64imafdcv_zvl256b -mabi=lp64d
+FCOMMON_OPT += -march=rv64imafdcv -mabi=lp64d
+endif
 endif
 ifeq ($(CORE), RISCV64_ZVL128B)
-CCOMMON_OPT += -march=rv64imafdcv_zvfh_zfh -mabi=lp64d 
+ifeq ($(BUILD_HFLOAT16), 1)
+CCOMMON_OPT += -march=rv64imafdcv_zvfh_zfh -mabi=lp64d
 FCOMMON_OPT += -march=rv64imafdcv_zvfh_zfh -mabi=lp64d
+else
+CCOMMON_OPT += -march=rv64imafdcv -mabi=lp64d
+FCOMMON_OPT += -march=rv64imafdcv -mabi=lp64d
+endif
 endif
 ifeq ($(CORE), RISCV64_GENERIC)
 CCOMMON_OPT += -march=rv64imafdc -mabi=lp64d

--- a/driver/others/Makefile
+++ b/driver/others/Makefile
@@ -218,7 +218,7 @@ mulx.$(SUFFIX) : $(ARCH)/mulx.c
 	$(CC) $(CFLAGS) -c -DXDOUBLE -UCOMPLEX $< -o $(@F)
 
 detect_riscv64.$(SUFFIX): detect_riscv64.c
-	$(CC) $(CFLAGS) -c -march=rv64imafdcv_zvfh_zfh $< -o $(@F)
+	$(CC) $(CFLAGS) -c -march=rv64imafdcv $< -o $(@F)
 
 xerbla.$(PSUFFIX) : xerbla.c
 	$(CC) $(PFLAGS) -c $< -o $(@F)


### PR DESCRIPTION
The compiler options that enable 16 bit floating point instructions
should not be enabled by default when building the RISCV64_ZVL128B
and RISCV64_ZVL256B targets.  The zfh and zvfh extensions are not part
of the 'V' extension and are not required by any of the RVA profiles.
There's no guarantee that kernels built with zfh and zvfh will work
correctly on fully compliant RVA23U64 devices.

To fix the issue we only build the RISCV64_ZVL128B and RISCV64_ZVL256B
kernels with the half float flags if BUILD_HFLOAT16=1.  We also update
the RISC-V dynamic detection code to disable the RISCV64_ZVL128B and
RISCV64_ZVL256B kernels at runtime if we've built with DYNAMIC_ARCH=1
and BUILD_HFLOAT16=1 and are running on a device that does not support
both Zfh and Zvfh.

Fixes: https://github.com/OpenMathLib/OpenBLAS/issues/5428