### PR TITLE
Fix floating point registers ld/st bug of Loongarch

### DIFF
--- a/kernel/loongarch64/cgemm_kernel_2x2_lasx.S
+++ b/kernel/loongarch64/cgemm_kernel_2x2_lasx.S
@@ -212,15 +212,15 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     SDARG      $r25,   $sp,   16
     SDARG      $r26,   $sp,   24
     SDARG      $r27,   $sp,   32
-    ST         $f23,   $sp,   40
-    ST         $f24,   $sp,   48
-    ST         $f25,   $sp,   56
-    ST         $f26,   $sp,   64
-    ST         $f27,   $sp,   72
-    ST         $f28,   $sp,   80
-    ST         $f29,   $sp,   88
-    ST         $f30,   $sp,   96
-    ST         $f31,   $sp,   104
+    fst.d      $f23,   $sp,   40
+    fst.d      $f24,   $sp,   48
+    fst.d      $f25,   $sp,   56
+    fst.d      $f26,   $sp,   64
+    fst.d      $f27,   $sp,   72
+    fst.d      $f28,   $sp,   80
+    fst.d      $f29,   $sp,   88
+    fst.d      $f30,   $sp,   96
+    fst.d      $f31,   $sp,   104
     ST         ALPHA_R,$sp,   112
     ST         ALPHA_I,$sp,   120
 
@@ -841,15 +841,15 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     LDARG      $r25,   $sp,   16
     LDARG      $r26,   $sp,   24
     LDARG      $r27,   $sp,   32
-    LD         $f23,   $sp,   40
-    LD         $f24,   $sp,   48
-    LD         $f25,   $sp,   56
-    LD         $f26,   $sp,   64
-    LD         $f27,   $sp,   72
-    LD         $f28,   $sp,   80
-    LD         $f29,   $sp,   88
-    LD         $f30,   $sp,   96
-    LD         $f31,   $sp,   104
+    fld.d      $f23,   $sp,   40
+    fld.d      $f24,   $sp,   48
+    fld.d      $f25,   $sp,   56
+    fld.d      $f26,   $sp,   64
+    fld.d      $f27,   $sp,   72
+    fld.d      $f28,   $sp,   80
+    fld.d      $f29,   $sp,   88
+    fld.d      $f30,   $sp,   96
+    fld.d      $f31,   $sp,   104
 
     addi.d     $sp,    $sp,   128
     jirl       $r0,    $r1,   0x0

--- a/kernel/loongarch64/cgemm_kernel_2x2_lsx.S
+++ b/kernel/loongarch64/cgemm_kernel_2x2_lsx.S
@@ -172,15 +172,15 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     SDARG      $r25,   $sp,   16
     SDARG      $r26,   $sp,   24
     SDARG      $r27,   $sp,   32
-    ST         $f23,   $sp,   40
-    ST         $f24,   $sp,   48
-    ST         $f25,   $sp,   56
-    ST         $f26,   $sp,   64
-    ST         $f27,   $sp,   72
-    ST         $f28,   $sp,   80
-    ST         $f29,   $sp,   88
-    ST         $f30,   $sp,   96
-    ST         $f31,   $sp,   104
+    fst.d      $f23,   $sp,   40
+    fst.d      $f24,   $sp,   48
+    fst.d      $f25,   $sp,   56
+    fst.d      $f26,   $sp,   64
+    fst.d      $f27,   $sp,   72
+    fst.d      $f28,   $sp,   80
+    fst.d      $f29,   $sp,   88
+    fst.d      $f30,   $sp,   96
+    fst.d      $f31,   $sp,   104
     ST         ALPHA_R,$sp,   112
     ST         ALPHA_I,$sp,   120
 
@@ -796,15 +796,15 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     LDARG      $r25,   $sp,   16
     LDARG      $r26,   $sp,   24
     LDARG      $r27,   $sp,   32
-    LD         $f23,   $sp,   40
-    LD         $f24,   $sp,   48
-    LD         $f25,   $sp,   56
-    LD         $f26,   $sp,   64
-    LD         $f27,   $sp,   72
-    LD         $f28,   $sp,   80
-    LD         $f29,   $sp,   88
-    LD         $f30,   $sp,   96
-    LD         $f31,   $sp,   104
+    fld.d      $f23,   $sp,   40
+    fld.d      $f24,   $sp,   48
+    fld.d      $f25,   $sp,   56
+    fld.d      $f26,   $sp,   64
+    fld.d      $f27,   $sp,   72
+    fld.d      $f28,   $sp,   80
+    fld.d      $f29,   $sp,   88
+    fld.d      $f30,   $sp,   96
+    fld.d      $f31,   $sp,   104
 
     addi.d     $sp,    $sp,   128
     jirl       $r0,    $r1,   0x0

