### PR TITLE
Use generic kernels for SCAL on POWER4/POWER5 to fix corner cases of Inf/NAN

### DIFF
--- a/kernel/power/KERNEL.POWER5
+++ b/kernel/power/KERNEL.POWER5
@@ -59,3 +59,11 @@ CROTKERNEL = ../arm/zrot.c
 ZROTKERNEL = ../arm/zrot.c
 SGEMVNKERNEL = ../arm/gemv_n.c
 SGEMVTKERNEL = ../arm/gemv_t.c
+
+SSCALKERNEL = ../arm/scal.c
+DSCALKERNEL = ../arm/scal.c
+CSCALKERNEL = ../arm/zscal.c
+ZSCALKERNEL = ../arm/zscal.c
+
+
+


### PR DESCRIPTION
fixes #5460