### PR TITLE
Fix potential over-optimization of the AVX512 small SGEMM kernel by gcc15

### DIFF
--- a/kernel/x86_64/sgemm_small_kernel_tt_skylakex.c
+++ b/kernel/x86_64/sgemm_small_kernel_tt_skylakex.c
@@ -307,7 +307,7 @@ int CNAME(BLASLONG M, BLASLONG N, BLASLONG K, FLOAT * A, BLASLONG lda, FLOAT alp
 		}
 	}
 	if (i < M) {
-		int index_n[16];
+		static int index_n[16];
 		for (int ii = 0; ii < 16; ii++) {
 			index_n[ii] = ii * ldc;
 		}


### PR DESCRIPTION
flagged by Address Sanitizer