### PR TITLE
Prevent possible conversion from bfloat16 to __bf16 - RISC-V

### DIFF
--- a/kernel/riscv64/sbgemm_kernel_16x8_zvl256b.c
+++ b/kernel/riscv64/sbgemm_kernel_16x8_zvl256b.c
@@ -6,6 +6,8 @@ int CNAME(BLASLONG M, BLASLONG N, BLASLONG K, FLOAT alpha, IFLOAT *A, IFLOAT *B,
     BLASLONG gvl = 0;
     BLASLONG m_top = 0;
     BLASLONG n_top = 0;
+    __bf16 *BB = (__bf16 *)(B);
+    __bf16 *AA = (__bf16 *)(A);
 
     // -- MAIN PASS
     for (BLASLONG j=0; j<N/8; j+=1) {
@@ -26,17 +28,17 @@ int CNAME(BLASLONG M, BLASLONG N, BLASLONG K, FLOAT alpha, IFLOAT *A, IFLOAT *B,
             vfloat32m2_t result7 = __riscv_vfmv_v_f_f32m2(0.0f, gvl);
 
             for (BLASLONG k=0; k<K; k++) {
-                __bf16 B0 = B[bi+0];
-                __bf16 B1 = B[bi+1];
-                __bf16 B2 = B[bi+2];
-                __bf16 B3 = B[bi+3];
-                __bf16 B4 = B[bi+4];
-                __bf16 B5 = B[bi+5];
-                __bf16 B6 = B[bi+6];
-                __bf16 B7 = B[bi+7];
+                __bf16 B0 = BB[bi+0];
+                __bf16 B1 = BB[bi+1];
+                __bf16 B2 = BB[bi+2];
+                __bf16 B3 = BB[bi+3];
+                __bf16 B4 = BB[bi+4];
+                __bf16 B5 = BB[bi+5];
+                __bf16 B6 = BB[bi+6];
+                __bf16 B7 = BB[bi+7];
                 bi += 8;
 
-                vbfloat16m1_t A0 = __riscv_vle16_v_bf16m1( &A[ai+0*gvl], gvl );
+                vbfloat16m1_t A0 = __riscv_vle16_v_bf16m1( &AA[ai+0*gvl], gvl );
                 ai += 16;
 
                 result0 = __riscv_vfwmaccbf16_vf_f32m2(result0, B0, A0, gvl);
@@ -100,17 +102,17 @@ int CNAME(BLASLONG M, BLASLONG N, BLASLONG K, FLOAT alpha, IFLOAT *A, IFLOAT *B,
             vfloat32m1_t result7 = __riscv_vfmv_v_f_f32m1(0.0f, gvl);
 
             for (BLASLONG k=0; k<K; k++) {
-                __bf16 B0 = B[bi+0];
-                __bf16 B1 = B[bi+1];
-                __bf16 B2 = B[bi+2];
-                __bf16 B3 = B[bi+3];
-                __bf16 B4 = B[bi+4];
-                __bf16 B5 = B[bi+5];
-                __bf16 B6 = B[bi+6];
-                __bf16 B7 = B[bi+7];
+                __bf16 B0 = BB[bi+0];
+                __bf16 B1 = BB[bi+1];
+                __bf16 B2 = BB[bi+2];
+                __bf16 B3 = BB[bi+3];
+                __bf16 B4 = BB[bi+4];
+                __bf16 B5 = BB[bi+5];
+                __bf16 B6 = BB[bi+6];
+                __bf16 B7 = BB[bi+7];
                 bi += 8;
 
-                vbfloat16mf2_t A0 = __riscv_vle16_v_bf16mf2( &A[ai+0*gvl], gvl );
+                vbfloat16mf2_t A0 = __riscv_vle16_v_bf16mf2( &AA[ai+0*gvl], gvl );
                 ai += 8;
 
                 result0 = __riscv_vfwmaccbf16_vf_f32m1(result0, B0, A0, gvl);
@@ -172,17 +174,17 @@ int CNAME(BLASLONG M, BLASLONG N, BLASLONG K, FLOAT alpha, IFLOAT *A, IFLOAT *B,
             vfloat32m1_t result7 = __riscv_vfmv_v_f_f32m1(0.0f, gvl);
 
             for (BLASLONG k=0; k < K; ++k) {
-                __bf16 B0 = B[bi+0];
-                __bf16 B1 = B[bi+1];
-                __bf16 B2 = B[bi+2];
-                __bf16 B3 = B[bi+3];
-                __bf16 B4 = B[bi+4];
-                __bf16 B5 = B[bi+5];
-                __bf16 B6 = B[bi+6];
-                __bf16 B7 = B[bi+7];
+                __bf16 B0 = BB[bi+0];
+                __bf16 B1 = BB[bi+1];
+                __bf16 B2 = BB[bi+2];
+                __bf16 B3 = BB[bi+3];
+                __bf16 B4 = BB[bi+4];
+                __bf16 B5 = BB[bi+5];
+                __bf16 B6 = BB[bi+6];
+                __bf16 B7 = BB[bi+7];
                 bi += 8;
 
-                vbfloat16mf2_t A0 = __riscv_vle16_v_bf16mf2( &A[ai+0*gvl], gvl );
+                vbfloat16mf2_t A0 = __riscv_vle16_v_bf16mf2( &AA[ai+0*gvl], gvl );
                 ai += 4;
 
                 result0 = __riscv_vfwmaccbf16_vf_f32m1(result0, B0, A0, gvl);
@@ -256,22 +258,22 @@ int CNAME(BLASLONG M, BLASLONG N, BLASLONG K, FLOAT alpha, IFLOAT *A, IFLOAT *B,
             BLASLONG bi = n_top * K;
 
             for (BLASLONG k=0; k<K; k++) {
-                result0+=(float)(A[ai+0])*(float)(B[bi+0]);
-                result1+=(float)(A[ai+1])*(float)(B[bi+0]);
-                result2+=(float)(A[ai+0])*(float)(B[bi+1]);
-                result3+=(float)(A[ai+1])*(float)(B[bi+1]);
-                result4+=(float)(A[ai+0])*(float)(B[bi+2]);
-                result5+=(float)(A[ai+1])*(float)(B[bi+2]);
-                result6+=(float)(A[ai+0])*(float)(B[bi+3]);
-                result7+=(float)(A[ai+1])*(float)(B[bi+3]);
-                result8+=(float)(A[ai+0])*(float)(B[bi+4]);
-                result9+=(float)(A[ai+1])*(float)(B[bi+4]);
-                result10+=(float)(A[ai+0])*(float)(B[bi+5]);
-                result11+=(float)(A[ai+1])*(float)(B[bi+5]);
-                result12+=(float)(A[ai+0])*(float)(B[bi+6]);
-                result13+=(float)(A[ai+1])*(float)(B[bi+6]);
-                result14+=(float)(A[ai+0])*(float)(B[bi+7]);
-                result15+=(float)(A[ai+1])*(float)(B[bi+7]);
+                result0+=(float)(AA[ai+0])*(float)(BB[bi+0]);
+                result1+=(float)(AA[ai+1])*(float)(BB[bi+0]);
+                result2+=(float)(AA[ai+0])*(float)(BB[bi+1]);
+                result3+=(float)(AA[ai+1])*(float)(BB[bi+1]);
+                result4+=(float)(AA[ai+0])*(float)(BB[bi+2]);
+                result5+=(float)(AA[ai+1])*(float)(BB[bi+2]);
+                result6+=(float)(AA[ai+0])*(float)(BB[bi+3]);
+                result7+=(float)(AA[ai+1])*(float)(BB[bi+3]);
+                result8+=(float)(AA[ai+0])*(float)(BB[bi+4]);
+                result9+=(float)(AA[ai+1])*(float)(BB[bi+4]);
+                result10+=(float)(AA[ai+0])*(float)(BB[bi+5]);
+                result11+=(float)(AA[ai+1])*(float)(BB[bi+5]);
+                result12+=(float)(AA[ai+0])*(float)(BB[bi+6]);
+                result13+=(float)(AA[ai+1])*(float)(BB[bi+6]);
+                result14+=(float)(AA[ai+0])*(float)(BB[bi+7]);
+                result15+=(float)(AA[ai+1])*(float)(BB[bi+7]);
                 ai+=2;
                 bi+=8;
             }
@@ -314,14 +316,14 @@ int CNAME(BLASLONG M, BLASLONG N, BLASLONG K, FLOAT alpha, IFLOAT *A, IFLOAT *B,
             BLASLONG bi = n_top * K;
 
             for (BLASLONG k=0; k<K; k++) {
-                result0+=(float)(A[ai+0])*(float)(B[bi+0]);
-                result1+=(float)(A[ai+0])*(float)(B[bi+1]);
-                result2+=(float)(A[ai+0])*(float)(B[bi+2]);
-                result3+=(float)(A[ai+0])*(float)(B[bi+3]);
-                result4+=(float)(A[ai+0])*(float)(B[bi+4]);
-                result5+=(float)(A[ai+0])*(float)(B[bi+5]);
-                result6+=(float)(A[ai+0])*(float)(B[bi+6]);
-                result7+=(float)(A[ai+0])*(float)(B[bi+7]);
+                result0+=(float)(AA[ai+0])*(float)(BB[bi+0]);
+                result1+=(float)(AA[ai+0])*(float)(BB[bi+1]);
+                result2+=(float)(AA[ai+0])*(float)(BB[bi+2]);
+                result3+=(float)(AA[ai+0])*(float)(BB[bi+3]);
+                result4+=(float)(AA[ai+0])*(float)(BB[bi+4]);
+                result5+=(float)(AA[ai+0])*(float)(BB[bi+5]);
+                result6+=(float)(AA[ai+0])*(float)(BB[bi+6]);
+                result7+=(float)(AA[ai+0])*(float)(BB[bi+7]);
                 ai+=1;
                 bi+=8;
             }
@@ -354,13 +356,13 @@ int CNAME(BLASLONG M, BLASLONG N, BLASLONG K, FLOAT alpha, IFLOAT *A, IFLOAT *B,
             vfloat32m2_t result3 = __riscv_vfmv_v_f_f32m2(0.0f, gvl);
 
             for (BLASLONG k=0; k<K; k++) {
-                __bf16 B0 = B[bi+0];
-                __bf16 B1 = B[bi+1];
-                __bf16 B2 = B[bi+2];
-                __bf16 B3 = B[bi+3];
+                __bf16 B0 = BB[bi+0];
+                __bf16 B1 = BB[bi+1];
+                __bf16 B2 = BB[bi+2];
+                __bf16 B3 = BB[bi+3];
                 bi += 4;
 
-                vbfloat16m1_t A0 = __riscv_vle16_v_bf16m1( &A[ai+0*gvl], gvl );
+                vbfloat16m1_t A0 = __riscv_vle16_v_bf16m1( &AA[ai+0*gvl], gvl );
                 ai += 16;
 
                 result0 = __riscv_vfwmaccbf16_vf_f32m2(result0, B0, A0, gvl);
@@ -401,13 +403,13 @@ int CNAME(BLASLONG M, BLASLONG N, BLASLONG K, FLOAT alpha, IFLOAT *A, IFLOAT *B,
             vfloat32m1_t result3 = __riscv_vfmv_v_f_f32m1(0.0f, gvl);
 
             for (BLASLONG k=0; k<K; k++) {
-                __bf16 B0 = B[bi+0];
-                __bf16 B1 = B[bi+1];
-                __bf16 B2 = B[bi+2];
-                __bf16 B3 = B[bi+3];
+                __bf16 B0 = BB[bi+0];
+                __bf16 B1 = BB[bi+1];
+                __bf16 B2 = BB[bi+2];
+                __bf16 B3 = BB[bi+3];
                 bi += 4;
 
-                vbfloat16mf2_t A0 = __riscv_vle16_v_bf16mf2( &A[ai+0*gvl], gvl );
+                vbfloat16mf2_t A0 = __riscv_vle16_v_bf16mf2( &AA[ai+0*gvl], gvl );
                 ai += 8;
 
                 result0 = __riscv_vfwmaccbf16_vf_f32m1(result0, B0, A0, gvl);
@@ -449,13 +451,13 @@ int CNAME(BLASLONG M, BLASLONG N, BLASLONG K, FLOAT alpha, IFLOAT *A, IFLOAT *B,
             vfloat32m1_t result3 = __riscv_vfmv_v_f_f32m1(0.0f, gvl);
 
             for (BLASLONG k=0; k < K; ++k) {
-                __bf16 B0 = B[bi+0];
-                __bf16 B1 = B[bi+1];
-                __bf16 B2 = B[bi+2];
-                __bf16 B3 = B[bi+3];
+                __bf16 B0 = BB[bi+0];
+                __bf16 B1 = BB[bi+1];
+                __bf16 B2 = BB[bi+2];
+                __bf16 B3 = BB[bi+3];
                 bi += 4;
 
-                vbfloat16mf2_t A0 = __riscv_vle16_v_bf16mf2( &A[ai+0*gvl], gvl );
+                vbfloat16mf2_t A0 = __riscv_vle16_v_bf16mf2( &AA[ai+0*gvl], gvl );
                 ai += 4;
 
                 result0 = __riscv_vfwmaccbf16_vf_f32m1(result0, B0, A0, gvl);
@@ -501,14 +503,14 @@ int CNAME(BLASLONG M, BLASLONG N, BLASLONG K, FLOAT alpha, IFLOAT *A, IFLOAT *B,
             BLASLONG bi = n_top * K;
 
             for (BLASLONG k=0; k<K; k++) {
-                result0+=(float)(A[ai+0])*(float)(B[bi+0]);
-                result1+=(float)(A[ai+1])*(float)(B[bi+0]);
-                result2+=(float)(A[ai+0])*(float)(B[bi+1]);
-                result3+=(float)(A[ai+1])*(float)(B[bi+1]);
-                result4+=(float)(A[ai+0])*(float)(B[bi+2]);
-                result5+=(float)(A[ai+1])*(float)(B[bi+2]);
-                result6+=(float)(A[ai+0])*(float)(B[bi+3]);
-                result7+=(float)(A[ai+1])*(float)(B[bi+3]);
+                result0+=(float)(AA[ai+0])*(float)(BB[bi+0]);
+                result1+=(float)(AA[ai+1])*(float)(BB[bi+0]);
+                result2+=(float)(AA[ai+0])*(float)(BB[bi+1]);
+                result3+=(float)(AA[ai+1])*(float)(BB[bi+1]);
+                result4+=(float)(AA[ai+0])*(float)(BB[bi+2]);
+                result5+=(float)(AA[ai+1])*(float)(BB[bi+2]);
+                result6+=(float)(AA[ai+0])*(float)(BB[bi+3]);
+                result7+=(float)(AA[ai+1])*(float)(BB[bi+3]);
                 ai+=2;
                 bi+=4;
             }
@@ -537,10 +539,10 @@ int CNAME(BLASLONG M, BLASLONG N, BLASLONG K, FLOAT alpha, IFLOAT *A, IFLOAT *B,
             BLASLONG bi = n_top * K;
 
             for (BLASLONG k=0; k<K; k++) {
-                result0+=(float)(A[ai+0])*(float)(B[bi+0]);
-                result1+=(float)(A[ai+0])*(float)(B[bi+1]);
-                result2+=(float)(A[ai+0])*(float)(B[bi+2]);
-                result3+=(float)(A[ai+0])*(float)(B[bi+3]);
+                result0+=(float)(AA[ai+0])*(float)(BB[bi+0]);
+                result1+=(float)(AA[ai+0])*(float)(BB[bi+1]);
+                result2+=(float)(AA[ai+0])*(float)(BB[bi+2]);
+                result3+=(float)(AA[ai+0])*(float)(BB[bi+3]);
                 ai+=1;
                 bi+=4;
             }
@@ -569,11 +571,11 @@ int CNAME(BLASLONG M, BLASLONG N, BLASLONG K, FLOAT alpha, IFLOAT *A, IFLOAT *B,
             vfloat32m2_t result1 = __riscv_vfmv_v_f_f32m2(0.0f, gvl);
 
             for (BLASLONG k=0; k<K; k++) {
-                __bf16 B0 = B[bi+0];
-                __bf16 B1 = B[bi+1];
+                __bf16 B0 = BB[bi+0];
+                __bf16 B1 = BB[bi+1];
                 bi += 2;
 
-                vbfloat16m1_t A0 = __riscv_vle16_v_bf16m1( &A[ai+0*gvl], gvl );
+                vbfloat16m1_t A0 = __riscv_vle16_v_bf16m1( &AA[ai+0*gvl], gvl );
                 ai += 16;
 
                 result0 = __riscv_vfwmaccbf16_vf_f32m2(result0, B0, A0, gvl);
@@ -603,11 +605,11 @@ int CNAME(BLASLONG M, BLASLONG N, BLASLONG K, FLOAT alpha, IFLOAT *A, IFLOAT *B,
             vfloat32m1_t result1 = __riscv_vfmv_v_f_f32m1(0.0f, gvl);
 
             for (BLASLONG k=0; k<K; k++) {
-                __bf16 B0 = B[bi+0];
-                __bf16 B1 = B[bi+1];
+                __bf16 B0 = BB[bi+0];
+                __bf16 B1 = BB[bi+1];
                 bi += 2;
 
-                vbfloat16mf2_t A0 = __riscv_vle16_v_bf16mf2( &A[ai+0*gvl], gvl );
+                vbfloat16mf2_t A0 = __riscv_vle16_v_bf16mf2( &AA[ai+0*gvl], gvl );
                 ai += 8;
 
                 result0 = __riscv_vfwmaccbf16_vf_f32m1(result0, B0, A0, gvl);
@@ -639,11 +641,11 @@ int CNAME(BLASLONG M, BLASLONG N, BLASLONG K, FLOAT alpha, IFLOAT *A, IFLOAT *B,
             vfloat32m1_t result1 = __riscv_vfmv_v_f_f32m1(0.0f, gvl);
 
             for (BLASLONG k=0; k < K; ++k) {
-                __bf16 B0 = B[bi+0];
-                __bf16 B1 = B[bi+1];
+                __bf16 B0 = BB[bi+0];
+                __bf16 B1 = BB[bi+1];
                 bi += 2;
 
-                vbfloat16mf2_t A0 = __riscv_vle16_v_bf16mf2( &A[ai+0*gvl], gvl );
+                vbfloat16mf2_t A0 = __riscv_vle16_v_bf16mf2( &AA[ai+0*gvl], gvl );
                 ai += 4;
 
                 result0 = __riscv_vfwmaccbf16_vf_f32m1(result0, B0, A0, gvl);
@@ -675,10 +677,10 @@ int CNAME(BLASLONG M, BLASLONG N, BLASLONG K, FLOAT alpha, IFLOAT *A, IFLOAT *B,
             BLASLONG bi = n_top * K;
 
             for (BLASLONG k=0; k<K; k++) {
-                result0+=(float)(A[ai+0])*(float)(B[bi+0]);
-                result1+=(float)(A[ai+1])*(float)(B[bi+0]);
-                result2+=(float)(A[ai+0])*(float)(B[bi+1]);
-                result3+=(float)(A[ai+1])*(float)(B[bi+1]);
+                result0+=(float)(AA[ai+0])*(float)(BB[bi+0]);
+                result1+=(float)(AA[ai+1])*(float)(BB[bi+0]);
+                result2+=(float)(AA[ai+0])*(float)(BB[bi+1]);
+                result3+=(float)(AA[ai+1])*(float)(BB[bi+1]);
                 ai+=2;
                 bi+=2;
             }
@@ -701,8 +703,8 @@ int CNAME(BLASLONG M, BLASLONG N, BLASLONG K, FLOAT alpha, IFLOAT *A, IFLOAT *B,
             BLASLONG bi = n_top * K;
 
             for (BLASLONG k=0; k<K; k++) {
-                result0+=(float)(A[ai+0])*(float)(B[bi+0]);
-                result1+=(float)(A[ai+0])*(float)(B[bi+1]);
+                result0+=(float)(AA[ai+0])*(float)(BB[bi+0]);
+                result1+=(float)(AA[ai+0])*(float)(BB[bi+1]);
                 ai+=1;
                 bi+=2;
             }
@@ -728,10 +730,10 @@ int CNAME(BLASLONG M, BLASLONG N, BLASLONG K, FLOAT alpha, IFLOAT *A, IFLOAT *B,
             vfloat32m2_t result0 = __riscv_vfmv_v_f_f32m2(0.0f, gvl);
 
             for (BLASLONG k=0; k<K; k++) {
-                __bf16 B0 = B[bi+0];
+                __bf16 B0 = BB[bi+0];
                 bi += 1;
 
-                vbfloat16m1_t A0 = __riscv_vle16_v_bf16m1( &A[ai+0*gvl], gvl );
+                vbfloat16m1_t A0 = __riscv_vle16_v_bf16m1( &AA[ai+0*gvl], gvl );
                 ai += 16;
 
                 result0 = __riscv_vfwmaccbf16_vf_f32m2(result0, B0, A0, gvl);
@@ -757,10 +759,10 @@ int CNAME(BLASLONG M, BLASLONG N, BLASLONG K, FLOAT alpha, IFLOAT *A, IFLOAT *B,
             vfloat32m1_t result0 = __riscv_vfmv_v_f_f32m1(0.0f, gvl);
 
             for (BLASLONG k=0; k<K; k++) {
-                __bf16 B0 = B[bi+0];
+                __bf16 B0 = BB[bi+0];
                 bi += 1;
 
-                vbfloat16mf2_t A0 = __riscv_vle16_v_bf16mf2( &A[ai+0*gvl], gvl );
+                vbfloat16mf2_t A0 = __riscv_vle16_v_bf16mf2( &AA[ai+0*gvl], gvl );
                 ai += 8;
 
                 result0 = __riscv_vfwmaccbf16_vf_f32m1(result0, B0, A0, gvl);
@@ -787,10 +789,10 @@ int CNAME(BLASLONG M, BLASLONG N, BLASLONG K, FLOAT alpha, IFLOAT *A, IFLOAT *B,
             vfloat32m1_t result0 = __riscv_vfmv_v_f_f32m1(0.0f, gvl);
 
             for (BLASLONG k=0; k < K; ++k) {
-                __bf16 B0 = B[bi+0];
+                __bf16 B0 = BB[bi+0];
                 bi += 1;
 
-                vbfloat16mf2_t A0 = __riscv_vle16_v_bf16mf2( &A[ai+0*gvl], gvl );
+                vbfloat16mf2_t A0 = __riscv_vle16_v_bf16mf2( &AA[ai+0*gvl], gvl );
                 ai += 4;
 
                 result0 = __riscv_vfwmaccbf16_vf_f32m1(result0, B0, A0, gvl);
@@ -814,8 +816,8 @@ int CNAME(BLASLONG M, BLASLONG N, BLASLONG K, FLOAT alpha, IFLOAT *A, IFLOAT *B,
             BLASLONG bi = n_top * K;
 
             for (BLASLONG k=0; k<K; k++) {
-                result0+=(float)(A[ai+0])*(float)(B[bi+0]);
-                result1+=(float)(A[ai+1])*(float)(B[bi+0]);
+                result0+=(float)(AA[ai+0])*(float)(BB[bi+0]);
+                result1+=(float)(AA[ai+1])*(float)(BB[bi+0]);
                 ai+=2;
                 bi+=1;
             }
@@ -835,7 +837,7 @@ int CNAME(BLASLONG M, BLASLONG N, BLASLONG K, FLOAT alpha, IFLOAT *A, IFLOAT *B,
             BLASLONG bi = n_top * K;
 
             for (BLASLONG k=0; k<K; k++) {
-                result0+=(float)(A[ai+0])*(float)(B[bi+0]);
+                result0+=(float)(AA[ai+0])*(float)(BB[bi+0]);
                 ai+=1;
                 bi+=1;
             }

--- a/kernel/riscv64/sbgemm_kernel_8x8_zvl128b.c
+++ b/kernel/riscv64/sbgemm_kernel_8x8_zvl128b.c
@@ -6,6 +6,8 @@ int CNAME(BLASLONG M, BLASLONG N, BLASLONG K, FLOAT alpha, IFLOAT *A, IFLOAT *B,
     BLASLONG gvl = 0;
     BLASLONG m_top = 0;
     BLASLONG n_top = 0;
+    __bf16 *BB = (__bf16 *)(B);
+    __bf16 *AA = (__bf16 *)(A);
 
     // -- MAIN PASS
     for (BLASLONG j=0; j<N/8; j+=1) {
@@ -26,17 +28,17 @@ int CNAME(BLASLONG M, BLASLONG N, BLASLONG K, FLOAT alpha, IFLOAT *A, IFLOAT *B,
             vfloat32m2_t result7 = __riscv_vfmv_v_f_f32m2(0.0f, gvl);
 
             for (BLASLONG k=0; k<K; k++) {
-                __bf16 B0 = B[bi+0];
-                __bf16 B1 = B[bi+1];
-                __bf16 B2 = B[bi+2];
-                __bf16 B3 = B[bi+3];
-                __bf16 B4 = B[bi+4];
-                __bf16 B5 = B[bi+5];
-                __bf16 B6 = B[bi+6];
-                __bf16 B7 = B[bi+7];
+                __bf16 B0 = BB[bi+0];
+                __bf16 B1 = BB[bi+1];
+                __bf16 B2 = BB[bi+2];
+                __bf16 B3 = BB[bi+3];
+                __bf16 B4 = BB[bi+4];
+                __bf16 B5 = BB[bi+5];
+                __bf16 B6 = BB[bi+6];
+                __bf16 B7 = BB[bi+7];
                 bi += 8;
 
-                vbfloat16m1_t A0 = __riscv_vle16_v_bf16m1( &A[ai+0*gvl], gvl );
+                vbfloat16m1_t A0 = __riscv_vle16_v_bf16m1( &AA[ai+0*gvl], gvl );
                 ai += 8;
 
                 result0 = __riscv_vfwmaccbf16_vf_f32m2(result0, B0, A0, gvl);
@@ -100,17 +102,17 @@ int CNAME(BLASLONG M, BLASLONG N, BLASLONG K, FLOAT alpha, IFLOAT *A, IFLOAT *B,
             vfloat32m1_t result7 = __riscv_vfmv_v_f_f32m1(0.0f, gvl);
 
             for (BLASLONG k=0; k < K; ++k) {
-                __bf16 B0 = B[bi+0];
-                __bf16 B1 = B[bi+1];
-                __bf16 B2 = B[bi+2];
-                __bf16 B3 = B[bi+3];
-                __bf16 B4 = B[bi+4];
-                __bf16 B5 = B[bi+5];
-                __bf16 B6 = B[bi+6];
-                __bf16 B7 = B[bi+7];
+                __bf16 B0 = BB[bi+0];
+                __bf16 B1 = BB[bi+1];
+                __bf16 B2 = BB[bi+2];
+                __bf16 B3 = BB[bi+3];
+                __bf16 B4 = BB[bi+4];
+                __bf16 B5 = BB[bi+5];
+                __bf16 B6 = BB[bi+6];
+                __bf16 B7 = BB[bi+7];
                 bi += 8;
 
-                vbfloat16mf2_t A0 = __riscv_vle16_v_bf16mf2(&A[ai + 0 * gvl], gvl);
+                vbfloat16mf2_t A0 = __riscv_vle16_v_bf16mf2(&AA[ai + 0 * gvl], gvl);
                 ai += 4;
 
                 result0 = __riscv_vfwmaccbf16_vf_f32m1(result0, B0, A0, gvl);
@@ -186,22 +188,22 @@ int CNAME(BLASLONG M, BLASLONG N, BLASLONG K, FLOAT alpha, IFLOAT *A, IFLOAT *B,
             float result15 = 0;
 
             for (BLASLONG k=0; k<K; k++) {
-                result0+=(float)(A[ai+0])*(float)(B[bi+0]);
-                result1+=(float)(A[ai+1])*(float)(B[bi+0]);
-                result2+=(float)(A[ai+0])*(float)(B[bi+1]);
-                result3+=(float)(A[ai+1])*(float)(B[bi+1]);
-                result4+=(float)(A[ai+0])*(float)(B[bi+2]);
-                result5+=(float)(A[ai+1])*(float)(B[bi+2]);
-                result6+=(float)(A[ai+0])*(float)(B[bi+3]);
-                result7+=(float)(A[ai+1])*(float)(B[bi+3]);
-                result8+=(float)(A[ai+0])*(float)(B[bi+4]);
-                result9+=(float)(A[ai+1])*(float)(B[bi+4]);
-                result10+=(float)(A[ai+0])*(float)(B[bi+5]);
-                result11+=(float)(A[ai+1])*(float)(B[bi+5]);
-                result12+=(float)(A[ai+0])*(float)(B[bi+6]);
-                result13+=(float)(A[ai+1])*(float)(B[bi+6]);
-                result14+=(float)(A[ai+0])*(float)(B[bi+7]);
-                result15+=(float)(A[ai+1])*(float)(B[bi+7]);
+                result0+=(float)(AA[ai+0])*(float)(BB[bi+0]);
+                result1+=(float)(AA[ai+1])*(float)(BB[bi+0]);
+                result2+=(float)(AA[ai+0])*(float)(BB[bi+1]);
+                result3+=(float)(AA[ai+1])*(float)(BB[bi+1]);
+                result4+=(float)(AA[ai+0])*(float)(BB[bi+2]);
+                result5+=(float)(AA[ai+1])*(float)(BB[bi+2]);
+                result6+=(float)(AA[ai+0])*(float)(BB[bi+3]);
+                result7+=(float)(AA[ai+1])*(float)(BB[bi+3]);
+                result8+=(float)(AA[ai+0])*(float)(BB[bi+4]);
+                result9+=(float)(AA[ai+1])*(float)(BB[bi+4]);
+                result10+=(float)(AA[ai+0])*(float)(BB[bi+5]);
+                result11+=(float)(AA[ai+1])*(float)(BB[bi+5]);
+                result12+=(float)(AA[ai+0])*(float)(BB[bi+6]);
+                result13+=(float)(AA[ai+1])*(float)(BB[bi+6]);
+                result14+=(float)(AA[ai+0])*(float)(BB[bi+7]);
+                result15+=(float)(AA[ai+1])*(float)(BB[bi+7]);
                 ai+=2;
                 bi+=8;
             }
@@ -242,14 +244,14 @@ int CNAME(BLASLONG M, BLASLONG N, BLASLONG K, FLOAT alpha, IFLOAT *A, IFLOAT *B,
             BLASLONG bi = n_top * K;
 
             for (BLASLONG k=0; k<K; k++) {
-                result0+=(float)(A[ai+0])*(float)(B[bi+0]);
-                result1+=(float)(A[ai+0])*(float)(B[bi+1]);
-                result2+=(float)(A[ai+0])*(float)(B[bi+2]);
-                result3+=(float)(A[ai+0])*(float)(B[bi+3]);
-                result4+=(float)(A[ai+0])*(float)(B[bi+4]);
-                result5+=(float)(A[ai+0])*(float)(B[bi+5]);
-                result6+=(float)(A[ai+0])*(float)(B[bi+6]);
-                result7+=(float)(A[ai+0])*(float)(B[bi+7]);
+                result0+=(float)(AA[ai+0])*(float)(BB[bi+0]);
+                result1+=(float)(AA[ai+0])*(float)(BB[bi+1]);
+                result2+=(float)(AA[ai+0])*(float)(BB[bi+2]);
+                result3+=(float)(AA[ai+0])*(float)(BB[bi+3]);
+                result4+=(float)(AA[ai+0])*(float)(BB[bi+4]);
+                result5+=(float)(AA[ai+0])*(float)(BB[bi+5]);
+                result6+=(float)(AA[ai+0])*(float)(BB[bi+6]);
+                result7+=(float)(AA[ai+0])*(float)(BB[bi+7]);
                 ai+=1;
                 bi+=8;
             }
@@ -284,13 +286,13 @@ int CNAME(BLASLONG M, BLASLONG N, BLASLONG K, FLOAT alpha, IFLOAT *A, IFLOAT *B,
             vfloat32m2_t result3 = __riscv_vfmv_v_f_f32m2(0.0f, gvl);
 
             for (BLASLONG k=0; k<K; k++) {
-                __bf16 B0 = B[bi+0];
-                __bf16 B1 = B[bi+1];
-                __bf16 B2 = B[bi+2];
-                __bf16 B3 = B[bi+3];
+                __bf16 B0 = BB[bi+0];
+                __bf16 B1 = BB[bi+1];
+                __bf16 B2 = BB[bi+2];
+                __bf16 B3 = BB[bi+3];
                 bi += 4;
 
-                vbfloat16m1_t A0 = __riscv_vle16_v_bf16m1( &A[ai+0*gvl], gvl );
+                vbfloat16m1_t A0 = __riscv_vle16_v_bf16m1( &AA[ai+0*gvl], gvl );
                 ai += 8;
 
                 result0 = __riscv_vfwmaccbf16_vf_f32m2(result0, B0, A0, gvl);
@@ -332,13 +334,13 @@ int CNAME(BLASLONG M, BLASLONG N, BLASLONG K, FLOAT alpha, IFLOAT *A, IFLOAT *B,
             vfloat32m1_t result3 = __riscv_vfmv_v_f_f32m1(0.0f, gvl);
 
             for (BLASLONG k=0; k < K; ++k) {
-                __bf16 B0 = B[bi+0];
-                __bf16 B1 = B[bi+1];
-                __bf16 B2 = B[bi+2];
-                __bf16 B3 = B[bi+3];
+                __bf16 B0 = BB[bi+0];
+                __bf16 B1 = BB[bi+1];
+                __bf16 B2 = BB[bi+2];
+                __bf16 B3 = BB[bi+3];
                 bi += 4;
 
-                vbfloat16mf2_t A0 = __riscv_vle16_v_bf16mf2(&A[ai + 0 * gvl], gvl);
+                vbfloat16mf2_t A0 = __riscv_vle16_v_bf16mf2(&AA[ai + 0 * gvl], gvl);
                 ai += 4;
 
                 result0 = __riscv_vfwmaccbf16_vf_f32m1(result0, B0, A0, gvl);
@@ -386,14 +388,14 @@ int CNAME(BLASLONG M, BLASLONG N, BLASLONG K, FLOAT alpha, IFLOAT *A, IFLOAT *B,
             float result7 = 0;
 
             for (BLASLONG k=0; k<K; k++) {
-                result0+=(float)(A[ai+0])*(float)(B[bi+0]);
-                result1+=(float)(A[ai+1])*(float)(B[bi+0]);
-                result2+=(float)(A[ai+0])*(float)(B[bi+1]);
-                result3+=(float)(A[ai+1])*(float)(B[bi+1]);
-                result4+=(float)(A[ai+0])*(float)(B[bi+2]);
-                result5+=(float)(A[ai+1])*(float)(B[bi+2]);
-                result6+=(float)(A[ai+0])*(float)(B[bi+3]);
-                result7+=(float)(A[ai+1])*(float)(B[bi+3]);
+                result0+=(float)(AA[ai+0])*(float)(BB[bi+0]);
+                result1+=(float)(AA[ai+1])*(float)(BB[bi+0]);
+                result2+=(float)(AA[ai+0])*(float)(BB[bi+1]);
+                result3+=(float)(AA[ai+1])*(float)(BB[bi+1]);
+                result4+=(float)(AA[ai+0])*(float)(BB[bi+2]);
+                result5+=(float)(AA[ai+1])*(float)(BB[bi+2]);
+                result6+=(float)(AA[ai+0])*(float)(BB[bi+3]);
+                result7+=(float)(AA[ai+1])*(float)(BB[bi+3]);
                 ai+=2;
                 bi+=4;
             }
@@ -422,10 +424,10 @@ int CNAME(BLASLONG M, BLASLONG N, BLASLONG K, FLOAT alpha, IFLOAT *A, IFLOAT *B,
             BLASLONG bi = n_top * K;
 
             for (BLASLONG k=0; k<K; k++) {
-                result0+=(float)(A[ai+0])*(float)(B[bi+0]);
-                result1+=(float)(A[ai+0])*(float)(B[bi+1]);
-                result2+=(float)(A[ai+0])*(float)(B[bi+2]);
-                result3+=(float)(A[ai+0])*(float)(B[bi+3]);
+                result0+=(float)(AA[ai+0])*(float)(BB[bi+0]);
+                result1+=(float)(AA[ai+0])*(float)(BB[bi+1]);
+                result2+=(float)(AA[ai+0])*(float)(BB[bi+2]);
+                result3+=(float)(AA[ai+0])*(float)(BB[bi+3]);
                 ai+=1;
                 bi+=4;
             }
@@ -454,11 +456,11 @@ int CNAME(BLASLONG M, BLASLONG N, BLASLONG K, FLOAT alpha, IFLOAT *A, IFLOAT *B,
             vfloat32m2_t result1 = __riscv_vfmv_v_f_f32m2(0.0f, gvl);
 
             for (BLASLONG k=0; k<K; k++) {
-                __bf16 B0 = B[bi+0];
-                __bf16 B1 = B[bi+1];
+                __bf16 B0 = BB[bi+0];
+                __bf16 B1 = BB[bi+1];
                 bi += 2;
 
-                vbfloat16m1_t A0 = __riscv_vle16_v_bf16m1( &A[ai+0*gvl], gvl );
+                vbfloat16m1_t A0 = __riscv_vle16_v_bf16m1( &AA[ai+0*gvl], gvl );
                 ai += 8;
 
                 result0 = __riscv_vfwmaccbf16_vf_f32m2(result0, B0, A0, gvl);
@@ -490,11 +492,11 @@ int CNAME(BLASLONG M, BLASLONG N, BLASLONG K, FLOAT alpha, IFLOAT *A, IFLOAT *B,
             vfloat32m1_t result1 = __riscv_vfmv_v_f_f32m1(0.0f, gvl);
 
             for (BLASLONG k=0; k < K; ++k) {
-                __bf16 B0 = B[bi+0];
-                __bf16 B1 = B[bi+1];
+                __bf16 B0 = BB[bi+0];
+                __bf16 B1 = BB[bi+1];
                 bi += 2;
 
-                vbfloat16mf2_t A0 = __riscv_vle16_v_bf16mf2(&A[ai + 0 * gvl], gvl);
+                vbfloat16mf2_t A0 = __riscv_vle16_v_bf16mf2(&AA[ai + 0 * gvl], gvl);
                 ai += 4;
 
                 result0 = __riscv_vfwmaccbf16_vf_f32m1(result0, B0, A0, gvl);
@@ -528,10 +530,10 @@ int CNAME(BLASLONG M, BLASLONG N, BLASLONG K, FLOAT alpha, IFLOAT *A, IFLOAT *B,
             float result3 = 0;
 
             for (BLASLONG k=0; k<K; k++) {
-                result0+=(float)(A[ai+0])*(float)(B[bi+0]);
-                result1+=(float)(A[ai+1])*(float)(B[bi+0]);
-                result2+=(float)(A[ai+0])*(float)(B[bi+1]);
-                result3+=(float)(A[ai+1])*(float)(B[bi+1]);
+                result0+=(float)(AA[ai+0])*(float)(BB[bi+0]);
+                result1+=(float)(AA[ai+1])*(float)(BB[bi+0]);
+                result2+=(float)(AA[ai+0])*(float)(BB[bi+1]);
+                result3+=(float)(AA[ai+1])*(float)(BB[bi+1]);
                 ai+=2;
                 bi+=2;
             }
@@ -555,8 +557,8 @@ int CNAME(BLASLONG M, BLASLONG N, BLASLONG K, FLOAT alpha, IFLOAT *A, IFLOAT *B,
             BLASLONG bi = n_top * K;
 
             for (BLASLONG k=0; k<K; k++) {
-                result0+=(float)(A[ai+0])*(float)(B[bi+0]);
-                result1+=(float)(A[ai+0])*(float)(B[bi+1]);
+                result0+=(float)(AA[ai+0])*(float)(BB[bi+0]);
+                result1+=(float)(AA[ai+0])*(float)(BB[bi+1]);
                 ai+=1;
                 bi+=2;
             }
@@ -582,10 +584,10 @@ int CNAME(BLASLONG M, BLASLONG N, BLASLONG K, FLOAT alpha, IFLOAT *A, IFLOAT *B,
             vfloat32m2_t result0 = __riscv_vfmv_v_f_f32m2(0.0f, gvl);
 
             for (BLASLONG k=0; k<K; k++) {
-                __bf16 B0 = B[bi+0];
+                __bf16 B0 = BB[bi+0];
                 bi += 1;
 
-                vbfloat16m1_t A0 = __riscv_vle16_v_bf16m1( &A[ai+0*gvl], gvl );
+                vbfloat16m1_t A0 = __riscv_vle16_v_bf16m1( &AA[ai+0*gvl], gvl );
                 ai += 8;
 
                 result0 = __riscv_vfwmaccbf16_vf_f32m2(result0, B0, A0, gvl);
@@ -612,10 +614,10 @@ int CNAME(BLASLONG M, BLASLONG N, BLASLONG K, FLOAT alpha, IFLOAT *A, IFLOAT *B,
             vfloat32m1_t result0 = __riscv_vfmv_v_f_f32m1(0.0f, gvl);
 
             for (BLASLONG k=0; k < K; ++k) {
-                __bf16 B0 = B[bi+0];
+                __bf16 B0 = BB[bi+0];
                 bi += 1;
 
-                vbfloat16mf2_t A0 = __riscv_vle16_v_bf16mf2(&A[ai + 0 * gvl], gvl);
+                vbfloat16mf2_t A0 = __riscv_vle16_v_bf16mf2(&AA[ai + 0 * gvl], gvl);
                 ai += 4;
 
                 result0 = __riscv_vfwmaccbf16_vf_f32m1(result0, B0, A0, gvl);
@@ -641,8 +643,8 @@ int CNAME(BLASLONG M, BLASLONG N, BLASLONG K, FLOAT alpha, IFLOAT *A, IFLOAT *B,
             float result1 = 0;
 
             for (BLASLONG k=0; k<K; k++) {
-                result0+=(float)(A[ai+0])*(float)(B[bi+0]);
-                result1+=(float)(A[ai+1])*(float)(B[bi+0]);
+                result0+=(float)(AA[ai+0])*(float)(BB[bi+0]);
+                result1+=(float)(AA[ai+1])*(float)(BB[bi+0]);
                 ai+=2;
                 bi+=1;
             }
@@ -662,7 +664,7 @@ int CNAME(BLASLONG M, BLASLONG N, BLASLONG K, FLOAT alpha, IFLOAT *A, IFLOAT *B,
             BLASLONG bi = n_top * K;
 
             for (BLASLONG k=0; k<K; k++) {
-                result0+=(float)(A[ai+0])*(float)(B[bi+0]);
+                result0+=(float)(AA[ai+0])*(float)(BB[bi+0]);
                 ai+=1;
                 bi+=1;
             }

--- a/kernel/riscv64/sbgemv_n_vector.c
+++ b/kernel/riscv64/sbgemv_n_vector.c
@@ -51,7 +51,13 @@ int CNAME(BLASLONG m, BLASLONG n, FLOAT alpha, IFLOAT *a, BLASLONG lda, IFLOAT *
 {
     if (n < 0) return(0);
 
-    IFLOAT *a_ptr, temp;
+#if defined(HFLOAT16)
+    _Float16 *a_ptr, *x_ptr, temp;
+    x_ptr = (_Float16 *)(x);
+#else
+    __bf16 *a_ptr, *x_ptr, temp;
+    x_ptr = (__bf16 *)(x);
+#endif
     FLOAT *y_ptr;
     BLASLONG i, j, vl;
     IFLOAT_V_T va;
@@ -76,9 +82,14 @@ int CNAME(BLASLONG m, BLASLONG n, FLOAT alpha, IFLOAT *a, BLASLONG lda, IFLOAT *
             }
         }
         for (j = 0; j < n; j++) {
-            temp = (IFLOAT)(alpha * (FLOAT)(x[0]));
+#if defined(HFLOAT16)
+            temp = (_Float16)(alpha * (FLOAT)(x_ptr[0]));
+            a_ptr = (_Float16 *)(a);
+#else
+            temp = (__bf16)(alpha * (FLOAT)(x_ptr[0]));
+            a_ptr = (__bf16 *)(a);
+#endif
             y_ptr = y;
-            a_ptr = a;
             for (i = m; i > 0; i -= vl) {
                 vl = VSETVL(i);
                 vy = VLEV_FLOAT(y_ptr, vl);
@@ -88,7 +99,7 @@ int CNAME(BLASLONG m, BLASLONG n, FLOAT alpha, IFLOAT *a, BLASLONG lda, IFLOAT *
                 y_ptr += vl;
                 a_ptr += vl;
             }
-            x += inc_x;
+            x_ptr += inc_x;
             a += lda;
         }
     } else {
@@ -110,9 +121,14 @@ int CNAME(BLASLONG m, BLASLONG n, FLOAT alpha, IFLOAT *a, BLASLONG lda, IFLOAT *
             }
         }
         for (j = 0; j < n; j++) {
-            temp = (IFLOAT)(alpha * (FLOAT)(x[0]));
+#if defined(HFLOAT16)
+            temp = (_Float16)(alpha * (FLOAT)(x_ptr[0]));
+            a_ptr = (_Float16 *)(a);
+#else
+            temp = (__bf16)(alpha * (FLOAT)(x_ptr[0]));
+            a_ptr = (__bf16 *)(a);
+#endif
             y_ptr = y;
-            a_ptr = a;
             for (i = m; i > 0; i -= vl) {
                 vl = VSETVL(i);
                 vy = VLSEV_FLOAT(y_ptr, stride_y, vl);
@@ -122,7 +138,7 @@ int CNAME(BLASLONG m, BLASLONG n, FLOAT alpha, IFLOAT *a, BLASLONG lda, IFLOAT *
                 y_ptr += vl * inc_y;
                 a_ptr += vl;
             }
-            x += inc_x;
+            x_ptr += inc_x;
             a += lda;
         }
     }

--- a/kernel/riscv64/sbgemv_t_vector.c
+++ b/kernel/riscv64/sbgemv_t_vector.c
@@ -58,7 +58,11 @@ int CNAME(BLASLONG m, BLASLONG n, FLOAT alpha, IFLOAT *a, BLASLONG lda, IFLOAT *
 {
     BLASLONG i = 0, j = 0, k = 0;
     BLASLONG ix = 0, iy = 0;
-    IFLOAT *a_ptr = a;
+#if defined(HFLOAT16)
+    _Float16 *a_ptr = (_Float16 *)(a);
+#else
+    __bf16 *a_ptr = (__bf16 *)(a);
+#endif
     FLOAT temp;
 
     IFLOAT_V_T va, vx;

--- a/kernel/riscv64/sbgemv_t_vector.c
+++ b/kernel/riscv64/sbgemv_t_vector.c
@@ -60,8 +60,10 @@ int CNAME(BLASLONG m, BLASLONG n, FLOAT alpha, IFLOAT *a, BLASLONG lda, IFLOAT *
     BLASLONG ix = 0, iy = 0;
 #if defined(HFLOAT16)
     _Float16 *a_ptr = (_Float16 *)(a);
+    _Float16 *x_ptr = (_Float16 *)(x);
 #else
     __bf16 *a_ptr = (__bf16 *)(a);
+    __bf16 *x_ptr = (__bf16 *)(x);
 #endif
     FLOAT temp;
 
@@ -83,7 +85,7 @@ int CNAME(BLASLONG m, BLASLONG n, FLOAT alpha, IFLOAT *a, BLASLONG lda, IFLOAT *
 #endif
             for (k = 0; k < m/gvl; k++) {
                 va = VLEV_IFLOAT(&a_ptr[j], gvl);
-                vx = VLEV_IFLOAT(&x[j], gvl);
+                vx = VLEV_IFLOAT(&x_ptr[j], gvl);
                 vr = VFMACCVV_FLOAT(vz, va, vx, gvl);           // could vfmacc here and reduce outside loop
                 v_res = VFREDSUM_FLOAT(vr, v_res, gvl);         // but that reordering diverges far enough from scalar path to make tests fail
                 j += gvl;
@@ -91,7 +93,7 @@ int CNAME(BLASLONG m, BLASLONG n, FLOAT alpha, IFLOAT *a, BLASLONG lda, IFLOAT *
             if (j < m) {
                 gvl = VSETVL(m-j);
                 va = VLEV_IFLOAT(&a_ptr[j], gvl);
-                vx = VLEV_IFLOAT(&x[j], gvl);
+                vx = VLEV_IFLOAT(&x_ptr[j], gvl);
                 vr = VFMACCVV_FLOAT(vz, va, vx, gvl);
                 v_res = VFREDSUM_FLOAT(vr, v_res, gvl);
             }
@@ -113,7 +115,7 @@ int CNAME(BLASLONG m, BLASLONG n, FLOAT alpha, IFLOAT *a, BLASLONG lda, IFLOAT *
 #endif
             for (k = 0; k < m/gvl; k++) {
                 va = VLEV_IFLOAT(&a_ptr[j], gvl);
-                vx = VLSEV_IFLOAT(&x[ix], stride_x, gvl);
+                vx = VLSEV_IFLOAT(&x_ptr[ix], stride_x, gvl);
                 vr = VFMACCVV_FLOAT(vz, va, vx, gvl);
                 v_res = VFREDSUM_FLOAT(vr, v_res, gvl);
                 j += gvl;
@@ -122,7 +124,7 @@ int CNAME(BLASLONG m, BLASLONG n, FLOAT alpha, IFLOAT *a, BLASLONG lda, IFLOAT *
             if (j < m) {
                 gvl = VSETVL(m-j);
                 va = VLEV_IFLOAT(&a_ptr[j], gvl);
-                vx = VLSEV_IFLOAT(&x[ix], stride_x, gvl);
+                vx = VLSEV_IFLOAT(&x_ptr[ix], stride_x, gvl);
                 vr = VFMACCVV_FLOAT(vz, va, vx, gvl);
                 v_res = VFREDSUM_FLOAT(vr, v_res, gvl);
             }


### PR DESCRIPTION
Prevent possible conversion from bfloat16 to __bf16