### PR TITLE
Automatically assume BIGNUMA if more than 256 CPUs defined/detected

### DIFF
--- a/driver/others/init.c
+++ b/driver/others/init.c
@@ -72,6 +72,12 @@ USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "common.h"
 
+#if (MAX_CPU_NUMBER > 256)
+#ifndef BIGNUMA
+#define BIGNUMA
+#endif
+#endif
+
 #if defined(OS_LINUX) && defined(SMP)
 
 #define _GNU_SOURCE


### PR DESCRIPTION
prompted by https://github.com/spack/spack-packages/issues/4178