### PR TITLE
Fix typos in Power10 kernel

### DIFF
--- a/kernel/power/ddot_microk_power10.c
+++ b/kernel/power/ddot_microk_power10.c
@@ -119,7 +119,7 @@ static double ddot_kernel_8 (long n, double *x, double *y)
        "+b" (y)		// 3
      :
        "m" (*(const double (*)[n]) x),
-       "m" (*(const double (*)[n]) y),
+       "m" (*(const double (*)[n]) y)
      :
        "cr0",
        "vs32","vs33","vs34","vs35","vs36","vs37","vs38","vs39",

--- a/kernel/power/sasum_microk_power10.c
+++ b/kernel/power/sasum_microk_power10.c
@@ -141,7 +141,7 @@ static float sasum_kernel_32 (long n, float *x)
        "=wa" (t2),	// 5
        "=wa" (t3)	// 6
      :
-       "m" (*(const float (*)[n]) x),
+       "m" (*(const float (*)[n]) x)
      :
        "cr0",
        "vs32","vs33","vs34","vs35","vs36","vs37","vs38","vs39",

--- a/kernel/power/zaxpy_microk_power10.c
+++ b/kernel/power/zaxpy_microk_power10.c
@@ -225,7 +225,7 @@ static void zaxpy_kernel_4 (long n, double *x, double *y,
        "=b" (ytmp)	// 12
      :
        "m" (*(const double (*)[n * 2]) x),
-       "m" (*(const double (*)[2]) mvecp)
+       "m" (*(const double (*)[2]) mvecp),
 
        "d" (alpha_r),	// 15
        "d" (alpha_i),	// 16


### PR DESCRIPTION
This PR fixes typos in Power 10 kernel #5448  which is causing the recent build failure.