### PR TITLE
Enable DSUM SIMD path for WASM128_GENERIC

### DIFF
--- a/kernel/arm/sum.c
+++ b/kernel/arm/sum.c
@@ -42,7 +42,7 @@ FLOAT CNAME(BLASLONG n, FLOAT *x, BLASLONG inc_x)
 	n *= inc_x;
 	if (inc_x == 1)
 	{
-#if V_SIMD && (!defined(DOUBLE) || (defined(DOUBLE) && V_SIMD_F64 && V_SIMD > 128))
+#if V_SIMD && (!defined(DOUBLE) || (defined(DOUBLE) && V_SIMD_F64 && (V_SIMD > 128 || defined(ARCH_WASM))))
 #ifdef DOUBLE
 		const int vstep = v_nlanes_f64;
 		const int unrollx4 = n & (-vstep * 4);


### PR DESCRIPTION
This enables the existing DSUM SIMD path for `ARCH_WASM` in `kernel/arm/sum.c`, where it was still gated off by the `V_SIMD > 128` check. SSUM was already using the same SIMD path on WASM, and in local direct WASM benchmarking SSUM showed about 3.56x, 3.91x, and 1.09x speedups while DSUM improved by about 1.68x, 2.18x, and 1.53x for contiguous inputs.