### PR TITLE
fix: dot_kernel_sve "n" usage & clobber list

### DIFF
--- a/.github/workflows/dynamic_arch.yml
+++ b/.github/workflows/dynamic_arch.yml
@@ -1,6 +1,6 @@
 name: continuous build
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -11,17 +11,24 @@ permissions:
 
 jobs:
   build:
-    if: "github.repository == 'OpenMathLib/OpenBLAS'"
+    if: "github.repository == 'OpenMathLib/OpenBLAS' || github.event_name == 'workflow_dispatch'"
     runs-on: ${{ matrix.os }}
 
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, ubuntu-24.04-arm]
+        cc: [gcc, clang, clang-21]
         fortran: [gfortran, flang]
         build: [cmake, make]
         exclude:
           - os: macos-latest
+            cc: gcc
+          - os: macos-latest
+            cc: clang-21
+          - os: macos-latest
+            fortran: flang
+          - os: ubuntu-24.04-arm
             fortran: flang
 
     steps:
@@ -42,10 +49,23 @@ jobs:
       - name: Install Dependencies
         run: |
           if [ "$RUNNER_OS" == "Linux" ]; then
+            cat << EOF | sudo tee -a /etc/apt/apt.conf.d/01norecommend
+          APT::Install-Recommends "0";
+          APT::Install-Suggests "0";
+          EOF
             sudo apt-get update
-            sudo apt-get install -y gfortran cmake ccache
-            wget http://security.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb
-            sudo apt install ./libtinfo5_6.3-2ubuntu0.1_amd64.deb
+            sudo apt-get install -y ccache
+            if [ "${{ matrix.cc }}" == "clang-21" ]; then
+                wget https://apt.llvm.org/llvm.sh
+                chmod +x llvm.sh
+                sudo ./llvm.sh 21
+            fi
+            if [ "${{ matrix.fortran }}" == "flang" ]; then
+              wget http://security.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2ubuntu0.1_amd64.deb
+              sudo apt install ./libtinfo5_6.3-2ubuntu0.1_amd64.deb
+            else
+              sudo apt-get install -y ${{ matrix.fortran }}
+            fi
           elif [ "$RUNNER_OS" == "macOS" ]; then
             # It looks like "gfortran" isn't working correctly unless "gcc" is re-installed.
             brew reinstall gcc
@@ -64,12 +84,12 @@ jobs:
           # GNU make and cmake call the compilers differently. It looks like
           # that causes the cache to mismatch. Keep the ccache for both build
           # tools separate to avoid polluting each other.
-          key: ccache-${{ runner.os }}-${{ matrix.build }}-${{ matrix.fortran }}-${{ github.ref }}-${{ github.sha }}
+          key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ matrix.build }}-${{ matrix.cc }}-${{ matrix.fortran }}-${{ github.ref }}-${{ github.sha }}
           # Restore a matching ccache cache entry. Prefer same branch and same Fortran compiler.
           restore-keys: |
-            ccache-${{ runner.os }}-${{ matrix.build }}-${{ matrix.fortran }}-${{ github.ref }}
-            ccache-${{ runner.os }}-${{ matrix.build }}-${{ matrix.fortran }}
-            ccache-${{ runner.os }}-${{ matrix.build }}
+            ccache-${{ runner.os }}-${{ runner.arch }}-${{ matrix.build }}-${{ matrix.cc }}-${{ matrix.fortran }}-${{ github.ref }}
+            ccache-${{ runner.os }}-${{ runner.arch }}-${{ matrix.build }}-${{ matrix.cc }}-${{ matrix.fortran }}
+            ccache-${{ runner.os }}-${{ runner.arch }}-${{ matrix.build }}-${{ matrix.cc }}
 
       - name: Configure ccache
         run: |
@@ -89,7 +109,7 @@ jobs:
           echo "max_size = 300M" > ~/.ccache/ccache.conf
           echo "compression = true" >> ~/.ccache/ccache.conf
           ccache -s
-          
+
       - name: Add gfortran runtime to link path
         if: matrix.build == 'make' && runner.os == 'macOS'
         run: |
@@ -110,7 +130,7 @@ jobs:
           fi
           case "${{ matrix.build }}" in
             "make")
-              make -j$(nproc) DYNAMIC_ARCH=1 USE_OPENMP=0 FC="ccache ${{ matrix.fortran }}"
+              make -j$(nproc) DYNAMIC_ARCH=1 USE_OPENMP=0 CC="ccache ${{ matrix.cc }}" FC="ccache ${{ matrix.fortran }}"
               ;;
             "cmake")
               mkdir build && cd build
@@ -119,6 +139,7 @@ jobs:
                     -DBUILD_WITHOUT_LAPACK=0 \
                     -DCMAKE_VERBOSE_MAKEFILE=ON \
                     -DCMAKE_BUILD_TYPE=Release \
