### PR TITLE
Skip C and Fortran compiler combination checks in AIX if NO_FORTRAN or ONLY_CBLAS is set

### DIFF
--- a/Makefile.power
+++ b/Makefile.power
@@ -147,11 +147,14 @@ endif
 ifdef BINARY64
 
 
+#Skip C/Fortran compiler combination checks in AIX if NO_FORTRAN or ONLY_CBLAS is set
+ifeq ($(filter 1,$(NO_FORTRAN) $(ONLY_CBLAS)),)
 ifeq ($(C_COMPILER)$(F_COMPILER)$(OSNAME), GCCIBMAIX)
 $(error Using GCC and XLF on AIX is not a supported combination.)
 endif
 ifeq ($(C_COMPILER)$(F_COMPILER)$(OSNAME), CLANGGFORTRANAIX)
 $(error Using Clang and gFortran on AIX is not a supported combination.)
+endif
 endif
 
 ifeq ($(OSNAME), AIX)


### PR DESCRIPTION
```
# make CC=/opt/freeware/bin/gcc NO_FORTRAN=1 BINARY=64 USE_OPENMP=1 INTERFACE64=1 DYNAMIC_ARCH=1 USE_THREAD=1 TARGET=POWER8
Makefile.power:151: *** Using GCC and XLF on AIX is not a supported combination..  Stop.
                                         
# make CC=/opt/IBM/openxlC/17.1.2/bin/ibm-clang_r ONLY_CBLAS=1 BINARY=64 USE_OPENMP=1 INTERFACE64=1 DYNAMIC_ARCH=1 USE_THREAD=1 TARGET=POWER8
Makefile.power:154: *** Using Clang and gFortran on AIX is not a supported combination..  Stop.
```

C and Fortran compiler combination checks in AIX should be avoided when `NO_FORTRAN` or `ONLY_CBLAS` is set.

In the first case above, `FC` picks up `xlf` value in AIX as part of the make's builtin, even though not set explicitly by the user and the check stops the build. 
In the second case, `ONLY_CBLAS` sets the default Fortran compiler as `gfortran` and hence the check stops the build. 