### PR TITLE
fix unspecified array size in DGEMV clobber list on POWER10

### DIFF
--- a/kernel/power/dgemv_n_microk_power10.c
+++ b/kernel/power/dgemv_n_microk_power10.c
@@ -466,7 +466,7 @@ static void dgemv_kernel_4x8 (long n, double *ap, long lda, double *x, double *y
        "=b" (tmp)
      :
        "m" (*(double (*)[4]) x),
-       "m" (*(double (*)[]) ap),
+       "m" (*(double (*)[4]) ap),
        "d" (alpha),	// 14
        "r" (x),		// 15
        "3" (ap),	// 16


### PR DESCRIPTION
fixes #5489 (bug introduced by my recent clobber list rewrite)