### PR TITLE
build: fix Makefile build with LLVM flang on macOS

### DIFF
--- a/exports/Makefile
+++ b/exports/Makefile
@@ -163,7 +163,11 @@ else
 ifeq ($(F_COMPILER), FLANG)
 	$(FC) $(FFLAGS) $(LDFLAGS) -fno-fortran-main -Mnomain -all_load -headerpad_max_install_names -install_name "$(CURDIR)/../$(INTERNALNAME)" -dynamiclib -o ../$(LIBDYNNAME) $< -Wl,-exported_symbols_list,osx.def  $(FEXTRALIB)
 else
+ifeq ($(F_COMPILER), FLANGNEW)
+	$(FC) $(FFLAGS) $(LDFLAGS) -Wl,-all_load -Wl,-headerpad_max_install_names -Wl,-install_name,"$(CURDIR)/../$(INTERNALNAME)" -Wl,-dylib -o ../$(LIBDYNNAME) $< -Wl,-exported_symbols_list,osx.def  $(FEXTRALIB)
+else
 	$(FC) $(FFLAGS) $(LDFLAGS) -all_load -headerpad_max_install_names -install_name "$(CURDIR)/../$(INTERNALNAME)" -dynamiclib -o ../$(LIBDYNNAME) $< -Wl,-exported_symbols_list,osx.def  $(FEXTRALIB)
+endif
 endif
 endif
 endif


### PR DESCRIPTION
CMake build has a workaround but Makefile still fails building with LLVM Flang:
```
flang-21: error: unknown argument: '-all_load'
flang-21: error: unknown argument: '-headerpad_max_install_names'
flang-21: error: unknown argument: '-install_name'
flang-21: error: unknown argument: '-dynamiclib'
```

This PR passes the options not found in `flang --help` directly to linker via `-Wl`.

Only `-dynamiclib` is not valid. Based on `man ld` and `ld64.lld --help`, it seems `-Wl,-dylib` should work for shared library. May need to confirm if `-dynamiclib` does anything else.
```
OPTIONS
   Options that control the kind of output
     -execute
             The default.  Produce a mach-o main executable that has file type MH_EXECUTE.

     -dylib  Produce a mach-o shared library that has file type MH_DYLIB.
```
```
OUTPUT KIND:
  -arch <arch_name> The architecture (e.g. ppc, ppc64, i386, x86_64)
  -bundle           Produce a bundle
  -dylib            Produce a shared library
```

---

An alternative could be to use CC instead of FC during linking similar to CMake workaround. 