### PR TITLE
Temporarily use the generic C kernel for DNRM2 on SPARC

### DIFF
--- a/kernel/sparc/KERNEL
+++ b/kernel/sparc/KERNEL
@@ -59,7 +59,8 @@ SNRM2KERNEL = snrm2.S
 endif
 
 ifndef DNRM2KERNEL
-DNRM2KERNEL = dnrm2.S
+#DNRM2KERNEL = dnrm2.S
+DNRM2KERNEL = ../arm/nrm2.c
 endif
 
 ifndef CNRM2KERNEL


### PR DESCRIPTION
to work around a segfault introduced by me in #3691 
fixes #5552