### PR TITLE
Reapply "build: fix rule for building dynamic files"

### DIFF
--- a/driver/others/Makefile
+++ b/driver/others/Makefile
@@ -127,10 +127,10 @@ endif
 xerbla.$(SUFFIX) : xerbla.c
 	$(CC) $(CFLAGS) -c $< -o $(@F)
 
-dynamic.$(SUFFIX) : dynamic.c
+dynamic%$(SUFFIX) : dynamic%c
 	$(CC) $(CFLAGS) -c $< -o $(@F)
 
-dynamic.$(PSUFFIX) : dynamic.c
+dynamic%$(PSUFFIX) : dynamic%c
 	$(CC) $(PFLAGS) -c $< -o $(@F)
 
 parameter.$(SUFFIX) : parameter.c ../../param.h


### PR DESCRIPTION
This reverts commit 7eab365219db16467a9cfed2a60fc0c9ac8b3334 and fixes the pattern rule requirement "% must match a non-empty stem" to match at least '.' in the pattern.

This whole file could actually be substantially simplified to just:

	%.$(SUFFIX): %.c
		$(CC) $(CFLAGS) -c $< -o $(@F)

	%.$(PSUFFIX): %.c
		$(CC) $(PFLAGS) -c $< -o $(@F)

if desired to entirely avoid the copy-paste duplication, but the net effect is the same.