### PR TITLE
Docs: OMP_NUM_THREADS also affects non-OpenMP builds

### DIFF
--- a/docs/runtime_variables.md
+++ b/docs/runtime_variables.md
@@ -2,8 +2,9 @@ OpenBLAS checks the following environment variables on startup:
 
 * `OPENBLAS_NUM_THREADS`: the number of threads to use (for non-OpenMP builds
   of OpenBLAS)
-* `OMP_NUM_THREADS`: the number of threads to use (for OpenMP builds - note
-  that setting this may also affect any other OpenMP code)
+* `OMP_NUM_THREADS`: the number of threads to use (for OpenMP builds, and as a
+  fallback for pthreads builds - note that setting this may also affect any
+  other OpenMP code)
 * `OPENBLAS_DEFAULT_NUM_THREADS`: the number of threads to use, irrespective if
   OpenBLAS was built for OpenMP or pthreads
 


### PR DESCRIPTION
I had a brief bit of confusion because the docs suggested that `OMP_NUM_THREADS` would only affect OpenMP builds, when actually it's used as a fallback in non-OpenMP builds as well.

https://github.com/OpenMathLib/OpenBLAS/blob/3a9da520d57c220a8fb3cf4166e1e77d73936566/driver/others/init.c#L825-L834