### PR TITLE
Fix cross compilation for x86 targets from non-x86

### DIFF
--- a/getarch.c
+++ b/getarch.c
@@ -2046,10 +2046,9 @@ int main(int argc, char *argv[]){
 #endif
 
 
-#ifdef INTEL_AMD
-#ifndef FORCE
+#if defined(INTEL_AMD) && !defined(FORCE)
     get_sse();
-#else
+#elif defined(FORCE_INTEL)
 
     sprintf(buffer, "%s", ARCHCONFIG);
 
@@ -2078,7 +2077,6 @@ int main(int argc, char *argv[]){
 	printf("\n");
       } else p ++;
     }
-#endif
 #endif
 
 #if defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__


### PR DESCRIPTION
When building on a non-x86 host the Makefile definitions for HAVE_* are never printed which leads to build failures and/or silently targeting the wrong microarchitecture. The issue is that INTEL_AMD is defined if the host architecture is x86, but for cross builds we need to test whether the target is x86. Test for that using the macro FORCE_INTEL.