### PR TITLE
Makefile: Recognize `-fdefault-integer-8` for LLVMs flang

### DIFF
--- a/Makefile.system
+++ b/Makefile.system
@@ -887,7 +887,7 @@ NO_BINARY_MODE  = 1
 BINARY_DEFINED  = 1
 ifdef INTERFACE64
 ifneq ($(INTERFACE64), 0)
-ifeq ($(F_COMPILER), GFORTRAN)
+ifeq ($(F_COMPILER), $(filter $(F_COMPILER),GFORTRAN FLANGNEW))
 FCOMMON_OPT +=  -fdefault-integer-8
 endif
 ifeq ($(F_COMPILER), FLANG)
@@ -902,7 +902,7 @@ NO_BINARY_MODE  = 1
 BINARY_DEFINED  = 1
 ifdef INTERFACE64
 ifneq ($(INTERFACE64), 0)
-ifeq ($(F_COMPILER), GFORTRAN)
+ifeq ($(F_COMPILER), $(filter $(F_COMPILER),GFORTRAN FLANGNEW))
 FCOMMON_OPT +=  -fdefault-integer-8
 endif
 ifeq ($(F_COMPILER), FLANG)
@@ -917,7 +917,7 @@ NO_BINARY_MODE  = 1
 BINARY_DEFINED  = 1
 ifdef INTERFACE64
 ifneq ($(INTERFACE64), 0)
-ifeq ($(F_COMPILER), GFORTRAN)
+ifeq ($(F_COMPILER), $(filter $(F_COMPILER),GFORTRAN FLANGNEW))
 FCOMMON_OPT +=  -fdefault-integer-8
 endif
 ifeq ($(F_COMPILER), FLANG)


### PR DESCRIPTION
Based on the discussion in https://github.com/OpenMathLib/OpenBLAS/pull/5536

---

When building OpenBLAS on `aarch64` with LLVM Flang, tests would segmentation fault when building with `INTERFACE64='1'`. IIUC, this happens due to a mismatch in integer size between Fortran and C.

Looking at `Makefile.system`, only `GFortran` and the old `Flang` are checked with `INTERFACE64`. So for `flang-new` / `flang`, no compiler flag is added. Checking `flang-new` 18 and newer, it seems to understand the `-fdefault-integer-8` flag, just like `GFortran`.

Therefore, change the tests slightly to also add `-fdefault-integer-8` for `FLANGNEW`. 

----

This PR does not touch the CMake installation of OpenBLAS. At the first glance, this flag might be added there already, but this needs more investigation. I wanted to get this to work for the Makefile build first...