### PR TITLE
Avoid potential miscompilation of the ARM64 (NeoverseV2) dot kernel

### DIFF
--- a/kernel/arm64/dot_kernel_asimd.c
+++ b/kernel/arm64/dot_kernel_asimd.c
@@ -262,7 +262,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 static RETURN_TYPE dot_kernel_asimd(BLASLONG n, FLOAT *x, BLASLONG inc_x, FLOAT *y, BLASLONG inc_y)
 {
-	RETURN_TYPE  dot = 0.0;
+	volatile RETURN_TYPE  dot = 0.0;
 	BLASLONG j = 0;
 
 	__asm__ __volatile__ (


### PR DESCRIPTION
Probable root cause likely to be some missing or improper declaration in the inline assembly, but making the result variable volatile fixes it for now. Original issue was https://github.com/numpy/numpy/issues/30816