### PR TITLE
Updated SGEMV ramps.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -29,6 +29,9 @@
 * Annop Wongwathanarat <annop.wongwathanarat@arm.com>
   * Optimizations and other improvements targeting AArch64
 
+* Anna Mayne <anna.mayne@arm.com>
+  * Optimizations and other improvements targeting AArch64
+
 ## Previous Developers
 
 * Zaheer Chothia <zaheer.chothia@gmail.com>
@@ -267,3 +270,5 @@ In chronological order:
   * [2025-05-29] Optimise axpby kernel for RISCV64_ZVL256B
   * [2025-06-05] Optimise hbmv kernel for RISCV64_ZVL256B
 
+* Anna Mayne <anna.mayne@arm.com>
+  * [2025-11-19] Update thread throttling profile for SGEMV on NEOVERSEV1 and NEOVERSEV2

--- a/interface/gemv.c
+++ b/interface/gemv.c
@@ -1,4 +1,5 @@
 /*********************************************************************/
+/* Copyright 2025 The OpenBLAS Project                               */
 /* Copyright 2009, 2010 The University of Texas at Austin.           */
 /* All rights reserved.                                              */
 /*                                                                   */
@@ -81,9 +82,12 @@ static inline int get_gemv_optimal_nthreads_neoversev1(BLASLONG MN, int ncpu) {
           : (MN < 1050625L)   ? MIN(ncpu, 40)
           : ncpu;
   #else
-      return (MN < 25600L)     ? 1
+      return
+            (MN < 25600L)     ? 1
           : (MN < 63001L)     ? MIN(ncpu, 4)
-          : (MN < 459684L)    ? MIN(ncpu, 16)
+          : (MN < 202500L)    ? MIN(ncpu, 8)
+          : (MN < 806404L)    ? MIN(ncpu, 16)
+          : (MN < 1638400L)    ? MIN(ncpu, 32)
           : ncpu;
   #endif
 }
@@ -93,9 +97,9 @@ static inline int get_gemv_optimal_nthreads_neoversev1(BLASLONG MN, int ncpu) {
 static inline int get_gemv_optimal_nthreads_neoversev2(BLASLONG MN, int ncpu) {
   return
       MN < 24964L    ? 1
-    : MN < 65536L    ? MIN(ncpu, 8)
-    : MN < 262144L   ? MIN(ncpu, 32)
-    : MN < 1638400L  ? MIN(ncpu, 64)
+    : MN < 145924L    ? MIN(ncpu, 8)
+    : MN < 692224L   ? MIN(ncpu, 16)
+    : MN < 1638400L  ? MIN(ncpu, 32)
     : ncpu;
 }
 #endif


### PR DESCRIPTION
Significant performance improvements are gained by the proposed changes on both c7g (NEOVERSEV1) and c8g (NEOVERSEV2) instances. To reproduce these values you need to run with OMP_ADAPTIVE=1. The plots below show the average time taken for 10000 iterations of sgemv operations on increasing square matrix/vector sizes, from 2x2 through to 1024x1024. The x axis reaches 2046 as we first run sgemv without transposition, then with. I've also include plots of the ratio, relative to the original stats (lower is better). These generate the following stats:
Geometric mean for c7g_sgemv.txt: 0.890437968914142
Geometric mean for c8g_sgemv.txt: 0.7884951978206536

<img width="720" height="453" alt="image" src="https://github.com/user-attachments/assets/fc034e6b-0dfc-42e4-8cfd-43bc8de0b81d" />

<img width="720" height="460" alt="image" src="https://github.com/user-attachments/assets/2c5b507d-6919-40a8-9d2e-16a16200d20c" />

<img width="720" height="454" alt="image" src="https://github.com/user-attachments/assets/6c1ada0a-6431-47ca-ad32-0a61691c7f0b" />

<img width="720" height="462" alt="image" src="https://github.com/user-attachments/assets/33e76d4b-617c-4c0b-9380-050356eaf1c8" />
