### PR TITLE
Rename the DllMain copy used in static linking to OpenBLASDllMain

### DIFF
--- a/driver/others/memory.c
+++ b/driver/others/memory.c
@@ -1601,7 +1601,7 @@ void DESTRUCTOR gotoblas_quit(void) {
 }
 
 #if defined(_MSC_VER) && !defined(__clang__)
-BOOL APIENTRY DllMain(HMODULE hModule, DWORD  ul_reason_for_call, LPVOID lpReserved)
+BOOL APIENTRY OpenBLASDllMain(HMODULE hModule, DWORD  ul_reason_for_call, LPVOID lpReserved)
 {
   switch (ul_reason_for_call)
   {
@@ -1650,10 +1650,10 @@ static int on_process_term(void)
 #endif
 
 #ifdef _WIN64
-static const PIMAGE_TLS_CALLBACK dll_callback(HINSTANCE h, DWORD ul_reason_for_call, PVOID pv) = DllMain;
+static const PIMAGE_TLS_CALLBACK dll_callback(HINSTANCE h, DWORD ul_reason_for_call, PVOID pv) = OpenBLASDllMain;
 #pragma const_seg()
 #else
-static void (APIENTRY *dll_callback)(HINSTANCE h, DWORD ul_reason_for_call, PVOID pv) = DllMain;
+static void (APIENTRY *dll_callback)(HINSTANCE h, DWORD ul_reason_for_call, PVOID pv) = OpenBLASDllMain;
 #pragma data_seg()
 #endif
 
@@ -3473,7 +3473,7 @@ void DESTRUCTOR gotoblas_quit(void) {
 }
 
 #if defined(_MSC_VER) && !defined(__clang__)
-BOOL APIENTRY DllMain(HMODULE hModule, DWORD  ul_reason_for_call, LPVOID lpReserved)
+BOOL APIENTRY OpenBLASDllMain(HMODULE hModule, DWORD  ul_reason_for_call, LPVOID lpReserved)
 {
   switch (ul_reason_for_call)
   {
@@ -3517,7 +3517,7 @@ static int on_process_term(void)
 #else
 #pragma data_seg(".CRT$XLB")
 #endif
-static void (APIENTRY *dll_callback)(HINSTANCE h, DWORD ul_reason_for_call, PVOID pv) = DllMain;
+static void (APIENTRY *dll_callback)(HINSTANCE h, DWORD ul_reason_for_call, PVOID pv) = OpenBLASDllMain;
 #ifdef _WIN64
 #pragma const_seg()
 #else


### PR DESCRIPTION
as suggested in #5366 - dll builds already add their own DllMain implementation from exports/dllinit.c
fixes #5366 
fixes #5511