### PR TITLE
Use linker response files with CMake on all Apple hardware

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -308,8 +308,8 @@ if (USE_OPENMP)
   endif()
 endif()
 
-# Fix "Argument list too long" for macOS with POWERPC or Intel CPUs 
-if(APPLE AND (NOT CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "arm64"))
+# Fix "Argument list too long" for macOS - mostly seen with older OS versions on POWERPC or Intel CPUs 
+if(APPLE)
   # Use response files
   set(CMAKE_C_USE_RESPONSE_FILE_FOR_OBJECTS 1)
   # Always build static library first


### PR DESCRIPTION
according to latest comment in #5336, the "argument list too long" error is affecting M2 now as well