### PR TITLE
typedef the unsupported fp16 as bfloat16 on Loongarch64 too

### DIFF
--- a/openblas_config_template.h
+++ b/openblas_config_template.h
@@ -40,7 +40,7 @@ typedef uint16_t bfloat16;
 #endif
 
 #if defined(__GNUC__) && (__GNUC__ > 12)
-#if defined(OPENBLAS_ARCH_POWER)
+#if defined(OPENBLAS_ARCH_POWER) || defined(OPENBLAS_ARCH_LOONGARCH64)
 typedef bfloat16 hfloat16;
 #else
 typedef _Float16 hfloat16;


### PR DESCRIPTION
fixes #5714 in the same way as #5670 did for PPC