--- a/kernel/loongarch64/cgemm_kernel_8x4_lsx.S
+++ b/kernel/loongarch64/cgemm_kernel_8x4_lsx.S
@@ -176,15 +176,15 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     SDARG      $r25,   $sp,   16
     SDARG      $r26,   $sp,   24
     SDARG      $r27,   $sp,   32
-    ST         $f23,   $sp,   40
-    ST         $f24,   $sp,   48
-    ST         $f25,   $sp,   56
-    ST         $f26,   $sp,   64
-    ST         $f27,   $sp,   72
-    ST         $f28,   $sp,   80
-    ST         $f29,   $sp,   88
-    ST         $f30,   $sp,   96
-    ST         $f31,   $sp,   104
+    fst.d      $f23,   $sp,   40
+    fst.d      $f24,   $sp,   48
+    fst.d      $f25,   $sp,   56
+    fst.d      $f26,   $sp,   64
+    fst.d      $f27,   $sp,   72
+    fst.d      $f28,   $sp,   80
+    fst.d      $f29,   $sp,   88
+    fst.d      $f30,   $sp,   96
+    fst.d      $f31,   $sp,   104
     ST         ALPHA_R,$sp,   112
     ST         ALPHA_I,$sp,   120
 
@@ -3297,15 +3297,15 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     LDARG      $r25,   $sp,   16
     LDARG      $r26,   $sp,   24
     LDARG      $r27,   $sp,   32
-    LD         $f23,   $sp,   40
-    LD         $f24,   $sp,   48
-    LD         $f25,   $sp,   56
-    LD         $f26,   $sp,   64
-    LD         $f27,   $sp,   72
-    LD         $f28,   $sp,   80
-    LD         $f29,   $sp,   88
-    LD         $f30,   $sp,   96
-    LD         $f31,   $sp,   104
+    fld.d      $f23,   $sp,   40
+    fld.d      $f24,   $sp,   48
+    fld.d      $f25,   $sp,   56
+    fld.d      $f26,   $sp,   64
+    fld.d      $f27,   $sp,   72
+    fld.d      $f28,   $sp,   80
+    fld.d      $f29,   $sp,   88
+    fld.d      $f30,   $sp,   96
+    fld.d      $f31,   $sp,   104
 
     addi.d     $sp,    $sp,   128
     jirl       $r0,    $r1,   0x0

--- a/kernel/loongarch64/dgemm_kernel_8x4.S
+++ b/kernel/loongarch64/dgemm_kernel_8x4.S
@@ -893,14 +893,14 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     SDARG    $r25,  $sp,   16
     SDARG    $r26,  $sp,   24
     SDARG    $r27,  $sp,   32
-    ST       $f24,  $sp,   40
-    ST       $f25,  $sp,   48
-    ST       $f26,  $sp,   56
-    ST       $f27,  $sp,   64
-    ST       $f28,  $sp,   72
-    ST       $f29,  $sp,   80
-    ST       $f30,  $sp,   88
-    ST       $f31,  $sp,   96
+    fst.d    $f24,  $sp,   40
+    fst.d    $f25,  $sp,   48
+    fst.d    $f26,  $sp,   56
+    fst.d    $f27,  $sp,   64
+    fst.d    $f28,  $sp,   72
+    fst.d    $f29,  $sp,   80
+    fst.d    $f30,  $sp,   88
+    fst.d    $f31,  $sp,   96
     ST       ALPHA, $sp,   104
 
 #if defined (TRMMKERNEL) && !defined(LEFT)
@@ -2879,14 +2879,14 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     LDARG    $r25,  $sp,   16
     LDARG    $r26,  $sp,   24
     LDARG    $r27,  $sp,   32
-    LD       $f24,  $sp,   40
-    LD       $f25,  $sp,   48
-    LD       $f26,  $sp,   56
-    LD       $f27,  $sp,   64
-    LD       $f28,  $sp,   72
-    LD       $f29,  $sp,   80
-    LD       $f30,  $sp,   88
-    LD       $f31,  $sp,   96
+    fld.d    $f24,  $sp,   40
+    fld.d    $f25,  $sp,   48
+    fld.d    $f26,  $sp,   56
+    fld.d    $f27,  $sp,   64
+    fld.d    $f28,  $sp,   72
+    fld.d    $f29,  $sp,   80
+    fld.d    $f30,  $sp,   88
+    fld.d    $f31,  $sp,   96
     addi.d   $sp,   $sp,   112
 
     jirl    $r0, $r1, 0x0

