### PR TITLE
powerpc: Bypass FP16 as BF16 on Power

### DIFF
--- a/openblas_config_template.h
+++ b/openblas_config_template.h
@@ -40,7 +40,11 @@ typedef uint16_t bfloat16;
 #endif
 
 #if defined(__GNUC__) && (__GNUC__ > 12)
+#if defined(OPENBLAS_ARCH_POWER)
+typedef bfloat16 hfloat16;
+#else
 typedef _Float16 hfloat16;
+#endif
 #else
 #include <stdint.h>
 typedef uint16_t hfloat16;


### PR DESCRIPTION
typedef FP16 as BF16 on Power as FP16 is
not yet supported