### PR TITLE
fix: rpcc on linux aarch64

### DIFF
--- a/common_arm64.h
+++ b/common_arm64.h
@@ -114,9 +114,9 @@ static __inline BLASULONG rpcc(void){
   #else
   BLASULONG ret = 0;
   blasint shift;
- 
-  __asm__ __volatile__ ("isb; mrs %0,cntvct_el0":"=r"(ret));
-  __asm__ __volatile__ ("mrs %0,cntfrq_el0; clz %w0, %w0":"=&r"(shift));
+
+  __asm__ __volatile__ ("isb\n\tmrs %0,cntvct_el0":"=r"(ret));
+  __asm__ __volatile__ ("mrs %x0,cntfrq_el0\n\tclz %w0, %w0":"=&r"(shift));
 
   return ret << shift;
   #endif


### PR DESCRIPTION
The inline assembly code seems ill-formed and gcc/clang are not generating the same thing.
This also removes hundreds of `warning: value size does not match register size specified by the constraint and modifier` when building with clang.

checked on [godbolt](https://godbolt.org/#z:OYLghAFBqd5QCxAYwPYBMCmBRdBLAF1QCcAaPECAMzwBtMA7AQwFtMQByARg9KtQYEAysib0QXACx8BBAKoBnTAAUAHpwAMvAFYTStJg1DIApACYAQuYukl9ZATwDKjdAGFUtAK4sGe1wAyeAyYAHI%2BAEaYxCBmXKQADqgKhE4MHt6%2BekkpjgJBIeEsUTFxtpj2eQxCBEzEBBk%2BfvF2mA5pNXUEBWGR0bEttfWNWYNdPUUlAwCUtqhexMjsHAD0KwDUACoAngmY69vzxOtoWOsI0Zik6yTrtKhM6OuG65iqrAn0AHQmGgCC5gAzMFkN4ziZAW4FAR8IIvggIdhfgD/l5ggQAGySAD6BHWxASyGQ2M86AgADdUHh0NMTAB2Kz/ZHrdZowRY3H4zB4iEAEXWGghjL%2BLPR6wUCDwVAIQuZ62x2KYChYCvl2MpBkc9FVEHMZjwCgiQvWLGICnW5gArBpSMhBOSHNiKoKzGYQHq%2BcQ9RBiNzprTAcKWQqlSrsWqNUwtZgdXrTearTa7QQqMQAI5O2iCwMnWgALwtZktAHcbYWSy63R7AbzzBiva6IBKpQR/bL/izfQQFgwuTzIRC3OLJdL2wC6bWmaj0Ry8QSidiQsWKVSafThXK2ZicXPuRaawKx6LBMOW0e1aHVQrI9HY66DUbLW4GCYnwR4%2BWk/bHc69e7XZ63pdm2gZyiGypXuqnhRnQMbhrqroflaqhfim6aZoKT4vm%2BoIFlapbXPhlb/mYfJ1g2ZhNiOrYBkGfY9n2%2B5uIOp6jqBTITsiHCzLQnCWrwfgcFopCoJwzGWNY4pHEshaAjwpAEJo3GzAA1rEgJfAAnBimkABxmBoGi6VwRaAhigL6JwkgCUpImcLwCggDailCdxpBwLASBoCwCSwWQFAQN5vn0DEdQsFiwBcJaBl8HQBDRI5EARLZETBHU2ycPJqXMMQ2wAPIRNobQufJ3lsIIeUMLQGWuaQWARF4wBuGItCOdwvBYCwhjAOItX4L67TkpgbXCW8bRePFmW8OiFS2bQeARMQ6UeFgtkEMQeAsFNpBDcQETJJgvKYF1RjzUYSmzFQBjAAoABqeCYMWeV7IJ8n8IIIhiOwUgyIIigqOotW6PEBjnaYEmWPoC2OZAsyoAkVRtQAtHlgLrEjADqLW8Kgu0bVgMMQLMrTtM4ECuCMzSkIEwS9MU/TxDkqQCJT2TJMzDATH0MQtBUxUdEMDSeE0egk1UnT1Fz9M87Ygus2Mku05MDPE9J308XxNm1aJHDrH8ABKACyWLrMARLrFFXxmF8GjrBAuCELcQJcNMvAuVo/qkGpZgYjbgIaFwdKaZpXC6XSkjmXSdKWRw1mkIJwk6w5TkKRd7kwIgKCoD5fnkJQQV%2BSAYXkrpSOgt1cRcDaNC0PFZqUMltXZel23N7lBVFQ421lYwBCVdVtn1Y1zW0K122dd1vXCf1/NDSNvBjcgE3LPJM28bV82LctGDLMJ62bdtu37UoR0nT1wSgK5l3XXdD1PS923vcIojiD9T//Wotm6GY%2BjdSg1jWChhEQmcMEZpGRqjdGWNR44zxtSYa8BiZ81Jn4cmDB3DCyyHJam6CpZTGkEzKorNsGELSHg/o0gxYCy6KzMoVCBAS26ErbmIBKFy0wX4OhgtyExEkKrBYSwJAaw4PxeOtkdbPGICwEuSMmC5m6usOIXwuA2ztg7Igxxnau1TlfVSsRJBaWDkY4xxiMQxzjgnHG9lbAp3dm5Dymd5gEASBNPOgVs7BWiKEVgyxi6lzkeXIwiiVEqNGvgDR1I9BP0%2Bq/aQ78lCfyBrEUgxYloJCmsI0Rli7IcDyhNFxeJUBUEkdI/x8iglKNCXbDwOcQqyTMNouxntvaWnMVrRO1jHLOQusIsw7SrEcDdj0naCU0isKAA%3D)