### PR TITLE
Fix f_check detection of LLVM 21 flang

### DIFF
--- a/f_check
+++ b/f_check
@@ -92,7 +92,7 @@ else
 		vendor=FLANG
 		openmp='-fopenmp'
 		;;	
-            *GNU*|*GCC*)
+            *GCC*)
 
                 v="${data#*GCC: *\) }"
                 v="${v%%\"*}"


### PR DESCRIPTION
The check for GCC is confused by the GNU-stack in

```
	.file	"FIRModule"
	.text
	.globl	zhoge_
	.p2align	4
	.type	zhoge_,@function
zhoge_:
	xorps	%xmm0, %xmm0
	xorps	%xmm1, %xmm1
	retq
.Lfunc_end0:
	.size	zhoge_, .Lfunc_end0-zhoge_

	.ident	"flang version 21.1.5"
	.section	".note.GNU-stack","",@progbits
```

And displays:
```
./f_check: line 102: [: 	: integer expression expected
```

Since it expects a string with GCC anyway, better to only match GCC and not GNU.