### PR TITLE
fix(warning): taking the absolute value of 'bfloat16' has no effect

### DIFF
--- a/common.h
+++ b/common.h
@@ -781,7 +781,7 @@ static __inline int readenv_atoi(char *env) {
 #endif
 #endif
 
-#if !defined(XDOUBLE) || !defined(QUAD_PRECISION)
+#if !defined(BFLOAT16) && (!defined(XDOUBLE) || !defined(QUAD_PRECISION))
 
 static __inline void compinv(FLOAT *b, FLOAT ar, FLOAT ai){
 


### PR DESCRIPTION
The `compinv` function is invalid when building for BFLOAT16 and leads to the following warning: `taking the absolute value of unsigned type 'bfloat16' (aka 'unsigned short') has no effect`.
Update pre-processor conditions to remove its definition when building for BFLOAT16.