### PR TITLE
Revert "[WIP,Testing] remove the lock around the thread shutdown function again"

### DIFF
--- a/driver/others/blas_server.c
+++ b/driver/others/blas_server.c
@@ -982,6 +982,8 @@ int BLASFUNC(blas_thread_shutdown)(void){
 
   int i;
 
+  LOCK_COMMAND(&server_lock);
+
   //Free buffers allocated for threads
   for(i=0; i<MAX_CPU_NUMBER; i++){
     if(blas_thread_buffer[i]!=NULL){
@@ -1021,6 +1023,7 @@ int BLASFUNC(blas_thread_shutdown)(void){
     blas_server_avail = 0;
 
   }
+  UNLOCK_COMMAND(&server_lock);
 
   return 0;
 }


### PR DESCRIPTION
Reverts OpenMathLib/OpenBLAS#5479 as it inadvertently removed a different, though superficially similar lock from the code. The intended fix is in #5556