### PR TITLE
arm64: fix clang ICE on Windows for zdot_thunderx2t99.c

### DIFF
--- a/kernel/arm64/dznrm2_thunderx2t99_fast.c
+++ b/kernel/arm64/dznrm2_thunderx2t99_fast.c
@@ -155,7 +155,10 @@ static double nrm2_compute(BLASLONG n, FLOAT *x, BLASLONG inc_x)
 	"	cmp	"J", xzr			\n"
 	"	beq	.Lnrm2_kernel_F1		\n"
 
+/* https://github.com/llvm/llvm-project/issues/149547 */
+#if !(defined(__clang__) && defined(OS_WINDOWS))
 	"	.align 5				\n"
+#endif
 	".Lnrm2_kernel_F:				\n"
 	"	"KERNEL_F"				\n"
 	"	subs	"J", "J", #1			\n"

--- a/kernel/arm64/scnrm2_thunderx2t99.c
+++ b/kernel/arm64/scnrm2_thunderx2t99.c
@@ -238,7 +238,10 @@ static double nrm2_compute(BLASLONG n, FLOAT *x, BLASLONG inc_x)
 	"	cmp	"J", xzr			\n"
 	"	beq	5f //nrm2_kernel_S_BEGIN	\n"
 
+/* https://github.com/llvm/llvm-project/issues/149547 */
+#if !(defined(__clang__) && defined(OS_WINDOWS))
 	"	.align 5				\n"
+#endif
 	"2: //nrm2_kernel_F:				\n"
 	"	"KERNEL_F"				\n"
 	"	subs	"J", "J", #1			\n"

--- a/kernel/arm64/zdot_thunderx2t99.c
+++ b/kernel/arm64/zdot_thunderx2t99.c
@@ -236,7 +236,10 @@ static void zdot_compute(BLASLONG n, FLOAT *x, BLASLONG inc_x, FLOAT *y, BLASLON
 	"	cmp	"J", xzr			\n"
 	"	beq	3f //dot_kernel_F1		\n"
 
+/* https://github.com/llvm/llvm-project/issues/149547 */
+#if !(defined(__clang__) && defined(OS_WINDOWS))
 	"	.align 5				\n"
+#endif
 	"2: //dot_kernel_F:				\n"
 	"	"KERNEL_F"				\n"
 	"	subs	"J", "J", #1			\n"

--- a/kernel/arm64/zsum_thunderx2t99.c
+++ b/kernel/arm64/zsum_thunderx2t99.c
@@ -136,7 +136,10 @@ static FLOAT zasum_compute(BLASLONG n, FLOAT *x, BLASLONG inc_x)
 	"	cmp	"J", xzr			\n"
 	"	beq	3f //asum_kernel_F1		\n"
 
+/* https://github.com/llvm/llvm-project/issues/149547 */
+#if !(defined(__clang__) && defined(OS_WINDOWS))
 	".align 5					\n"
+#endif
 	"2: //asum_kernel_F16:				\n"
 	"	"KERNEL_F16"				\n"
 	"	subs	"J", "J", #1			\n"


### PR DESCRIPTION
Guard .align directive to avoid internal compiler error on
AArch64 Windows with clang.

See: https://github.com/llvm/llvm-project/issues/149547
See: #5076, which applied this same fix to the other files

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
