### PR TITLE
Fix DROUNDUP_LWORK: patch was not fully copied

### DIFF
--- a/lapack-netlib/SRC/dspgvd.f
+++ b/lapack-netlib/SRC/dspgvd.f
@@ -225,7 +225,8 @@
 *     ..
 *     .. External Functions ..
       LOGICAL            LSAME
-      EXTERNAL           LSAME
+      DOUBLE PRECISION   DROUNDUP_LWORK
+      EXTERNAL           LSAME, DROUNDUP_LWORK
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           DPPTRF, DSPEVD, DSPGST, DTPMV, DTPSV, XERBLA

--- a/lapack-netlib/SRC/dsygvd.f
+++ b/lapack-netlib/SRC/dsygvd.f
@@ -245,7 +245,8 @@
 *     ..
 *     .. External Functions ..
       LOGICAL            LSAME
-      EXTERNAL           LSAME
+      DOUBLE PRECISION   DROUNDUP_LWORK
+      EXTERNAL           LSAME, DROUNDUP_LWORK
 *     ..
 *     .. External Subroutines ..
       EXTERNAL           DPOTRF, DSYEVD, DSYGST, DTRMM, DTRSM, XERBLA


### PR DESCRIPTION
Asm before fix: https://godbolt.org/z/dzoTvaoTq

The most interesting lines are 153-154:
```
         bl      droundup_lwork_
         fcvt    d0, s0
```
Here, `droundup_lwork_` sets d0 register based on integer value in x0 register. Then, `fcvt` sets `d0` fp64 register with value from `s0` fp32 register. However, s0 was set to zero (and, actually, never used), so, after this, d0 is 0.0 that breaks computing of memory requirement. 

Asm after fix: https://godbolt.org/z/MW4rvoETa

Only these two files are affected.

Bug was introduced by commit https://github.com/OpenMathLib/OpenBLAS/commit/99c120916a25b4190ed22fca5cc7928d29fb86af (PR #5702)

Fixes #5754 