### PR TITLE
Improve processing of linker arguments in f_check

### DIFF
--- a/f_check
+++ b/f_check
@@ -343,13 +343,13 @@ linker_a=""
 
 if [ -n "$link" ]; then
 
-    link=`echo "$link" | sed 's/\-Y[[:space:]]P\,/\-Y/g'`
+    link=`echo " $link" | sed 's/ \-Y[[:space:]]P\,/ \-Y/g'`
 
-    link=`echo "$link" | sed 's/\-R[[:space:]]*/\-rpath\%/g'`
+    link=`echo "$link" | sed 's/ \-R[[:space:]]*/ \-rpath\%/g'`
 
-    link=`echo "$link" | sed 's/\-rpath[[:space:]]+/\-rpath\%/g'`
+    link=`echo "$link" | sed 's/ \-rpath[[:space:]]+/ \-rpath\%/g'`
 
-    link=`echo "$link" | sed 's/\-rpath-link[[:space:]]+/\-rpath-link\%/g'`
+    link=`echo "$link" | sed 's/ \-rpath-link[[:space:]]+/ \-rpath-link\%/g'`
 
     flags=`echo "$link" | tr "',\n" " "`
     # remove leading and trailing quotes from each flag.


### PR DESCRIPTION
This changes the option replacement logic to expect a space before the dash denoting a linker option, which should keep it from replacing spurious matches within directory names
fixes #5664