### PR TITLE
lapack/laed3: fix MinGW build by matching LAMC3 prototype

### DIFF
--- a/lapack/laed3/laed3_parallel.c
+++ b/lapack/laed3/laed3_parallel.c
@@ -33,6 +33,9 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <stdio.h>
 #include "common.h"
 
+#ifdef max
+#undef max
+#endif
 #define max(a,b) ((a) > (b) ? (a) : (b))
 #define copysign(x,y) ((y) < 0 ? ((x) < 0 ? (x) : -(x)) : ((x) < 0 ? -(x) : (x)))
 
@@ -54,7 +57,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define LASET  BLASFUNC(slaset)
 #endif
 
-FLOAT LAMC3(FLOAT *, FLOAT *);
+FLOATRET LAMC3(FLOAT *, FLOAT *);
 void LAED4(blasint *, blasint *, FLOAT *, FLOAT *, FLOAT *, FLOAT *, FLOAT *, blasint *);
 void LACPY(char *, blasint *, blasint *, FLOAT *, blasint *, FLOAT *, blasint *);
 void LASET(char *, blasint *, blasint *, FLOAT *, FLOAT *, FLOAT *, blasint *);

--- a/lapack/laed3/laed3_single.c
+++ b/lapack/laed3/laed3_single.c
@@ -53,7 +53,7 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define LASET  BLASFUNC(slaset)
 #endif
 
-FLOAT LAMC3(FLOAT *, FLOAT *);
+FLOATRET LAMC3(FLOAT *, FLOAT *);
 void LAED4(blasint *, blasint *, FLOAT *, FLOAT *, FLOAT *, FLOAT *, FLOAT *, blasint *);
 void LACPY(char *, blasint *, blasint *, FLOAT *, blasint *, FLOAT *, blasint *);
 void LASET(char *, blasint *, blasint *, FLOAT *, FLOAT *, FLOAT *, blasint *);


### PR DESCRIPTION
## Summary

This PR fixes a MinGW build failure in `lapack/laed3`.

`common_interface.h` declares `slamc3` with return type `FLOATRET`
(when `NEED_F2CCONV` is active), but `laed3_single.c` and
`laed3_parallel.c` redeclare `LAMC3` as returning `FLOAT`.

This leads to conflicting-type errors such as:

```text
error: conflicting types for ‘slamc3_’; have ‘float(float *, float *)’
note: previous declaration of ‘slamc3_’ with type ‘double(float *, float *)’
```

Fix
change the local LAMC3 prototype in:
lapack/laed3/laed3_single.c
lapack/laed3/laed3_parallel.c
from FLOAT to FLOATRET so it matches the shared declaration in
common_interface.h

Additionally, this PR undefines the Windows max macro before the local
max macro definition in laed3_parallel.c to avoid macro redefinition
warnings during MinGW/Windows builds.

Why this is correct

The shared interface already defines the ABI-visible declaration for
slamc3. The local declarations in the two laed3 translation units
should match that interface exactly. Using FLOATRET restores that
consistency and removes the MinGW conflicting-type failure.

The max change does not alter behavior; it only avoids a warning caused
by windows.h / minwindef.h defining max as a macro.

Notes

I have verified that this change addresses the MinGW compile failure
reported in slaed3_single.obj / slaed3_parallel.obj.

I have not changed the surrounding logic or numerical code paths.
This PR is intentionally minimal and limited to fixing the declaration
mismatch and the Windows macro warning.