### PR TITLE
c_check: loongarch64: Fix typo

### DIFF
--- a/c_check
+++ b/c_check
@@ -131,7 +131,7 @@ case "$architecture" in
     	defined=1
     	;;
     arm|arm64) defined=1 ;;
-    zarch|e2k|alpha|ia64|riscv64|loonarch64|wasm)
+    zarch|e2k|alpha|ia64|riscv64|loongarch64|wasm)
     	defined=1
     	BINARY=64
     	;;


### PR DESCRIPTION
Fixes: 42c7a27e6b201eb9b28b9ab3b65d5f3ab08e1af0