### PR TITLE
Fix #5521: add @SUFFIX64@ in OpenBLASConfig.cmake.in

### DIFF
--- a/cmake/OpenBLASConfig.cmake.in
+++ b/cmake/OpenBLASConfig.cmake.in
@@ -50,30 +50,30 @@ set(PN OpenBLAS)
 
 # need to check that the @USE_*@ evaluate to something cmake can perform boolean logic upon
 if(@USE_OPENMP@)
-    set(${PN}_openmp_FOUND 1)
+    set(${PN}@SUFFIX64@_openmp_FOUND 1)
 elseif(@USE_THREAD@)
-    set(${PN}_pthread_FOUND 1)
+    set(${PN}@SUFFIX64@_pthread_FOUND 1)
 else()
-    set(${PN}_serial_FOUND 1)
+    set(${PN}@SUFFIX64@_serial_FOUND 1)
 endif()
 
-check_required_components(${PN})
+check_required_components(${PN}@SUFFIX64@)
 
 #-----------------------------------------------------------------------------
 # Don't include targets if this file is being picked up by another
 # project which has already built this as a subproject
 #-----------------------------------------------------------------------------
-if(NOT TARGET ${PN}::OpenBLAS)
-    include("${CMAKE_CURRENT_LIST_DIR}/${PN}Targets.cmake")
+if(NOT TARGET ${PN}@SUFFIX64@::OpenBLAS)
+    include("${CMAKE_CURRENT_LIST_DIR}/${PN}@SUFFIX64@Targets.cmake")
 
-    get_property(_loc TARGET ${PN}::OpenBLAS PROPERTY LOCATION)
-    set(${PN}_LIBRARY ${_loc})
-    get_property(_ill TARGET ${PN}::OpenBLAS PROPERTY INTERFACE_LINK_LIBRARIES)
-    set(${PN}_LIBRARIES ${_ill})
+    get_property(_loc TARGET ${PN}@SUFFIX64@::OpenBLAS PROPERTY LOCATION)
+    set(${PN}@SUFFIX64@_LIBRARY ${_loc})
+    get_property(_ill TARGET ${PN}@SUFFIX64@::OpenBLAS PROPERTY INTERFACE_LINK_LIBRARIES)
+    set(${PN}@SUFFIX64@_LIBRARIES ${_ill})
 
-    get_property(_id TARGET ${PN}::OpenBLAS PROPERTY INCLUDE_DIRECTORIES)
-    set(${PN}_INCLUDE_DIR ${_id})
-    get_property(_iid TARGET ${PN}::OpenBLAS PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
-    set(${PN}_INCLUDE_DIRS ${_iid})
+    get_property(_id TARGET ${PN}@SUFFIX64@::OpenBLAS PROPERTY INCLUDE_DIRECTORIES)
+    set(${PN}@SUFFIX64@_INCLUDE_DIR ${_id})
+    get_property(_iid TARGET ${PN}@SUFFIX64@::OpenBLAS PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
+    set(${PN}@SUFFIX64@_INCLUDE_DIRS ${_iid})
 endif()
 


### PR DESCRIPTION
Fixes #5521

This PR updates OpenBLASConfig.cmake.in to correctly use the @SUFFIX64@ placeholder for CMake targets and variables.

When OpenBLAS is built with SUFFIX64=64, this ensures the exported CMake target is OpenBLAS64::OpenBLAS (instead of OpenBLAS::OpenBLAS).

To support ：
```
    target_link_libraries(${LIBRARY_NAME}Shared PUBLIC
        OpenBLAS64::OpenBLAS
    )
```