### PR TITLE
Disable bf16 flags on RISC-V unless BUILD_BFLOAT16=1

### DIFF
--- a/Makefile.riscv64
+++ b/Makefile.riscv64
@@ -11,7 +11,7 @@ ifeq ($(BUILD_HFLOAT16), 1)
 RISCV64_OPT := $(RISCV64_OPT)_zvfh_zfh
 endif
 ifeq ($(BUILD_BFLOAT16), 1)
-RISCV64_OPT := $(RISCV64_OPT)_zfbfmin_zvfbfmin_zvfbfwma
+RISCV64_OPT := $(RISCV64_OPT)_zvfbfwma
 endif
 ifeq ($(CORE), RISCV64_ZVL256B)
 CCOMMON_OPT += -march=$(RISCV64_OPT)_zvl256b -mabi=lp64d

--- a/driver/others/dynamic_riscv64.c
+++ b/driver/others/dynamic_riscv64.c
@@ -184,7 +184,7 @@ static gotoblas_t* get_coretype(void) {
 		openblas_warning(1, coremsg);
 		return NULL;
 #elif defined(BUILD_BFLOAT16)
-		snprintf(coremsg, sizeof(coremsg), "Cpu support for Zfbfmin+Zvfbfmin+Zvfbfwma extensions required due to BUILD_BFLOAT16=1\n");
+		snprintf(coremsg, sizeof(coremsg), "Cpu support for Zvfbfwma extensions required due to BUILD_BFLOAT16=1\n");
 		openblas_warning(1, coremsg);
 		return NULL;
 #else

--- a/driver/others/dynamic_riscv64.c
+++ b/driver/others/dynamic_riscv64.c
@@ -99,8 +99,6 @@ struct riscv_hwprobe {
 #define		RISCV_HWPROBE_IMA_V		(1 << 2)
 #define		RISCV_HWPROBE_EXT_ZFH		(1 << 27)
 #define		RISCV_HWPROBE_EXT_ZVFH		(1 << 30)
-#define		RISCV_HWPROBE_EXT_ZFBFMIN	(1 << 52)
-#define		RISCV_HWPROBE_EXT_ZVFBFMIN	(1 << 53)
 #define		RISCV_HWPROBE_EXT_ZVFBFWMA	(1 << 54)
 
 #ifndef NR_riscv_hwprobe
@@ -174,7 +172,7 @@ static gotoblas_t* get_coretype(void) {
 #if defined(BUILD_HFLOAT16)
 		vector_mask = (RISCV_HWPROBE_IMA_V | RISCV_HWPROBE_EXT_ZFH | RISCV_HWPROBE_EXT_ZVFH);
 #elif defined(BUILD_BFLOAT16)
-		vector_mask = (RISCV_HWPROBE_IMA_V | RISCV_HWPROBE_EXT_ZFBFMIN | RISCV_HWPROBE_EXT_ZVFBFMIN | RISCV_HWPROBE_EXT_ZVFBFWMA);
+		vector_mask = (RISCV_HWPROBE_IMA_V | RISCV_HWPROBE_EXT_ZVFBFWMA);
 #else
 		vector_mask = RISCV_HWPROBE_IMA_V;
 #endif

--- a/driver/others/dynamic_riscv64.c
+++ b/driver/others/dynamic_riscv64.c
@@ -99,6 +99,9 @@ struct riscv_hwprobe {
 #define		RISCV_HWPROBE_IMA_V		(1 << 2)
 #define		RISCV_HWPROBE_EXT_ZFH		(1 << 27)
 #define		RISCV_HWPROBE_EXT_ZVFH		(1 << 30)
+#define		RISCV_HWPROBE_EXT_ZFBFMIN	(1 << 52)
+#define		RISCV_HWPROBE_EXT_ZVFBFMIN	(1 << 53)
+#define		RISCV_HWPROBE_EXT_ZVFBFWMA	(1 << 54)
 
 #ifndef NR_riscv_hwprobe
 #ifndef NR_arch_specific_syscall
@@ -170,6 +173,8 @@ static gotoblas_t* get_coretype(void) {
 	if (ret == 0) {
 #if defined(BUILD_HFLOAT16)
 		vector_mask = (RISCV_HWPROBE_IMA_V | RISCV_HWPROBE_EXT_ZFH | RISCV_HWPROBE_EXT_ZVFH);
+#elif defined(BUILD_BFLOAT16)
+		vector_mask = (RISCV_HWPROBE_IMA_V | RISCV_HWPROBE_EXT_ZFBFMIN | RISCV_HWPROBE_EXT_ZVFBFMIN | RISCV_HWPROBE_EXT_ZVFBFWMA);
 #else
 		vector_mask = RISCV_HWPROBE_IMA_V;
 #endif
@@ -178,6 +183,10 @@ static gotoblas_t* get_coretype(void) {
 	} else {
 #if defined(BUILD_HFLOAT16)
 		snprintf(coremsg, sizeof(coremsg), "Cpu support for Zfh+Zvfh extensions required due to BUILD_HFLOAT16=1\n");
+		openblas_warning(1, coremsg);
+		return NULL;
+#elif defined(BUILD_BFLOAT16)
+		snprintf(coremsg, sizeof(coremsg), "Cpu support for Zfbfmin+Zvfbfmin+Zvfbfwma extensions required due to BUILD_BFLOAT16=1\n");
 		openblas_warning(1, coremsg);
 		return NULL;
 #else


### PR DESCRIPTION
Following the same type of changes that were made for fp16 flags on RISC-V to dynamically detect bf16 flags.

[https://github.com/OpenMathLib/OpenBLAS/pull/5431](https://github.com/OpenMathLib/OpenBLAS/pull/5431)