### PR TITLE
Refactoring: ARM64 dot Kernel: don't call num_cpu_avail twice

### DIFF
--- a/kernel/arm64/dot.c
+++ b/kernel/arm64/dot.c
@@ -97,7 +97,7 @@ static inline int get_dot_optimal_nthreads(BLASLONG n) {
   if (n <= 10000L)
     return 1;
   else
-    return num_cpu_avail(1);
+    return ncpu;
 }
 #endif
 


### PR DESCRIPTION
This is a tiny refactoring. In `get_dot_optimal_nthreads`, we'd call `num_cpu_avail(1)` twice. This PR simply uses the value from the first invocation when returning it.