### PR TITLE
Add CPU ID for Neoverse V3

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -275,3 +275,6 @@ In chronological order:
 
 * Fadi Arafeh <fadi.arafeh@arm.com>
   * [2026-03-05] Accelerate SVE128 SBGEMM/BGEMM
+
+* Nathan Sircombe <nathan.sircombe@arm.com>
+  * [2026-04-16] Add CPU ID for Neoverse V3

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Please read `GotoBLAS_01Readme.txt` for older CPU models already supported by th
 - **Cortex-A53**: same as ARMV8 (different cpu specifications)
 - **Cortex-A55**: same as ARMV8 (different cpu specifications)
 - **Cortex A57**: Optimized Level-3 and Level-2 functions
-- **Cortex A72**: same as A57 ( different cpu specifications)
+- **Cortex A72**: same as A57 (different cpu specifications)
 - **Cortex A73**: same as A57 (different cpu specifications)
 - **Cortex A76**: same as A57 (different cpu specifications)
 - **Falkor**: same as A57 (different cpu specifications)
@@ -189,6 +189,8 @@ Please read `GotoBLAS_01Readme.txt` for older CPU models already supported by th
 - **Neoverse V1**: (AWS Graviton3) optimized Level-3 BLAS
 - **Neoverse N2**: preliminary support
 - **Neoverse V2**: preliminary support
+- **Neoverse V3**: preliminary support
+- **Neoverse V3AE**: preliminary support
 - **Apple Vortex**: preliminary support based on ThunderX2/3
 - **Apple VortexM4**: preliminary support based on ThunderX2/3, SME kernels for SGEMM,SSYMM,STRMM,SSYRK,SSYR2K
 - **A64FX**:  preliminary support, optimized Level-3 BLAS

--- a/driver/others/dynamic_arm64.c
+++ b/driver/others/dynamic_arm64.c
@@ -425,10 +425,11 @@ static gotoblas_t *get_coretype(void) {
 	    return &gotoblas_NEOVERSEN1;
       	  }else
 	    return &gotoblas_NEOVERSEV1;
-  case 0xd4f:
-  case 0xd83:
-  case 0xd85:
-  case 0xd87:
+  case 0xd4f: // Neoverse V2
+  case 0xd83: // Neoverse V3AE
+  case 0xd84: // Neoverse V3
+  case 0xd85: // Cortex X925
+  case 0xd87: // Cortex A725
       if (!(getauxval(AT_HWCAP) & HWCAP_SVE)) {
         openblas_warning(FALLBACK_VERBOSE, NEOVERSEN1_FALLBACK);
         return &gotoblas_NEOVERSEN1;

--- a/driver/others/dynamic_arm64.c
+++ b/driver/others/dynamic_arm64.c
@@ -1,6 +1,6 @@
 /*********************************************************************/
 /* Copyright 2009, 2010 The University of Texas at Austin.           */
-/* Copyright 2023-2024 The OpenBLAS Project                          */
+/* Copyright 2023-2024, 2026 The OpenBLAS Project                    */
 /* All rights reserved.                                              */
 /*                                                                   */
 /* Redistribution and use in source and binary forms, with or        */


### PR DESCRIPTION
The PR which added NeoverseV3 detection to openBLAS includes the V3AE
variant, but not V3. This patch includes the missing cpuid and labels
the V3 variants.

This ensures that Neoverse V3 will use existing V2 kernels rather than
falling back to ARMV8SVE.
 