### PR TITLE
fix RVV 1.0 detection code

### DIFF
--- a/driver/others/detect_riscv64.c
+++ b/driver/others/detect_riscv64.c
@@ -63,12 +63,12 @@ uint64_t detect_riscv64_rvv100(void)
 	 * RVV 1.0 and we return 0.
 	 */
 
-	asm volatile("vsetvli x0, x0, e8, m1, ta, ma\n\t"
+	asm volatile("vsetvli t0, x0, e8, m1, ta, ma\n\t"
 		     "csrr %0, vtype\n\t"
 		     "slt %0, x0, %0\n"
 		     : "=r" (rvv10_supported)
 		     :
-		     :);
+		     :"t0", "vtype");
 
 	return rvv10_supported;
 }


### PR DESCRIPTION
There were a couple of issues with the detection code used to check for RVV 1.0 on kernels that do not support hwprobe.

1. The vtype clobber was missing
2. The wrong form of vsetvli was being used. The vsetvli x0, x0 form is inappropriate for this use case as it can only be safely used in code where the value of vtype is known.  The use of vsetvli x0, x0 here can lead to a failure to detect RVV 1.0, if, for example, the vill bit happens to be set before detect_riscv64_rvv100 is called.

We fix both issues by adding the missing clobber and replacing the first parameter to vsetvli with t0 (which we add to our clobbers).