### PR TITLE
fix define for YIELDING

### DIFF
--- a/common.h
+++ b/common.h
@@ -390,18 +390,19 @@ typedef int blasint;
 #define YIELDING
 #endif
 
+#if defined(_MSC_VER) && !defined(__clang__)
+#undef YIELDING // MSVC doesn't support assembly code
+#define YIELDING    	YieldProcessor()
+#endif
+
 #ifndef YIELDING
 #if defined(OS_SUNOS)
 #define YIELDING	thr_yield()
 
 #elif defined(OS_WINDOWS)
-# if defined(_MSC_VER) && !defined(__clang__)
-# define YIELDING    	YieldProcessor()
-# else
-# define YIELDING	SwitchToThread()
-# endif
+#define YIELDING	SwitchToThread()
 
-#else
+#else // assume linux
 #define YIELDING	sched_yield()
 #endif
 #endif

--- a/common.h
+++ b/common.h
@@ -362,18 +362,6 @@ typedef int blasint;
 #define MAX_CPU_NUMBER 2
 #endif
 
-#if defined(OS_SUNOS)
-#define YIELDING	thr_yield()
-#endif
-
-#if defined(OS_WINDOWS)
-#if defined(_MSC_VER) && !defined(__clang__)
-#define YIELDING    YieldProcessor()
-#else
-#define YIELDING	SwitchToThread()
-#endif
-#endif
-
 #if defined(ARMV7) || defined(ARMV6) || defined(ARMV8) || defined(ARMV5)
 #define YIELDING        __asm__ __volatile__ ("nop;nop;nop;nop;nop;nop;nop;nop; \n");
 #endif
@@ -398,13 +386,24 @@ typedef int blasint;
 #endif
 #endif
 
-
 #ifdef __EMSCRIPTEN__
 #define YIELDING
 #endif
 
 #ifndef YIELDING
+#if defined(OS_SUNOS)
+#define YIELDING	thr_yield()
+
+#elif defined(OS_WINDOWS)
+# if defined(_MSC_VER) && !defined(__clang__)
+# define YIELDING    	YieldProcessor()
+# else
+# define YIELDING	SwitchToThread()
+# endif
+
+#else
 #define YIELDING	sched_yield()
+#endif
 #endif
 
 /***

--- a/common.h
+++ b/common.h
@@ -402,7 +402,7 @@ typedef int blasint;
 #elif defined(OS_WINDOWS)
 #define YIELDING	SwitchToThread()
 
-#else // assume linux
+#else // assume POSIX.1-2008
 #define YIELDING	sched_yield()
 #endif
 #endif


### PR DESCRIPTION
The intent seem to be to define this in one way, but previously it was
then immediately overriding it for various architectures, causing a
compiler warning.