--- a/kernel/loongarch64/dgemm_ncopy_16.S
+++ b/kernel/loongarch64/dgemm_ncopy_16.S
@@ -113,15 +113,15 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     SDARG      $r29, $sp,  0x30
     SDARG      $r30, $sp,  0x38
     SDARG      $r31, $sp,  0x40
-    ST         $f23, $sp,  0x48
-    ST         $f24, $sp,  0x50
-    ST         $f25, $sp,  0x58
-    ST         $f26, $sp,  0x60
-    ST         $f27, $sp,  0x68
-    ST         $f28, $sp,  0x70
-    ST         $f29, $sp,  0x78
-    ST         $f30, $sp,  0x80
-    ST         $f31, $sp,  0x88
+    fst.d      $f23, $sp,  0x48
+    fst.d      $f24, $sp,  0x50
+    fst.d      $f25, $sp,  0x58
+    fst.d      $f26, $sp,  0x60
+    fst.d      $f27, $sp,  0x68
+    fst.d      $f28, $sp,  0x70
+    fst.d      $f29, $sp,  0x78
+    fst.d      $f30, $sp,  0x80
+    fst.d      $f31, $sp,  0x88
 
     move       TD,   DST
     move       TS,   SRC
@@ -678,15 +678,15 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     LDARG      $r29, $sp,  0x30
     LDARG      $r30, $sp,  0x38
     LDARG      $r31, $sp,  0x40
-    LD         $f23, $sp,  0x48
-    LD         $f24, $sp,  0x50
-    LD         $f25, $sp,  0x58
-    LD         $f26, $sp,  0x60
-    LD         $f27, $sp,  0x68
-    LD         $f28, $sp,  0x70
-    LD         $f29, $sp,  0x78
-    LD         $f30, $sp,  0x80
-    LD         $f31, $sp,  0x88
+    fld.d      $f23, $sp,  0x48
+    fld.d      $f24, $sp,  0x50
+    fld.d      $f25, $sp,  0x58
+    fld.d      $f26, $sp,  0x60
+    fld.d      $f27, $sp,  0x68
+    fld.d      $f28, $sp,  0x70
+    fld.d      $f29, $sp,  0x78
+    fld.d      $f30, $sp,  0x80
+    fld.d      $f31, $sp,  0x88
     addi.d     $sp,  $sp,  0x90
     jirl       $r0,  $r1,  0x00
 

--- a/kernel/loongarch64/zgemm_kernel_2x2.S
+++ b/kernel/loongarch64/zgemm_kernel_2x2.S
@@ -123,13 +123,13 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     SDARG      $r24,   $sp,   8
     SDARG      $r25,   $sp,   16
     SDARG      $r26,   $sp,   24
-    ST         $f23,   $sp,   32
-    ST         $f24,   $sp,   40
-    ST         $f25,   $sp,   48
-    ST         $f26,   $sp,   56
-    ST         $f27,   $sp,   64
-    ST         $f28,   $sp,   72
-    ST         $f29,   $sp,   80
+    fst.d      $f23,   $sp,   32
+    fst.d      $f24,   $sp,   40
+    fst.d      $f25,   $sp,   48
+    fst.d      $f26,   $sp,   56
+    fst.d      $f27,   $sp,   64
+    fst.d      $f28,   $sp,   72
+    fst.d      $f29,   $sp,   80
 
 
 #if defined (TRMMKERNEL) && !defined(LEFT)
@@ -834,13 +834,13 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     LDARG      $r24,   $sp,   8
     LDARG      $r25,   $sp,   16
     LDARG      $r26,   $sp,   24
-    LD         $f23,   $sp,   32
-    LD         $f24,   $sp,   40
-    LD         $f25,   $sp,   48
-    LD         $f26,   $sp,   56
-    LD         $f27,   $sp,   64
-    LD         $f28,   $sp,   72
-    LD         $f29,   $sp,   80
+    fld.d      $f23,   $sp,   32
+    fld.d      $f24,   $sp,   40
+    fld.d      $f25,   $sp,   48
+    fld.d      $f26,   $sp,   56
+    fld.d      $f27,   $sp,   64
+    fld.d      $f28,   $sp,   72
+    fld.d      $f29,   $sp,   80
 
     addi.d     $sp,    $sp,   88
     jirl       $r0,    $r1,   0x0

--- a/kernel/loongarch64/zgemm_kernel_2x2_lasx.S
+++ b/kernel/loongarch64/zgemm_kernel_2x2_lasx.S
@@ -174,15 +174,15 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     SDARG      $r25,   $sp,   16
     SDARG      $r26,   $sp,   24
     SDARG      $r27,   $sp,   32
