### PR TITLE
Fix ARMV9SME/VORTEXM4 GEMM compilation with SMP disabled

### DIFF
--- a/interface/gemm.c
+++ b/interface/gemm.c
@@ -184,11 +184,11 @@ static int init_amxtile_permission() {
 }
 #endif
 
-#ifdef SMP
 #ifdef DYNAMIC_ARCH
 extern char* gotoblas_corename(void);
 #endif
 
+#ifdef SMP
 #if defined(DYNAMIC_ARCH) || defined(NEOVERSEV1)
 static inline int get_gemm_optimal_nthreads_neoversev1(double MNK, int ncpu) {
   return


### PR DESCRIPTION
gemm.c currently declares `gotoblas_corename` in SMP-enabled builds, but the ARMV9SME and VORTEXM4 targets call `gotoblas_corename` even when SMP is disabled. Fix compilation of the ARMV9SME and VORTEXM4 targets with SMP disabled by unconditionally declaring `gotoblas_corename` for `DYNAMIC_ARCH` builds.

The compilation error can be reproduced with `make DYNAMIC_ARCH=1 USE_THREAD=0`:

```
gemm.c:558:12: error: call to undeclared function 'gotoblas_corename'; ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
  558 | if (strcmp(gotoblas_corename(), "armv9sme") == 0
      |            ^
```