### PR TITLE
fix: don't use `_Float16` type on GCC 12

### DIFF
--- a/openblas_config_template.h
+++ b/openblas_config_template.h
@@ -39,7 +39,7 @@ typedef unsigned long BLASULONG;
 typedef uint16_t bfloat16;
 #endif
 
-#if defined(__GNUC__) && (__GNUC__ >= 12)
+#if defined(__GNUC__) && (__GNUC__ > 12)
 typedef _Float16 hfloat16;
 #else
 #include <stdint.h>


### PR DESCRIPTION
`_Float16` is not supported by GCC 12 on Arm64 architectures: https://godbolt.org/z/nKbrjPTvG

Related to:
https://github.com/Homebrew/homebrew-core/pull/263008 https://github.com/Homebrew/homebrew-core/pull/263009