-    ST         $f23,   $sp,   40
-    ST         $f24,   $sp,   48
-    ST         $f25,   $sp,   56
-    ST         $f26,   $sp,   64
-    ST         $f27,   $sp,   72
-    ST         $f28,   $sp,   80
-    ST         $f29,   $sp,   88
-    ST         $f30,   $sp,   96
-    ST         $f31,   $sp,   104
+    fst.d      $f23,   $sp,   40
+    fst.d      $f24,   $sp,   48
+    fst.d      $f25,   $sp,   56
+    fst.d      $f26,   $sp,   64
+    fst.d      $f27,   $sp,   72
+    fst.d      $f28,   $sp,   80
+    fst.d      $f29,   $sp,   88
+    fst.d      $f30,   $sp,   96
+    fst.d      $f31,   $sp,   104
     ST         ALPHA_R,$sp,   112
     ST         ALPHA_I,$sp,   120
 
@@ -806,15 +806,15 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     LDARG      $r25,   $sp,   16
     LDARG      $r26,   $sp,   24
     LDARG      $r27,   $sp,   32
-    LD         $f23,   $sp,   40
-    LD         $f24,   $sp,   48
-    LD         $f25,   $sp,   56
-    LD         $f26,   $sp,   64
-    LD         $f27,   $sp,   72
-    LD         $f28,   $sp,   80
-    LD         $f29,   $sp,   88
-    LD         $f30,   $sp,   96
-    LD         $f31,   $sp,   104
+    fld.d      $f23,   $sp,   40
+    fld.d      $f24,   $sp,   48
+    fld.d      $f25,   $sp,   56
+    fld.d      $f26,   $sp,   64
+    fld.d      $f27,   $sp,   72
+    fld.d      $f28,   $sp,   80
+    fld.d      $f29,   $sp,   88
+    fld.d      $f30,   $sp,   96
+    fld.d      $f31,   $sp,   104
 
     addi.d     $sp,    $sp,   128
     jirl       $r0,    $r1,   0x0

--- a/kernel/loongarch64/zgemm_kernel_4x4_lsx.S
+++ b/kernel/loongarch64/zgemm_kernel_4x4_lsx.S
@@ -176,15 +176,15 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     SDARG      $r25,   $sp,   16
     SDARG      $r26,   $sp,   24
     SDARG      $r27,   $sp,   32
-    ST         $f23,   $sp,   40
-    ST         $f24,   $sp,   48
-    ST         $f25,   $sp,   56
-    ST         $f26,   $sp,   64
-    ST         $f27,   $sp,   72
-    ST         $f28,   $sp,   80
-    ST         $f29,   $sp,   88
-    ST         $f30,   $sp,   96
-    ST         $f31,   $sp,   104
+    fst.d      $f23,   $sp,   40
+    fst.d      $f24,   $sp,   48
+    fst.d      $f25,   $sp,   56
+    fst.d      $f26,   $sp,   64
+    fst.d      $f27,   $sp,   72
+    fst.d      $f28,   $sp,   80
+    fst.d      $f29,   $sp,   88
+    fst.d      $f30,   $sp,   96
+    fst.d      $f31,   $sp,   104
     ST         ALPHA_R,$sp,   112
     ST         ALPHA_I,$sp,   120
 
@@ -2300,15 +2300,15 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     LDARG      $r25,   $sp,   16
     LDARG      $r26,   $sp,   24
     LDARG      $r27,   $sp,   32
-    LD         $f23,   $sp,   40
-    LD         $f24,   $sp,   48
-    LD         $f25,   $sp,   56
-    LD         $f26,   $sp,   64
-    LD         $f27,   $sp,   72
-    LD         $f28,   $sp,   80
-    LD         $f29,   $sp,   88
-    LD         $f30,   $sp,   96
-    LD         $f31,   $sp,   104
+    fld.d      $f23,   $sp,   40
+    fld.d      $f24,   $sp,   48
+    fld.d      $f25,   $sp,   56
+    fld.d      $f26,   $sp,   64
+    fld.d      $f27,   $sp,   72
+    fld.d      $f28,   $sp,   80
+    fld.d      $f29,   $sp,   88
+    fld.d      $f30,   $sp,   96
+    fld.d      $f31,   $sp,   104
 
     addi.d     $sp,    $sp,   128
     jirl       $r0,    $r1,   0x0


### PR DESCRIPTION
Some floating-point registers need to save their full values (64 bits) before and after function calls. However, when using ST/LD macros, the fst.s/fld.s directive may actually be used, which only saves a 32-bit value. This may lead to some unexpected mistakes.
This patch do same thing with commit e05d98d00a8a4cf3566013f12b6420344d579d2e.