### PR TITLE
Fix compilation on ARM

### DIFF
--- a/kernel/arm64/ssymm_direct_alpha_beta_arm64_sme1.c
+++ b/kernel/arm64/ssymm_direct_alpha_beta_arm64_sme1.c
@@ -189,7 +189,11 @@ static void ssymm_direct_sme1_preprocessLL(uint64_t nbr, uint64_t nbc,
     }
   }
 }
-
+#else
+static void ssymm_direct_sme1_preprocessLU(uint64_t nbr, uint64_t nbc,
+                const float *restrict a, float *restrict a_mod){}
+static void ssymm_direct_sme1_preprocessLL(uint64_t nbr, uint64_t nbc,
+                const float *restrict a, float *restrict a_mod){}
 #endif
 
 //

--- a/kernel/arm64/strmm_direct_arm64_sme1.c
+++ b/kernel/arm64/strmm_direct_arm64_sme1.c
@@ -227,6 +227,8 @@ static inline void strmm_direct_alpha_sme1_2VLx2VL(uint64_t m, uint64_t k, uint6
 }
 
 #else
+void strmm_direct_sme1_preprocess(uint64_t nbr, uint64_t nbc,
+                                  const float *restrict a, float *restrict a_mod) {}
 void strmm_direct_alpha_sme1_2VLx2VL(uint64_t m, uint64_t k, uint64_t n, const float* alpha,\
                                    const float *ba, float *restrict bb){}
 #endif


### PR DESCRIPTION
Define a dummy function if SME is not supported, following what sgemm does.

Also, what's the reason for the condition on `__clang__` only? Is there known problem that is not expected to be fixable on all other compiler vendors? Why is the feature test not enough?
