### PR TITLE
Use generic SCAL kernels for PPC970 running FreeBSD

### DIFF
--- a/kernel/power/KERNEL.PPC970
+++ b/kernel/power/KERNEL.PPC970
@@ -89,3 +89,10 @@ DROTKERNEL   = ../arm/rot.c
 CROTKERNEL   = ../arm/zrot.c
 ZROTKERNEL   = ../arm/zrot.c
 endif
+
+ifeq ($(OSNAME), FreeBSD)
+SSCALKERNEL  = ../arm/scal.c
+DSCALKERNEL  = ../arm/scal.c
+CSCALKERNEL  = ../arm/zscal.c
+ZSCALKERNEL  = ../arm/zscal.c
+endif


### PR DESCRIPTION
fixes #5627