### PR TITLE
fix regression due to adding bgemv interfaces

### DIFF
--- a/interface/scal.c
+++ b/interface/scal.c
@@ -73,7 +73,7 @@ void CNAME(blasint n, FLOAT alpha, FLOAT *x, blasint incx){
   float alpha_float;
   SBF16TOS_K(1, &alpha, 1, &alpha_float, 1);
 #else
-  float alpha_float = alpha;
+  FLOAT alpha_float = alpha;
 #endif
 
   if (alpha_float == ONE) return;


### PR DESCRIPTION
Fixes #5570 

It turns out #5831 changed this comparison from double to float, which impacted SciPy tests. There may be some similar inaccuracies in `kernels/generic/scal.c`, since I see it uses `float` rather than `FLOAT` but that is not currently used in the openblas-libs build as far as  I can tell.