### PR TITLE
use 100 minute timeout for azure mingw32 job

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -91,6 +91,7 @@ jobs:
       openblas_utest.exe
 
 - job: Windows_mingw_gmake
+  timeoutInMinutes: 100
   pool:
      vmImage: 'windows-latest'
   steps:   


### PR DESCRIPTION
The Windows_mingw_gmake job is consistently timing out at the default 60 minutes. Add an explicit timeout and make it 100 minutes.