### PR TITLE
CMake: Demote the OpenMP mixed linkage check to NOTICE

### DIFF
--- a/cmake/system.cmake
+++ b/cmake/system.cmake
@@ -418,10 +418,15 @@ if (USE_OPENMP)
   if (NOT NOFORTRAN)
     find_package(OpenMP COMPONENTS Fortran REQUIRED)
     # Avoid mixed OpenMP linkage
-    get_target_property(OMP_C_LIB OpenMP::OpenMP_C INTERFACE_LINK_LIBRARIES)
-    get_target_property(OMP_Fortran_LIB OpenMP::OpenMP_Fortran INTERFACE_LINK_LIBRARIES)
-    if (NOT OMP_C_LIB STREQUAL OMP_Fortran_LIB)
-      message(FATAL_ERROR "Multiple OpenMP runtime libraries detected. Mixed OpenMP runtime linkage is dangerous. You may pass -DOpenMP_LANG_LIB_NAMES and -DOpenMP_omp_LIBRARY to manually choose the OpenMP library.")
+    get_target_property(OMP_C_LIBS OpenMP::OpenMP_C INTERFACE_LINK_LIBRARIES)
+    get_target_property(OMP_F_LIBS OpenMP::OpenMP_Fortran INTERFACE_LINK_LIBRARIES)
+    if (NOT OMP_C_LIBS STREQUAL OMP_F_LIBS)
+      message(NOTICE
+        "OpenMP runtimes detected:\n"
+        "C=${OMP_C_LIBS}\n"
+        "Fortran=${OMP_F_LIBS}\n"
+        "Please check that they are the same OpenMP runtime implementation."
+      )
     endif()
   endif ()
 endif ()

--- a/cmake/system.cmake
+++ b/cmake/system.cmake
@@ -422,10 +422,11 @@ if (USE_OPENMP)
     get_target_property(OMP_F_LIBS OpenMP::OpenMP_Fortran INTERFACE_LINK_LIBRARIES)
     if (NOT OMP_C_LIBS STREQUAL OMP_F_LIBS)
       message(NOTICE
-        "OpenMP runtimes detected:\n"
+        "CMake detected different OpenMP libraries for C and Fortran:\n"
         "C=${OMP_C_LIBS}\n"
         "Fortran=${OMP_F_LIBS}\n"
-        "Please check that they are the same OpenMP runtime implementation."
+        "In case you encounter issues, please check that this is correct.\n"
+        "You may pass -DOpenMP_<lang>_LIB_NAMES and -DOpenMP_<libname>_LIBRARY to cmake to manually force the OpenMP library."
       )
     endif()
   endif ()


### PR DESCRIPTION
Closes #5412 and #5413. If preferred, we can also remove the check altogether.