+                    -DCMAKE_C_COMPILER=${{ matrix.cc }} \
                     -DCMAKE_Fortran_COMPILER=${{ matrix.fortran }} \
                     -DCMAKE_C_COMPILER_LAUNCHER=ccache \
                     -DCMAKE_Fortran_COMPILER_LAUNCHER=ccache \
@@ -142,13 +163,13 @@ jobs:
             "make")
               MAKE_FLAGS='DYNAMIC_ARCH=1 USE_OPENMP=0'
               echo "::group::Tests in 'test' directory"
-              make -C test $MAKE_FLAGS FC="ccache ${{ matrix.fortran }}"
+              make -C test $MAKE_FLAGS CC="ccache ${{ matrix.cc }}" FC="ccache ${{ matrix.fortran }}"
               echo "::endgroup::"
               echo "::group::Tests in 'ctest' directory"
-              make -C ctest $MAKE_FLAGS FC="ccache ${{ matrix.fortran }}"
+              make -C ctest $MAKE_FLAGS CC="ccache ${{ matrix.cc }}" FC="ccache ${{ matrix.fortran }}"
               echo "::endgroup::"
               echo "::group::Tests in 'utest' directory"
-              make -C utest $MAKE_FLAGS FC="ccache ${{ matrix.fortran }}"
+              make -C utest $MAKE_FLAGS CC="ccache ${{ matrix.cc }}" FC="ccache ${{ matrix.fortran }}"
               echo "::endgroup::"
               ;;
             "cmake")
@@ -372,15 +393,15 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-        
+
       - name: Install Dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y gcc gfortran make
-          
+
       - name: Build OpenBLAS
         run: |
-          make -j${nproc} 
+          make -j${nproc}
           make -j${nproc} lapack-test
-    
-          
+
+

--- a/kernel/arm64/dot_kernel_sve.c
+++ b/kernel/arm64/dot_kernel_sve.c
@@ -48,7 +48,7 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 "        add     x12, %[X_], x9, lsl #"SHIFT"               \n" \
 "        add     x13, %[Y_], x9, lsl #"SHIFT"               \n"
 #define TAIL_WHILE                                        \
-"        whilelo p1."DTYPE", x8, x0                         \n"
+"        whilelo p1."DTYPE", x8, %[N_]                         \n"
 #define UPDATE(pg, x,y,out)                               \
 "        ld1"WIDTH"    { z2."DTYPE" }, "pg"/z, ["x", x8, lsl #"SHIFT"]  \n" \
 "        ld1"WIDTH"    { z3."DTYPE" }, "pg"/z, ["y", x8, lsl #"SHIFT"]  \n" \
@@ -66,7 +66,7 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 "        movi    d1, #0x0                             \n" \
         SETUP_TRUE                                        \
 "        neg     x10, x9, lsl #1                      \n" \
-"        ands    x11, x10, x0                         \n" \
+"        ands    x11, x10, %[N_]                      \n" \
 "        b.eq    2f // skip_2x                        \n" \
         OFFSET_INPUTS                                     \
 "1: // vector_2x                                      \n" \
@@ -78,7 +78,7 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         SUM_VECTOR("1") \
 "2: // skip_2x                                        \n" \
 "        neg     x10, x9                              \n" \
-"        and     x10, x10, x0                         \n" \
+"        and     x10, x10, %[N_]                      \n" \
 "        cmp     x8, x10                              \n" \
 "        b.hs    4f // tail                           \n" \
 "3: // vector_1x                                      \n" \
@@ -87,7 +87,7 @@ THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 "        cmp     x8, x10                              \n" \
 "        b.lo    3b // vector_1x                      \n" \
 "4: // tail                                           \n" \
-"        cmp     x10, x0                              \n" \
+"        cmp     x10, %[N_]                           \n" \
 "        b.eq    5f // end                            \n" \
         TAIL_WHILE                                        \
         UPDATE("p1", "%[X_]", "%[Y_]", "z0")              \
@@ -110,9 +110,9 @@ dot_kernel_sve(BLASLONG n, FLOAT* x, FLOAT* y)
         [Y_] "r" (y)
       : "cc",
         "memory",
-        "x0", "x1", "x2", "x3", "x4", "x5", "x6", "x7",
-        "x8", "x9", "x10", "x11", "x12", "x13", "d1", 
-        "z0", "z1"
+        "x8", "x9", "x10", "x11", "x12", "x13",
+        "v0", "v1",
+        "z0", "z1", "z2", "z3"
   );
 
   return ret;


### PR DESCRIPTION
fix #5532

The `n` argument was assumed to be in `x0` which is not always true.
Use `%[N_]` instead of `x0` in the assembly code.

The clobber list listed `x0`->`x7` but those are not used in the assembly code, remove them from the clobber list.
`v0`, `z2` & `z3` were missing in the clobber list.
`d1` relabelled as `v1` (`v0` & `v1` are used through aliases `d0`/`d1`, `s0`/`s1`)

CI tests added for Ubuntu 24.04 runner default clang (18.1.3) as well as clang-21 on both x86_64 & aarch64