### PR TITLE
build: skip tests when building for iOS

### DIFF
--- a/c_check
+++ b/c_check
@@ -23,6 +23,7 @@ config="$2"
 compiler_name="$3"
 shift 3
 flags="$*"
+is_ios=false
 
 # First, we need to know the target OS and compiler name
 {
@@ -78,6 +79,7 @@ case "$data" in *OS_CYGWIN_NT*) os=CYGWIN_NT ;; esac
 case "$data" in *OS_INTERIX*) os=Interix ;; esac
 case "$data" in *OS_ANDROID*) os=Android ;; esac
 case "$data" in *OS_HAIKU*) os=Haiku ;; esac
+case "$data" in *OS_IOS*) is_ios=true ;; esac
 
 case "$data" in
     *ARCH_X86_64*) architecture=x86_64 ;;
@@ -409,6 +411,8 @@ fi
 [ "$os" != "$hostos" ] && cross=1
 [ "$os" = "Android" ] && [ "$hostos" = "Linux" ] && [ -n "$TERMUX_APP_PID" ] \
     && cross=0
+
+[ "$is_ios" = true ] && cross=1
 
 [ "$USE_OPENMP" != 1 ] && openmp=''
 

--- a/ctest.c
+++ b/ctest.c
@@ -182,3 +182,6 @@ ARCH_RISCV64
 OS_WINDOWS
 #endif
 
+#if defined(TARGET_OS_IPHONE)
+OS_IOS
+#endif


### PR DESCRIPTION
I tried building for the iOS following the doc and encountered the following error:
```
...
TEST 1520/1522 csbmv:xerbla_inc_c_zero [OK]
TEST 1521/1522 csbmv:xerbla_k_invalid [OK]
TEST 1522/1522 csbmv:xerbla_lda_invalid [OK]
RESULTS: 1522 tests (1516 ok, 6 failed, 0 skipped) ran in 184 ms
make[1]: *** [run_test] Error 6
make: *** [tests] Error 2
```

Initially, I thought this was caused by the tests being built, so I tried modifying the doc's `make` to `make libs`. However, I was informed that ["Cross-build condition should already prevent running the tests"](https://github.com/OpenMathLib/OpenBLAS/pull/5596#discussion_r2678618947).

The original build process didn’t distinguish the `iOS` platform and treated it the same as `Darwin`. I updated the `Darwin` build process as follows:

1. Add in `ctest.c`:
```c
#if defined(TARGET_OS_IPHONE)
OS_IOS
#endif
```

2. Add an `is_ios` variable in `c_check`, setting `cross=1` when it is true.

I tested this on a physical device, and the `iOS` build now works correctly.