### PR TITLE
Fix Intel OpenMP flag

### DIFF
--- a/cmake/fc.cmake
+++ b/cmake/fc.cmake
@@ -128,7 +128,7 @@ if (${F_COMPILER} STREQUAL "INTEL" OR CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
   endif ()
   set(FCOMMON_OPT "${FCOMMON_OPT} -recursive -fp-model=consistent")
   if (USE_OPENMP)
-    set(OpenMP_Fortran_FLAGS "-openmp" CACHE STRING "OpenMP Fortran compiler flags")
+    set(OpenMP_Fortran_FLAGS "-qopenmp" CACHE STRING "OpenMP Fortran compiler flags")
   endif ()
 endif ()
 


### PR DESCRIPTION
Fixes the Fortran OpenMP flag for the Intel compilers. Quoting the Intel compiler docs:
> Options -qopenmp (Linux) and /Qopenmp (Windows) enable the parallelizer to generate multi-threaded code based on the OpenMP pragmas in the source

Tested with ifort 2021.5.0; CMake command `cmake .. -DUSE_OPENMP=ON -DUSE_THREAD=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=icc -DCMAKE_Fortran_COMPILER=ifort -DBUILD_SHARED_LIBS=ON -DBUILD_STATIC_LIBS=ON`

Relevant portion of the error prior to the fix:
```
ifort: command line error: option '-openmp' is not supported. Please use the replacement option '-qopenmp'
[  0%] Building Fortran object CMakeFiles/LAPACK_OVERRIDES.dir/lapack-netlib/SRC/sgbbrd.f.o
make[2]: *** [CMakeFiles/LAPACK_OVERRIDES.dir/build.make:5548: CMakeFiles/LAPACK_OVERRIDES.dir/lapack-netlib/SRC/la_constants.f90.o] Error 1
make[2]: *** Waiting for unfinished jobs....
```