### PR TITLE
Work around llvm failing to compile the AVX512 sgemm kernel

### DIFF
--- a/Makefile.x86_64
+++ b/Makefile.x86_64
@@ -61,6 +61,9 @@ endif
 ifeq ($(CORE), SKYLAKEX)
 ifndef NO_AVX512
 CCOMMON_OPT += -march=skylake-avx512
+ifeq ($(C_COMPILER, CLANG)
+CCOMMON_OPT += -mllvm -exhaustive-register-search
+endif
 ifneq ($(F_COMPILER), NAG)
 FCOMMON_OPT += -march=skylake-avx512
 endif
@@ -93,6 +96,7 @@ ifeq ($(C_COMPILER), GCC)
   endif
  endif
 else ifeq ($(C_COMPILER), CLANG)
+ CCOMMON_OPT += -mllvm -exhaustive-register-search
  # cooperlake support was added in clang 9
  ifeq ($(CLANGVERSIONGTEQ9), 1)
   CCOMMON_OPT += -march=cooperlake
@@ -135,6 +139,7 @@ ifeq ($(C_COMPILER), GCC)
   endif
  endif
 else ifeq ($(C_COMPILER), CLANG)
+  CCOMMON_OPT += -mllvm -exhaustive-register-search
  # sapphire rapids support was added in clang 12
  ifeq ($(CLANGVERSIONGTEQ12), 1)
   CCOMMON_OPT += -march=sapphirerapids

--- a/Makefile.x86_64
+++ b/Makefile.x86_64
@@ -61,7 +61,7 @@ endif
 ifeq ($(CORE), SKYLAKEX)
 ifndef NO_AVX512
 CCOMMON_OPT += -march=skylake-avx512
-ifeq ($(C_COMPILER, CLANG)
+ifeq ($(C_COMPILER), CLANG)
 CCOMMON_OPT += -mllvm -exhaustive-register-search
 endif
 ifneq ($(F_COMPILER), NAG)


### PR DESCRIPTION
this was already fixed for CMake builds a while back, but apparently not copied to the makefile
fixes #5641 (at least in non-debug builds)